### PR TITLE
Consume dataYaml in config, add config testing

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,10 +36,38 @@ type Config struct {
 	Period     time.Duration           `config:"period"`
 	Processors processors.PluginConfig `config:"processors"`
 	Fetchers   []*common.Config        `config:"fetchers"`
+
+	Streams []Stream `config:"streams"`
+}
+
+type Stream struct {
+	DataYaml struct {
+		ActivatedRules struct {
+			CISK8S []string `config:"cis_k8s"`
+		} `config:"activated_rules"`
+	} `config:"data_yaml"`
 }
 
 var DefaultConfig = Config{
 	Period: 10 * time.Second,
+}
+
+func New(cfg *common.Config) (Config, error) {
+	c := DefaultConfig
+
+	if err := cfg.Unpack(&c); err != nil {
+		return c, err
+	}
+
+	return c, nil
+}
+
+func (c *Config) Update(cfg *common.Config) error {
+	if err := cfg.Unpack(&c); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Datastream function to generate the datastream value

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,3 +19,52 @@
 // +build !integration
 
 package config
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/stretchr/testify/suite"
+)
+
+type ConfigTestSuite struct {
+	suite.Suite
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	suite.Run(t, new(ConfigTestSuite))
+}
+
+func (s *ConfigTestSuite) SetupTest() {
+}
+
+func (s *ConfigTestSuite) TestNew() {
+	var tests = []struct {
+		config           string
+		expectedPatterns []string
+	}{
+		{
+			`
+  streams:
+    - data_yaml:
+        activated_rules:
+          cis_k8s:
+            - a
+            - b
+            - c
+            - d
+`,
+			[]string{"a", "b", "c", "d"},
+		},
+	}
+
+	for _, test := range tests {
+		cfg, err := common.NewConfigFrom(test.config)
+		s.NoError(err)
+
+		c, err := New(cfg)
+		s.NoError(err)
+
+		s.Equal(test.expectedPatterns, c.Streams[0].DataYaml.ActivatedRules.CISK8S)
+	}
+}

--- a/config/updates.go
+++ b/config/updates.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Config is put into a different package to prevent cyclic imports in case
+// it is needed in several locations
+
+package config
+
+import (
+	"context"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/reload"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+type reloader struct {
+	ctx context.Context
+	ch  chan<- *common.Config
+}
+
+func (r *reloader) Reload(configs []*reload.ConfigWithMeta) error {
+	if len(configs) == 0 {
+		return nil
+	}
+
+	logp.L().Infof("Received %v new configs for reload.", len(configs))
+
+	select {
+	case <-r.ctx.Done():
+	default:
+		// TODO(yashtewari): Based on limitations elsewhere, such as the CSP integration,
+		// don't think we should receive more than one Config here. Need to confirm and handle.
+		r.ch <- configs[len(configs)-1].Config
+	}
+
+	return nil
+}
+
+func Updates(ctx context.Context) <-chan *common.Config {
+	ch := make(chan *common.Config)
+	r := &reloader{
+		ctx: ctx,
+		ch:  ch,
+	}
+
+	reload.Register.MustRegisterList("inputs", r)
+
+	return ch
+}


### PR DESCRIPTION
The `dataYaml` var specifies which CIS rules are "active", hence defining the scope of work to be done by the beat.