### PR TITLE
Make cloudbeat wait for initial reconfiguration from Fleet server.

### DIFF
--- a/beater/cloudbeat.go
+++ b/beater/cloudbeat.go
@@ -37,6 +37,10 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+const (
+	reconfigureWaitTimeout = 5 * time.Minute
+)
+
 // cloudbeat configuration.
 type cloudbeat struct {
 	ctx    context.Context
@@ -122,11 +126,23 @@ func (bt *cloudbeat) Run(b *beat.Beat) error {
 	bt.log.Info("cloudbeat is running! Hit CTRL-C to stop it.")
 
 	// Configure the beats Manager to start after all the reloadable hooks are initialized
-	// and shutdown when the function return.
+	// and shutdown when the function returns.
 	if err := b.Manager.Start(); err != nil {
 		return err
 	}
 	defer b.Manager.Stop()
+
+	if b.Manager.Enabled() {
+		bt.log.Infof("Waiting for initial reconfiguration from Fleet server...")
+		update, err := bt.reconfigureWait(reconfigureWaitTimeout)
+		if err != nil {
+			return err
+		}
+
+		if err := bt.configUpdate(update); err != nil {
+			return fmt.Errorf("failed to update with initial reconfiguration from Fleet server: %w", err)
+		}
+	}
 
 	if err := bt.data.Run(bt.ctx); err != nil {
 		return err
@@ -154,34 +170,9 @@ func (bt *cloudbeat) Run(b *beat.Beat) error {
 			return nil
 
 		case update := <-bt.configUpdates:
-			if err := bt.config.Update(update); err != nil {
-				bt.log.Errorf("Could not update cloudbeat config: %v", err)
-				break
+			if err := bt.configUpdate(update); err != nil {
+				bt.log.Errorf("Failed to update cloudbeat config: %v", err)
 			}
-
-			policies, err := csppolicies.CISKubernetes()
-			if err != nil {
-				bt.log.Errorf("Could not load CIS Kubernetes policies: %v", err)
-				break
-			}
-
-			if len(bt.config.Streams) == 0 {
-				bt.log.Infof("Did not receive any input stream, skipping.")
-				break
-			}
-
-			y, err := bt.config.DataYaml()
-			if err != nil {
-				bt.log.Errorf("Could not marshal to YAML: %v", err)
-				break
-			}
-
-			if err := csppolicies.HostBundleWithDataYaml("bundle.tar.gz", policies, y); err != nil {
-				bt.log.Errorf("Could not update bundle with dataYaml: %v", err)
-				break
-			}
-
-			bt.log.Infof("Bundle updated with dataYaml: %s", y)
 
 		case fetchedResources := <-output:
 			cycleId, _ := uuid.NewV4()
@@ -197,6 +188,74 @@ func (bt *cloudbeat) Run(b *beat.Beat) error {
 			bt.log.Infof("Cycle %v has ended", cycleId)
 		}
 	}
+}
+
+// reconfigureWait will wait for and consume incoming reconfuration from the Fleet server, and keep
+// discarding them until the incoming config contains the necessary information to start cloudbeat
+// properly, thereafter returning the valid config.
+func (bt *cloudbeat) reconfigureWait(timeout time.Duration) (*common.Config, error) {
+	rctx, cancel := context.WithTimeout(bt.ctx, timeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-rctx.Done():
+			return nil, fmt.Errorf("cancelled via context")
+
+		case update, ok := <-bt.configUpdates:
+			if !ok {
+				return nil, fmt.Errorf("reconfiguration channel is closed")
+			}
+
+			c, err := config.New(update)
+			if err != nil {
+				bt.log.Errorf("Could not parse reconfiguration %v, skipping with error: %v", update.FlattenedKeys(), err)
+				continue
+			}
+
+			if len(c.Streams) == 0 {
+				bt.log.Infof("No streams received in reconfiguration %v", update.FlattenedKeys())
+				continue
+			}
+
+			if c.Streams[0].DataYaml == nil {
+				bt.log.Infof("data_yaml not present in reconfiguration %v", update.FlattenedKeys())
+				continue
+			}
+
+			return update, nil
+		}
+	}
+}
+
+// configUpdate applies incoming reconfiguration from the Fleet server to the cloudbeat config,
+// and updates the hosted bundle with the new values.
+func (bt *cloudbeat) configUpdate(update *common.Config) error {
+	if err := bt.config.Update(bt.log, update); err != nil {
+		return err
+	}
+
+	policies, err := csppolicies.CISKubernetes()
+	if err != nil {
+		return fmt.Errorf("could not load CIS Kubernetes policies: %w", err)
+	}
+
+	if len(bt.config.Streams) == 0 {
+		bt.log.Infof("Did not receive any input stream from incoming config, skipping.")
+		return nil
+	}
+
+	y, err := bt.config.DataYaml()
+	if err != nil {
+		return fmt.Errorf("could not marshal to YAML: %w", err)
+	}
+
+	if err := csppolicies.HostBundleWithDataYaml("bundle.tar.gz", policies, y); err != nil {
+		return fmt.Errorf("could not update bundle with dataYaml: %w", err)
+	}
+
+	bt.log.Infof("Bundle updated with dataYaml: %s", y)
+	return nil
 }
 
 func InitRegistry(log *logp.Logger, c config.Config) (manager.FetchersRegistry, error) {

--- a/beater/cloudbeat_test.go
+++ b/beater/cloudbeat_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package beater
 
 import (

--- a/beater/cloudbeat_test.go
+++ b/beater/cloudbeat_test.go
@@ -1,0 +1,180 @@
+package beater
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/stretchr/testify/suite"
+)
+
+type BeaterTestSuite struct {
+	suite.Suite
+
+	log *logp.Logger
+}
+
+func TestBeaterTestSuite(t *testing.T) {
+	s := new(BeaterTestSuite)
+	s.log = logp.NewLogger("cloudbeat_beater_test_suite")
+
+	if err := logp.TestingSetup(); err != nil {
+		t.Error(err)
+	}
+
+	suite.Run(t, s)
+}
+
+func (s *BeaterTestSuite) SetupTest() {
+}
+
+func (s *BeaterTestSuite) TestReconfigureWait() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	beat := &cloudbeat{
+		ctx:    ctx,
+		cancel: cancel,
+		log:    s.log,
+	}
+
+	configNoStreams, err := common.NewConfigFrom(`
+    not_streams:
+      - data_yaml:
+          activated_rules:
+            cis_k8s:
+              - a
+              - b
+              - c
+              - d
+              - e
+`)
+	s.NoError(err)
+
+	configNoDataYaml, err := common.NewConfigFrom(`
+    streams:
+      - not_data_yaml:
+          activated_rules:
+            cis_k8s:
+              - a
+              - b
+              - c
+              - d
+              - e
+`)
+	s.NoError(err)
+
+	configWithDataYaml, err := common.NewConfigFrom(`
+    streams:
+      - data_yaml:
+          activated_rules:
+            cis_k8s:
+              - a
+              - b
+              - c
+              - d
+              - e
+`)
+	s.NoError(err)
+
+	type incomingConfigs []struct {
+		after  time.Duration
+		config *common.Config
+	}
+
+	testcases := []struct {
+		timeout  time.Duration
+		configs  incomingConfigs
+		expected *common.Config
+	}{
+		{
+			5 * time.Millisecond,
+			incomingConfigs{},
+			nil,
+		},
+		{
+			40 * time.Millisecond,
+			incomingConfigs{
+				{1 * time.Millisecond, configWithDataYaml},
+			},
+			configWithDataYaml,
+		},
+		{
+			40 * time.Millisecond,
+			incomingConfigs{
+				{1 * time.Millisecond, configNoStreams},
+				{1 * time.Millisecond, configNoDataYaml},
+				{1 * time.Millisecond, configNoStreams},
+			},
+			nil,
+		},
+		{
+			40 * time.Millisecond,
+			incomingConfigs{
+				{1 * time.Millisecond, configNoStreams},
+				{1 * time.Millisecond, configNoDataYaml},
+				{1 * time.Millisecond, configNoStreams},
+				{1 * time.Millisecond, configWithDataYaml},
+			},
+			configWithDataYaml,
+		},
+		{
+			40 * time.Millisecond,
+			incomingConfigs{
+				{1 * time.Millisecond, configNoStreams},
+				{1 * time.Millisecond, configNoDataYaml},
+				{1 * time.Millisecond, configNoStreams},
+				{40 * time.Millisecond, configWithDataYaml},
+			},
+			nil,
+		},
+		{
+			40 * time.Millisecond,
+			incomingConfigs{
+				{1 * time.Millisecond, configNoStreams},
+				{40 * time.Millisecond, configNoDataYaml},
+				{1 * time.Millisecond, configNoStreams},
+			},
+			nil,
+		},
+		{
+			40 * time.Millisecond,
+			incomingConfigs{
+				{1 * time.Millisecond, configNoDataYaml},
+				{1 * time.Millisecond, configWithDataYaml},
+				{1 * time.Millisecond, configNoStreams},
+			},
+			configWithDataYaml,
+		},
+		{
+			40 * time.Millisecond,
+			incomingConfigs{
+				{1 * time.Millisecond, configWithDataYaml},
+				{1 * time.Millisecond, configNoStreams},
+			},
+			configWithDataYaml,
+		},
+	}
+
+	for _, tcase := range testcases {
+		cu := make(chan *common.Config)
+		beat.configUpdates = cu
+
+		go func(ic incomingConfigs) {
+			defer close(cu)
+
+			for _, c := range ic {
+				time.Sleep(c.after)
+				cu <- c.config
+			}
+		}(tcase.configs)
+
+		u, err := beat.reconfigureWait(tcase.timeout)
+		if tcase.expected == nil {
+			s.Error(err)
+		} else {
+			s.Equal(tcase.expected, u)
+		}
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"gopkg.in/yaml.v3"
 )
@@ -42,7 +43,7 @@ type Config struct {
 }
 
 type Stream struct {
-	DataYaml struct {
+	DataYaml *struct {
 		ActivatedRules struct {
 			CISK8S []string `config:"cis_k8s" yaml:"cis_k8s" json:"cis_k8s"`
 		} `config:"activated_rules" yaml:"activated_rules" json:"activated_rules"`
@@ -68,27 +69,22 @@ func New(cfg *common.Config) (Config, error) {
 //
 // NOTE(yashtewari): This will be removed with the planned update to restart the
 // beat with the new config.
-func (c *Config) Update(cfg *common.Config) error {
+func (c *Config) Update(log *logp.Logger, cfg *common.Config) error {
+	log.Infof("Updating config with the following keys: %v", cfg.FlattenedKeys())
+
 	if err := cfg.Unpack(&c); err != nil {
 		return err
 	}
 
 	// Check if the incoming config has streams.
-	m := make(map[string]interface{})
-	if err := cfg.Unpack(&m); err != nil {
-		return err
-	}
+	if cfg.HasField("streams") {
+		uc, err := New(cfg)
+		if err != nil {
+			return err
+		}
 
-	if _, ok := m["streams"]; !ok {
-		return nil
+		c.Streams = uc.Streams
 	}
-
-	uc, err := New(cfg)
-	if err != nil {
-		return err
-	}
-
-	c.Streams = uc.Streams
 
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,14 +32,19 @@ import (
 
 type ConfigTestSuite struct {
 	suite.Suite
+
+	log *logp.Logger
 }
 
 func TestConfigTestSuite(t *testing.T) {
+	s := new(ConfigTestSuite)
+	s.log = logp.NewLogger("cloudbeat_config_test_suite")
+
 	if err := logp.TestingSetup(); err != nil {
 		t.Error(err)
 	}
 
-	suite.Run(t, new(ConfigTestSuite))
+	suite.Run(t, s)
 }
 
 func (s *ConfigTestSuite) SetupTest() {
@@ -74,6 +79,46 @@ func (s *ConfigTestSuite) TestNew() {
 		s.NoError(err)
 
 		s.Equal(test.expected, c.Streams[0].DataYaml.ActivatedRules.CISK8S)
+	}
+}
+
+func (s *ConfigTestSuite) TestDataYamlExists() {
+	var tests = []struct {
+		config   string
+		expected bool
+	}{
+		{
+			`
+  streams:
+    - data_yaml:
+        activated_rules:
+          cis_k8s:
+            - a
+            - b
+            - c
+            - d
+            - e
+`,
+			true,
+		},
+		{
+			`
+  streams:
+    - not_data_yaml:
+        something: true
+`,
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		cfg, err := common.NewConfigFrom(test.config)
+		s.NoError(err)
+
+		c, err := New(cfg)
+		s.NoError(err)
+
+		s.Equal(test.expected, c.Streams[0].DataYaml != nil)
 	}
 }
 
@@ -178,7 +223,7 @@ func (s *ConfigTestSuite) TestConfigUpdate() {
 		cfg, err := common.NewConfigFrom(test.update)
 		s.NoError(err)
 
-		err = c.Update(cfg)
+		err = c.Update(s.log, cfg)
 		s.NoError(err)
 
 		s.Equal(test.expected, c.Streams[0].DataYaml.ActivatedRules.CISK8S)
@@ -256,7 +301,7 @@ func (s *ConfigTestSuite) TestConfigUpdateIsolated() {
 		cfg, err := common.NewConfigFrom(test.update)
 		s.NoError(err)
 
-		err = c.Update(cfg)
+		err = c.Update(s.log, cfg)
 		s.NoError(err)
 
 		s.Equal(test.expectedPeriod, c.Period)


### PR DESCRIPTION
The reconfiguration logic makes cloudbeat align with the CIS rules enabled/disabled by the user.

Prior to this change, the "default" behavior would kick of and send findings for _all_ CIS rules to the index, before the Fleet server could tell it which findings to send. This is undesirable as it pollutes the index with unwanted findings.