### PR TITLE
Use Elasticsearch events for automated testing.

### DIFF
--- a/tests/product/tests/test_k8s_objects_rules.py
+++ b/tests/product/tests/test_k8s_objects_rules.py
@@ -8,7 +8,7 @@ import pytest
 
 # from product.tests.data.k8s_object.k8s_object_rules import *
 from product.tests.data.k8s_object import k8s_object_rules as k8s_tc
-from commonlib.utils import get_evaluation, get_resource_identifier
+from commonlib.utils import get_ES_evaluation, get_resource_identifier
 from commonlib.framework.reporting import skip_param_case, SkipReportData
 
 
@@ -58,7 +58,7 @@ from commonlib.framework.reporting import skip_param_case, SkipReportData
         # *k8s_tc.cis_5_2_10.keys() - TODO: cases are not implemented
     ]
 )
-def test_kube_resource_patch(test_env, rule_tag, resource_type, resource_body, expected):
+def test_kube_resource_patch(elastic_client, test_env, rule_tag, resource_type, resource_body, expected):
     """
     Test kube resource
     @param test_env: pre step that set-ups a kube resources to test on
@@ -92,16 +92,10 @@ def test_kube_resource_patch(test_env, rule_tag, resource_type, resource_body, e
         raise ValueError(
             f'Could not patch resource type {resource_type}:'
             f' {relevant_metadata} with patch {resource_body}')
-
-    # check resource evaluation
-    pods = k8s_client.get_agent_pod_instances(agent_name=agent_config.name,
-                                              namespace=agent_config.namespace)
-
-    evaluation = get_evaluation(
-        k8s=k8s_client,
+    
+    evaluation = get_ES_evaluation(
+        elastic_client=elastic_client,
         timeout=agent_config.findings_timeout,
-        pod_name=pods[0].metadata.name,
-        namespace=agent_config.namespace,
         rule_tag=rule_tag,
         exec_timestamp=datetime.utcnow(),
         resource_identifier=get_resource_identifier(resource_body),

--- a/tests/product/tests/test_process_api_server_rules.py
+++ b/tests/product/tests/test_process_api_server_rules.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import time
 import pytest
 
-from commonlib.utils import get_evaluation
+from commonlib.utils import get_ES_evaluation
 from product.tests.data.process.process_test_cases import api_server_rules
 
 
@@ -16,7 +16,8 @@ from product.tests.data.process.process_test_cases import api_server_rules
     ("rule_tag", "dictionary", "resource", "expected"),
     api_server_rules,
 )
-def test_process_api_server(config_node_pre_test,
+def test_process_api_server(elastic_client,
+                            config_node_pre_test,
                             rule_tag,
                             dictionary,
                             resource,
@@ -40,8 +41,6 @@ def test_process_api_server(config_node_pre_test,
 
     # Currently, single node is used, in the future may be extended for all nodes.
     node = k8s_client.get_cluster_nodes()[0]
-    pods = k8s_client.get_agent_pod_instances(agent_name=cloudbeat_agent.name, namespace=cloudbeat_agent.namespace)
-
     api_client.edit_process_file(container_name=node.metadata.name,
                                  dictionary=dictionary,
                                  resource=resource)
@@ -50,11 +49,9 @@ def test_process_api_server(config_node_pre_test,
     # TODO: Implement a more optimal way of waiting
     time.sleep(60)
 
-    evaluation = get_evaluation(
-        k8s=k8s_client,
+    evaluation = get_ES_evaluation(
+        elastic_client=elastic_client,
         timeout=cloudbeat_agent.findings_timeout,
-        pod_name=pods[0].metadata.name,
-        namespace=cloudbeat_agent.namespace,
         rule_tag=rule_tag,
         exec_timestamp=datetime.utcnow(),
     )

--- a/tests/product/tests/test_process_controller_manager_rules.py
+++ b/tests/product/tests/test_process_controller_manager_rules.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import time
 import pytest
 
-from commonlib.utils import get_evaluation
+from commonlib.utils import get_ES_evaluation
 from product.tests.data.process.process_test_cases import controller_manager_rules
 
 
@@ -16,7 +16,8 @@ from product.tests.data.process.process_test_cases import controller_manager_rul
     ("rule_tag", "dictionary", "resource", "expected"),
     controller_manager_rules,
 )
-def test_process_controller_manager(config_node_pre_test,
+def test_process_controller_manager(elastic_client,
+                                    config_node_pre_test,
                                     rule_tag,
                                     dictionary,
                                     resource,
@@ -40,8 +41,6 @@ def test_process_controller_manager(config_node_pre_test,
 
     # Currently, single node is used, in the future may be extended for all nodes.
     node = k8s_client.get_cluster_nodes()[0]
-    pods = k8s_client.get_agent_pod_instances(agent_name=cloudbeat_agent.name, namespace=cloudbeat_agent.namespace)
-
     api_client.edit_process_file(container_name=node.metadata.name,
                                  dictionary=dictionary,
                                  resource=resource)
@@ -49,12 +48,10 @@ def test_process_controller_manager(config_node_pre_test,
     # Wait for process reboot
     # TODO: Implement a more optimal way of waiting
     time.sleep(60)
-
-    evaluation = get_evaluation(
-        k8s=k8s_client,
+    
+    evaluation = get_ES_evaluation(
+        elastic_client=elastic_client,
         timeout=cloudbeat_agent.findings_timeout,
-        pod_name=pods[0].metadata.name,
-        namespace=cloudbeat_agent.namespace,
         rule_tag=rule_tag,
         exec_timestamp=datetime.utcnow(),
     )

--- a/tests/product/tests/test_process_etcd_rules.py
+++ b/tests/product/tests/test_process_etcd_rules.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import time
 import pytest
 
-from commonlib.utils import get_evaluation
+from commonlib.utils import get_ES_evaluation
 from product.tests.data.process.process_test_cases import etcd_rules
 
 
@@ -16,7 +16,8 @@ from product.tests.data.process.process_test_cases import etcd_rules
     ("rule_tag", "dictionary", "resource", "expected"),
     etcd_rules,
 )
-def test_process_etcd(config_node_pre_test,
+def test_process_etcd(elastic_client,
+                      config_node_pre_test,
                       rule_tag,
                       dictionary,
                       resource,
@@ -40,21 +41,17 @@ def test_process_etcd(config_node_pre_test,
 
     # Currently, single node is used, in the future may be extended for all nodes.
     node = k8s_client.get_cluster_nodes()[0]
-    pods = k8s_client.get_agent_pod_instances(agent_name=cloudbeat_agent.name, namespace=cloudbeat_agent.namespace)
-
     api_client.edit_process_file(container_name=node.metadata.name,
                                  dictionary=dictionary,
                                  resource=resource)
-
+    
     # Wait for process reboot
     # TODO: Implement a more optimal way of waiting
     time.sleep(60)
 
-    evaluation = get_evaluation(
-        k8s=k8s_client,
+    evaluation = get_ES_evaluation(
+        elastic_client=elastic_client,
         timeout=cloudbeat_agent.findings_timeout,
-        pod_name=pods[0].metadata.name,
-        namespace=cloudbeat_agent.namespace,
         rule_tag=rule_tag,
         exec_timestamp=datetime.utcnow(),
     )

--- a/tests/product/tests/test_process_kubelet_rules.py
+++ b/tests/product/tests/test_process_kubelet_rules.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import time
 import pytest
 
-from commonlib.utils import get_evaluation
+from commonlib.utils import get_ES_evaluation
 from product.tests.data.process.process_test_cases import kubelet_rules
 
 
@@ -16,7 +16,8 @@ from product.tests.data.process.process_test_cases import kubelet_rules
     ("rule_tag", "dictionary", "resource", "expected"),
     kubelet_rules,
 )
-def test_process_kubelet(config_node_pre_test,
+def test_process_kubelet(elastic_client,
+                         config_node_pre_test,
                          rule_tag,
                          dictionary,
                          resource,
@@ -40,21 +41,17 @@ def test_process_kubelet(config_node_pre_test,
 
     # Currently, single node is used, in the future may be extended for all nodes.
     node = k8s_client.get_cluster_nodes()[0]
-    pods = k8s_client.get_agent_pod_instances(agent_name=cloudbeat_agent.name, namespace=cloudbeat_agent.namespace)
-
     api_client.edit_config_file(container_name=node.metadata.name,
                                 dictionary=dictionary,
                                 resource=resource)
 
-    # Wait for updated file fetch
+    # Wait for process reboot
     # TODO: Implement a more optimal way of waiting
     time.sleep(60)
 
-    evaluation = get_evaluation(
-        k8s=k8s_client,
+    evaluation = get_ES_evaluation(
+        elastic_client=elastic_client,
         timeout=cloudbeat_agent.findings_timeout,
-        pod_name=pods[0].metadata.name,
-        namespace=cloudbeat_agent.namespace,
         rule_tag=rule_tag,
         exec_timestamp=datetime.utcnow(),
     )


### PR DESCRIPTION
Use of OPA decision logs to match findings against expected findings is now deprecated.

The deprecated function `get_evaluation` has been renamed to `get_logs_evaluation` but not yet deleted, because it's still useful for debugging.

Resolves: https://github.com/elastic/security-team/issues/4049