### PR TITLE
Fetch kube controller manager process

### DIFF
--- a/_meta/config/cloudbeat.common.yml.tmpl
+++ b/_meta/config/cloudbeat.common.yml.tmpl
@@ -8,7 +8,7 @@ cloudbeat:
     processes:
       etcd:
       kube-apiserver:
-      kube-controller-manager:
+      kube-controller:
       kube-scheduler:
       kubelet:
         config-file-arguments:

--- a/cloudbeat.reference.yml
+++ b/cloudbeat.reference.yml
@@ -17,7 +17,7 @@ cloudbeat:
     processes:
       etcd:
       kube-apiserver:
-      kube-controller-manager:
+      kube-controller:
       kube-scheduler:
       kubelet:
         config-file-arguments:

--- a/cloudbeat.yml
+++ b/cloudbeat.yml
@@ -20,7 +20,7 @@ cloudbeat:
     processes:
       etcd:
       kube-apiserver:
-      kube-controller-manager:
+      kube-controller:
       kube-scheduler:
       kubelet:
         config-file-arguments:

--- a/deploy/k8s/cloudbeat-ds-debug.yml
+++ b/deploy/k8s/cloudbeat-ds-debug.yml
@@ -139,7 +139,7 @@ data:
         processes:
           etcd:
           kube-apiserver:
-          kube-controller-manager:
+          kube-controller:
           kube-scheduler:
           kubelet:
             config-file-arguments:

--- a/deploy/k8s/kustomize/base/cloudbeat-ds.yml
+++ b/deploy/k8s/kustomize/base/cloudbeat-ds.yml
@@ -137,7 +137,7 @@ data:
         processes:
           etcd:
           kube-apiserver:
-          kube-controller-manager:
+          kube-controller:
           kube-scheduler:
           kubelet:
             config-file-arguments:

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20220413140705-d101ba1d2ae5
-	github.com/elastic/csp-security-policies v1.0.0
+	github.com/elastic/csp-security-policies v1.0.1
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ini/ini v1.66.4 // indirect
 	github.com/go-logr/logr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+J
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20220413140705-d101ba1d2ae5 h1:kINUJJmzJyws37K/4TXyUI9Odv/2vTjHlg8BXTXCtBA=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20220413140705-d101ba1d2ae5/go.mod h1:PhsCH91qJN33+rN/L8q2jWILmswlezJ6T+MMM6EDc8g=
-github.com/elastic/csp-security-policies v1.0.0 h1:6/jgO5C+EeDH5Wb73ojA8dgA4EDXMYO3vcYGGPtrn1A=
-github.com/elastic/csp-security-policies v1.0.0/go.mod h1:24NNr0b/5HTGtndJOmhrefb59rd7NjuqI/To39tgn+w=
+github.com/elastic/csp-security-policies v1.0.1 h1:j/cTKxa5oqMx4VZR1ifzo6miyAfs3wWOlbNw+OIS5GU=
+github.com/elastic/csp-security-policies v1.0.1/go.mod h1:24NNr0b/5HTGtndJOmhrefb59rd7NjuqI/To39tgn+w=
 github.com/elastic/elastic-agent-client/v7 v7.0.0-20210727140539-f0905d9377f6 h1:nFvXHBjYK3e9+xF0WKDeAKK4aOO51uC28s+L9rBmilo=
 github.com/elastic/elastic-agent-client/v7 v7.0.0-20210727140539-f0905d9377f6/go.mod h1:uh/Gj9a0XEbYoM4NYz4LvaBVARz3QXLmlNjsrKY9fTc=
 github.com/elastic/elastic-agent-libs v0.1.1/go.mod h1:h8K/f7RcdxM2f19VahcS1jeco170ItqV9N7HyYsn9Ss=

--- a/tests/deploy/cloudbeat-pytest.yml
+++ b/tests/deploy/cloudbeat-pytest.yml
@@ -151,7 +151,7 @@ data:
         processes:
           etcd:
           kube-apiserver:
-          kube-controller-manager:
+          kube-controller:
           kube-scheduler:
           kubelet:
             config-file-arguments:

--- a/tests/deploy/k8s-cloudbeat-tests/templates/cloudbeat-ds.yml
+++ b/tests/deploy/k8s-cloudbeat-tests/templates/cloudbeat-ds.yml
@@ -138,7 +138,7 @@ data:
         processes:
           etcd:
           kube-apiserver:
-          kube-controller-manager:
+          kube-controller:
           kube-scheduler:
           kubelet:
             config-file-arguments:


### PR DESCRIPTION
Correcting the fetching of kube contoller manager process
Bumping csp policies version

```json
{
  "bundles": {
    "test": {}
  },
  "decision_id": "472a31dd-eaa9-44c0-80be-685a05d1978d",
  "input": {
    "resource": {
      "command": "kube-controller-manager --allocate-node-cidrs=true --authentication-kubeconfig=/etc/kubernetes/controller-manager.conf --authorization-kubeconfig=/etc/kubernetes/controller-manager.conf --bind-address=127.0.0.1 --client-ca-file=/etc/kubernetes/pki/ca.crt --cluster-cidr=10.244.0.0/16 --cluster-name=kind-mono --cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt --cluster-signing-key-file=/etc/kubernetes/pki/ca.key --controllers=*,bootstrapsigner,tokencleaner --enable-hostpath-provisioner=true --kubeconfig=/etc/kubernetes/controller-manager.conf --leader-elect=true --port=0 --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt --root-ca-file=/etc/kubernetes/pki/ca.crt --service-account-private-key-file=/etc/kubernetes/pki/sa.key --service-cluster-ip-range=10.96.0.0/16 --use-service-account-credentials=true",
      "external_data": {},
      "pid": "490",
      "stat": {
        "EffectiveGID": "",
        "EffectiveUID": "",
        "Group": "490",
        "Name": "kube-controller",
        "Nice": "0",
        "Parent": "313",
        "RealGID": "",
        "RealUID": "",
        "ResidentSize": "111608000",
        "SavedGID": "",
        "SavedUID": "",
        "StartTime": "69976008",
        "State": "S",
        "SystemTime": "86226",
        "Threads": "10",
        "TotalSize": "812740000",
        "UserTime": "77917"
      }
    },
    "type": "process"
  },
  "labels": {
    "id": "c5bf8cc2-969b-4593-a659-4a16f1790770",
    "version": "0.38.1"
  },
  "level": "info",
  "metrics": {
    "timer_rego_external_resolve_ns": 8042,
    "timer_rego_query_eval_ns": 18398792,
    "timer_sdk_decision_eval_ns": 18702625
  },
  "msg": "Decision Log",
  "path": "main",
  "result": {
    "findings": [
      {
        "result": {
          "evaluation": "failed",
          "evidence": {
            "process_args": {
              "--allocate-node-cidrs": "true",
              "--authentication-kubeconfig": "/etc/kubernetes/controller-manager.conf",
              "--authorization-kubeconfig": "/etc/kubernetes/controller-manager.conf",
              "--bind-address": "127.0.0.1",
              "--client-ca-file": "/etc/kubernetes/pki/ca.crt",
              "--cluster-cidr": "10.244.0.0/16",
              "--cluster-name": "kind-mono",
              "--cluster-signing-cert-file": "/etc/kubernetes/pki/ca.crt",
              "--cluster-signing-key-file": "/etc/kubernetes/pki/ca.key",
              "--controllers": "*,bootstrapsigner,tokencleaner",
              "--enable-hostpath-provisioner": "true",
              "--kube-controller-manager": "",
              "--kubeconfig": "/etc/kubernetes/controller-manager.conf",
              "--leader-elect": "true",
              "--port": "0",
              "--requestheader-client-ca-file": "/etc/kubernetes/pki/front-proxy-ca.crt",
              "--root-ca-file": "/etc/kubernetes/pki/ca.crt",
              "--service-account-private-key-file": "/etc/kubernetes/pki/sa.key",
              "--service-cluster-ip-range": "10.96.0.0/16",
              "--use-service-account-credentials": "true"
            }
          }
        },
        "rule": {
          "audit": "Run the following command on the control plane node:\n```\nps -ef | grep kube-controller-manager\n```\nVerify that `RotateKubeletServerCertificate` argument exists and is set to `true`.\n",
          "benchmark": {
            "name": "CIS Kubernetes V1.23",
            "version": "v1.0.0"
          },
          "default_value": "By default, `RotateKubeletServerCertificate` is set to \"true\" this recommendation verifies that it has not been disabled.\n",
          "description": "Enable kubelet server certificate rotation on controller-manager.\n",
          "id": "a75f69ac-866e-5fbe-b9ce-b5a2a8c20834",
          "impact": "None\n",
          "name": "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)",
          "profile_applicability": "* Level 2 - Master Node\n",
          "rationale": "`RotateKubeletServerCertificate` causes the kubelet to both request a serving certificate after bootstrapping its client credentials and rotate the certificate as its existing credentials expire. This automated periodic rotation ensures that the there are no downtimes due to expired certificates and thus addressing availability in the CIA security triad. Note: This recommendation only applies if you let kubelets get their certificates from the API server. In case your kubelet certificates come from an outside authority/tool (e.g. Vault) then you need to take care of rotation yourself.\n",
          "references": "1. [https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/#approval-controller](https://kubernetes.io/docs/admin/kubelet-tls-bootstrapping/#approval-controller)\n2. [https://github.com/kubernetes/features/issues/267](https://github.com/kubernetes/features/issues/267)\n3. [https://github.com/kubernetes/kubernetes/pull/45059](https://github.com/kubernetes/kubernetes/pull/45059)\n4. [https://kubernetes.io/docs/admin/kube-controller-manager/](https://kubernetes.io/docs/admin/kube-controller-manager/)\n",
          "remediation": "Edit the Controller Manager pod specification file\n`/etc/kubernetes/manifests/kube-controller-manager.yaml` \non the control plane node and set the `--feature-gates` parameter to\ninclude `RotateKubeletServerCertificate=true`.\n```\n--feature-gates=RotateKubeletServerCertificate=true\n```\n",
          "section": "Controller Manager",
          "tags": [
            "CIS",
            "Kubernetes",
            "CIS 1.3.6",
            "Controller Manager"
          ],
          "version": "1.0"
        }
      }
    ]
  }
}
```
Fixes https://github.com/elastic/cloudbeat/issues/111