### PR TITLE
Fix-pre-merge-ci

### DIFF
--- a/.github/workflows/cloudbeat-ci.yml
+++ b/.github/workflows/cloudbeat-ci.yml
@@ -11,6 +11,10 @@ env:
   GO_VERSION: 1.18.2
   CONTAINER_SUFFIX: ${{ github.run_id }}
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   Build:
     name: Build
@@ -86,11 +90,11 @@ jobs:
     name: ${{ matrix.test-target }}-tests
     needs: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 55
     strategy:
       matrix:
         # test-targets chosen by stabillity and runtime.Only pre_merge will be set as mandatory
-        test-target: [pre_merge, file_system_rules, k8s_object_rules, process_etcd_rules, process_scheduler_rules, process_api_server_rules, process_controller_manager_rules, process_etcd_rules, process_kubelet_rules]
+        test-target: [pre_merge, file_system_rules, k8s_object_rules, process_scheduler_rules, process_api_server_rules, process_controller_manager_rules, process_etcd_rules, process_kubelet_rules]
       fail-fast: false
     steps:
       - name: Check out the repo

--- a/.github/workflows/cloudbeat-ci.yml
+++ b/.github/workflows/cloudbeat-ci.yml
@@ -140,12 +140,6 @@ jobs:
           name: allure_results-${{ matrix.test-target}}
           path: tests/allure/results/
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: failure()
-        with:
-          limit-access-to-actor: true
-
       - name: clear cache
         id: clear_cache
         if: success()


### PR DESCRIPTION
- Remove tmate actions
- Extend test run time to 55 mins to accommodate API tests
- add concurrency to limit executions to one per pr