### PR TITLE
Update CI to support producing release candidate builds(aka "Staging")

### DIFF
--- a/.ci/scripts/package.sh
+++ b/.ci/scripts/package.sh
@@ -6,5 +6,9 @@ set -euox pipefail
 export PLATFORMS="linux/amd64,linux/arm64"
 export TYPES="tar.gz"
 
-make release-manager-snapshot
+if [ $WORKFLOW = "staging" ] ; then
+    make release-manager-snapshot
+else 
+    make release-manager-release
+
 cp build/dependencies-*.csv build/distributions/.

--- a/.ci/scripts/package.sh
+++ b/.ci/scripts/package.sh
@@ -7,8 +7,9 @@ export PLATFORMS="linux/amd64,linux/arm64"
 export TYPES="tar.gz"
 
 if [ $WORKFLOW = "staging" ] ; then
-    make release-manager-snapshot
-else 
     make release-manager-release
+else 
+    make release-manager-snapshot
+fi
 
 cp build/dependencies-*.csv build/distributions/.

--- a/.ci/scripts/rm-docker.sh
+++ b/.ci/scripts/rm-docker.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 IMAGE="docker.elastic.co/infra/release-manager:latest"
-WORKFLOW="snapshot"
-# Hardcoded until we determine on our release candidate/release branch structure.
-
 # Allow other users write access to create checksum files
 chmod -R 777 build/distributions 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,7 +150,6 @@ pipeline {
           environment {
             PATH = "${env.PATH}:${env.WORKSPACE}/bin"
             HOME = "${env.WORKSPACE}"
-            // SNAPSHOT = "true"
           }
           when {
             beforeAgent true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
     ES_LOG_LEVEL = "${params.ES_LOG_LEVEL}"
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
+    WORKFLOW = "${params.Build_type}"
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -32,6 +33,7 @@ pipeline {
     booleanParam(name: 'test_ci', defaultValue: false, description: 'Enable test')
     booleanParam(name: 'release_ci', defaultValue: true, description: 'Enable build the release packages')
     booleanParam(name: 'its_ci', defaultValue: true, description: 'Enable async ITs')
+    choice(name: 'Build_type', choices: ['snapshot', 'staging'], description: 'Choose Snapshot or Staging Build type(Default: Snapshot)')
     string(name: 'DIAGNOSTIC_INTERVAL', defaultValue: "0", description: 'Elasticsearch detailed logging every X seconds')
     string(name: 'ES_LOG_LEVEL', defaultValue: "error", description: 'Elasticsearch error level')
   }
@@ -148,7 +150,7 @@ pipeline {
           environment {
             PATH = "${env.PATH}:${env.WORKSPACE}/bin"
             HOME = "${env.WORKSPACE}"
-            SNAPSHOT = "true"
+            // SNAPSHOT = "true"
           }
           when {
             beforeAgent true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     ES_LOG_LEVEL = "${params.ES_LOG_LEVEL}"
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
-    WORKFLOW = "${params.Build_type}"
+    WORKFLOW = "${params.build_type}"
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -33,7 +33,7 @@ pipeline {
     booleanParam(name: 'test_ci', defaultValue: false, description: 'Enable test')
     booleanParam(name: 'release_ci', defaultValue: true, description: 'Enable build the release packages')
     booleanParam(name: 'its_ci', defaultValue: true, description: 'Enable async ITs')
-    choice(name: 'Build_type', choices: ['snapshot', 'staging'], description: 'Choose Snapshot or Staging Build type(Default: Snapshot)')
+    choice(name: 'build_type', choices: ['snapshot', 'staging'], description: 'Choose Snapshot or Staging Build type(Default: Snapshot)')
     string(name: 'DIAGNOSTIC_INTERVAL', defaultValue: "0", description: 'Elasticsearch detailed logging every X seconds')
     string(name: 'ES_LOG_LEVEL', defaultValue: "error", description: 'Elasticsearch error level')
   }

--- a/Makefile
+++ b/Makefile
@@ -244,5 +244,5 @@ build/dependencies.csv: $(PYTHON) go.mod
 ifdef SNAPSHOT
 	$(PYTHON) scripts/make/generate_notice.py --csv build/dependencies-${CLOUDBEAT_VERSION}-SNAPSHOT.csv
 else
-	$(PYTHON) scripts/make/generate_notice.py --csv build/dependencies-$CLOUDBEAT_VERSION.csv
+	$(PYTHON) scripts/make/generate_notice.py --csv build/dependencies-${CLOUDBEAT_VERSION}.csv
 endif


### PR DESCRIPTION
Update ci to run staging builds.
Added drop down list to enable invoking manual Staging build("Release candidates") via an option in cloudbeat's jenkins job
https://internal-ci.elastic.co/job/cloudbeat/job/cloudbeat-mbp/
![image](https://user-images.githubusercontent.com/16253938/171027298-cec0d89c-182d-47ec-a5bf-b08059455e4b.png)


