### PR TITLE
Pass version to rm container

### DIFF
--- a/.ci/scripts/rm-docker.sh
+++ b/.ci/scripts/rm-docker.sh
@@ -32,4 +32,5 @@ docker run --rm \
       --branch "$BRANCH" \
       --commit `git rev-parse HEAD` \
       --workflow "$WORKFLOW" \
+      --version "$VERSION" \
       --artifact-set main


### PR DESCRIPTION
Pass the `--version` option to the release-manager container, it is
becoming required to ensure that teams version bumps do not need to wait
for the version bump within the docker image.