### PR TITLE
Common data provider node name resolution

### DIFF
--- a/transformer/events_creator_test.go
+++ b/transformer/events_creator_test.go
@@ -20,12 +20,13 @@ package transformer
 import (
 	"context"
 	"encoding/json"
-	"github.com/elastic/beats/v7/libbeat/logp"
 	"io/ioutil"
 	"os"
 	"testing"
-	"testing/fstest"
 
+	"github.com/elastic/beats/v7/libbeat/logp"
+
+	"github.com/elastic/cloudbeat/config"
 	"github.com/elastic/cloudbeat/evaluator"
 	"github.com/elastic/cloudbeat/resources/fetchers"
 	"github.com/elastic/cloudbeat/resources/fetching"
@@ -203,12 +204,11 @@ func (s *EventsCreatorTestSuite) TestTransformer_ProcessAggregatedResources() {
 
 			cdp := CommonDataProvider{
 				kubeClient: kc,
-				fsys: fstest.MapFS{
-					"hostname": {
-						Data: []byte("testing_node"),
-					},
-				},
+				cfg: config.Config{},
 			}
+
+			// libbeat DiscoverKubernetesNode performs a fallback to environment variable NODE_NAME
+			os.Setenv("NODE_NAME", "testing_node")
 
 			commonData, err := cdp.FetchCommonData(ctx)
 			s.NoError(err)

--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -18,8 +18,7 @@
 package transformer
 
 import (
-	"io/fs"
-
+	"github.com/elastic/cloudbeat/config"
 	"github.com/gofrs/uuid"
 	"k8s.io/client-go/kubernetes"
 )
@@ -35,7 +34,7 @@ type CycleMetadata struct {
 
 type CommonDataProvider struct {
 	kubeClient kubernetes.Interface
-	fsys fs.FS
+	cfg config.Config
 }
 
 type CommonData struct {


### PR DESCRIPTION
Switched to using libbeat internal utils in order to resolve the node name.

TODO: Should we continue if the initialization of the common data layer has failed?
If yes, then what should we do for the ids and other future data that has not been collected.
How would we in the current state indicate that there is an error (assuming that nobody would look in the logs since everything will work and we cannot understand from the ids that there are problems)?

Fixes https://github.com/elastic/cloudbeat/issues/83
