### PR TITLE
File fetcher id change

### DIFF
--- a/resources/fetchers/file_system_fetcher.go
+++ b/resources/fetchers/file_system_fetcher.go
@@ -135,7 +135,7 @@ func (r FileSystemResource) GetData() interface{} {
 
 func (r FileSystemResource) GetMetadata() fetching.ResourceMetadata {
 	return fetching.ResourceMetadata{
-		ID:      r.Inode,
+		ID:      r.Path,
 		Type:    FSResourceType,
 		SubType: r.SubType,
 		Name:    r.Path, // The Path from the container and not from the host


### PR DESCRIPTION
Due to the gap https://github.com/elastic/cloudbeat/issues/73, decided to have the `path` without `creation date`.
As discussed with @eyalkraft and @tehilashn this means that this PR isn't interested in the physical file, but only in its path for uniqueness. 

I shall note that the path is mounted to the pod and on the host machine the location may be different.

Fixes https://github.com/elastic/security-team/issues/3599
Gaps https://github.com/elastic/cloudbeat/issues/73
Gaps https://github.com/elastic/cloudbeat/issues/78