### PR TITLE
Kube Fetcher logs + set Interval

### DIFF
--- a/resources/fetchers/kube_factory.go
+++ b/resources/fetchers/kube_factory.go
@@ -48,7 +48,7 @@ func (f *KubeFactory) CreateFrom(cfg KubeApiFetcherConfig) (fetching.Fetcher, er
 		watchers: make([]kubernetes.Watcher, 0),
 	}
 
-	logp.L().Infof("Kube Fetcher created with the following config:"+
-		"\n Name: %s\nInterval: %s\nKubeconfig: %s", cfg.Name, cfg.Kubeconfig, cfg.Interval)
+	logp.L().Infof("Kube Fetcher created with the following config: Name: %s, Interval: %s, "+
+		"Kubeconfig: %s", cfg.Name, cfg.Interval, cfg.Kubeconfig)
 	return fe, nil
 }

--- a/resources/fetchers/kube_fetcher.go
+++ b/resources/fetchers/kube_fetcher.go
@@ -108,7 +108,7 @@ func (f *KubeFetcher) initWatcher(client k8s.Interface, r requiredResource) erro
 	// if the configured Client's Role does not have the necessary permissions to list the Resource
 	// being watched. This needs to be handled.
 	//
-	// When such a failure happens, cloudbeat won't shut down gracefuly, i.e. Stop will not work. This
+	// When such a failure happens, cloudbeat won't shut down gracefully, i.e. Stop will not work. This
 	// happens due to a context.TODO present in the libbeat dependency. It needs to accept context
 	// from the caller instead.
 	if err := watcher.Start(); err != nil {
@@ -143,7 +143,7 @@ func (f *KubeFetcher) initWatchers() error {
 }
 
 func (f *KubeFetcher) Fetch(ctx context.Context) ([]fetching.Resource, error) {
-	logp.L().Debug("kube fetcher starts to fetch data")
+	logp.L().Info("kube fetcher starts to fetch data")
 	var err error
 	watcherlock.Do(func() {
 		err = f.initWatchers()

--- a/resources/fetchers/kube_fetcher.go
+++ b/resources/fetchers/kube_fetcher.go
@@ -96,6 +96,8 @@ type KubeApiFetcherConfig struct {
 }
 
 func (f *KubeFetcher) initWatcher(client k8s.Interface, r requiredResource) error {
+	f.cfg.Interval = time.Duration(time.Duration.Seconds(30)) // todo: hard coded - need to get from config
+
 	watcher, err := kubernetes.NewWatcher(client, r.resource, kubernetes.WatchOptions{
 		SyncTimeout: f.cfg.Interval,
 		Namespace:   r.namespace,
@@ -126,7 +128,7 @@ func (f *KubeFetcher) initWatchers() error {
 		return fmt.Errorf("could not get k8s client: %w", err)
 	}
 
-	logp.Info("Kubernetes client initiated.")
+	logp.L().Info("Kubernetes client initiated.")
 
 	f.watchers = make([]kubernetes.Watcher, 0)
 
@@ -137,7 +139,7 @@ func (f *KubeFetcher) initWatchers() error {
 		}
 	}
 
-	logp.Info("Kubernetes Watchers initiated.")
+	logp.L().Info("Kubernetes Watchers initiated.")
 
 	return nil
 }

--- a/resources/fetchers/kube_provider.go
+++ b/resources/fetchers/kube_provider.go
@@ -34,6 +34,7 @@ type K8sResource struct {
 const k8sObjMetadataField = "ObjectMeta"
 
 func GetKubeData(watchers []kubernetes.Watcher) []fetching.Resource {
+	logp.L().Info("Fetching Kubernetes data")
 	ret := make([]fetching.Resource, 0)
 
 	for _, watcher := range watchers {
@@ -58,6 +59,7 @@ func GetKubeData(watchers []kubernetes.Watcher) []fetching.Resource {
 		}
 	}
 
+	logp.L().Info("Fetched: %v", ret)
 	return ret
 }
 

--- a/resources/fetchers/kube_provider.go
+++ b/resources/fetchers/kube_provider.go
@@ -59,7 +59,6 @@ func GetKubeData(watchers []kubernetes.Watcher) []fetching.Resource {
 		}
 	}
 
-	logp.L().Info("Fetched: %v", ret)
 	return ret
 }
 

--- a/resources/fetchers/process_fetcher.go
+++ b/resources/fetchers/process_fetcher.go
@@ -104,7 +104,7 @@ func (f *ProcessesFetcher) fetchProcessData(procStat proc.ProcStat, processConf 
 	return ProcessResource{PID: processId, Cmd: cmd, Stat: procStat, ExternalData: configMap}, nil
 }
 
-//getProcessConfigurationFile - reads the configuration file associated with a process.
+// getProcessConfigurationFile - reads the configuration file associated with a process.
 // As an input this function receives a ProcessInputConfiguration that contains ConfigFileArguments, a string array that represents some process flags
 // The function extracts the configuration file associated with each flag and returns it.
 func (f *ProcessesFetcher) getProcessConfigurationFile(processConfig ProcessInputConfiguration, cmd string, processName string) map[string]interface{} {


### PR DESCRIPTION
**what this PR do**
- adds more fetchers logs
- set kube-api interval to 30s (hard-coded)