### PR TITLE
Update CSP integration input types

### DIFF
--- a/_meta/config/cloudbeat.common.yml.tmpl
+++ b/_meta/config/cloudbeat.common.yml.tmpl
@@ -1,7 +1,7 @@
 cloudbeat:
   # Defines how often an event is sent to the output
   period: 4h
-  type: cloudbeat/vanilla # cloudbeat/eks in case of EKS configuration
+  type: cloudbeat/cis_k8s # cloudbeat/cis_eks in case of EKS configuration
   fetchers:
     # Vanilla K8s Fetchers configuration
     vanilla:

--- a/beater/validator_test.go
+++ b/beater/validator_test.go
@@ -47,7 +47,7 @@ func TestValidatorTestSuite(t *testing.T) {
 func (s *ValidatorTestSuite) TestConfig() {
 	configNoStreams := config.MustNewConfigFrom(`
 not_streams:
-  - data_yaml:
+  - runtime_cfg:
       activated_rules:
         cis_k8s:
           - a
@@ -57,9 +57,9 @@ not_streams:
           - e
 `)
 
-	configNoDataYaml := config.MustNewConfigFrom(`
+	configNoRuntimeCfg := config.MustNewConfigFrom(`
 streams:
-  - not_data_yaml:
+  - not_runtime_cfg:
       activated_rules:
         cis_k8s:
           - a
@@ -68,9 +68,9 @@ streams:
           - d
           - e
 `)
-	configWithDataYaml := config.MustNewConfigFrom(`
+	configWithRuntimeCfg := config.MustNewConfigFrom(`
 streams:
-  - data_yaml:
+  - runtime_cfg:
       activated_rules:
         cis_k8s:
           - a
@@ -89,13 +89,13 @@ streams:
 			config.NewConfig(),
 		}, {
 			true,
-			configNoDataYaml,
+			configNoRuntimeCfg,
 		}, {
 			true,
 			configNoStreams,
 		}, {
 			false,
-			configWithDataYaml,
+			configWithRuntimeCfg,
 		},
 	}
 

--- a/cloudbeat.reference.yml
+++ b/cloudbeat.reference.yml
@@ -10,7 +10,7 @@
 cloudbeat:
   # Defines how often an event is sent to the output
   period: 4h
-  type: cloudbeat/vanilla # cloudbeat/eks in case of EKS configuration
+  type: cloudbeat/cis_k8s # cloudbeat/cis_eks in case of EKS configuration
   fetchers:
     # Vanilla K8s Fetchers configuration
     vanilla:
@@ -686,9 +686,6 @@ output.elasticsearch:
 
     # Strategy for fetching the topics metadata from the broker. Default is false.
     #full: false
-
-  # The number of concurrent load-balanced Kafka output workers.
-  #worker: 1
 
   # The number of times to retry publishing an event after a publishing failure.
   # After the specified number of retries, events are typically dropped.

--- a/cloudbeat.yml
+++ b/cloudbeat.yml
@@ -13,7 +13,7 @@
 cloudbeat:
   # Defines how often an event is sent to the output
   period: 4h
-  type: cloudbeat/vanilla # cloudbeat/eks in case of EKS configuration
+  type: cloudbeat/cis_k8s # cloudbeat/cis_eks in case of EKS configuration
   fetchers:
     # Vanilla K8s Fetchers configuration
     vanilla:

--- a/config/config.go
+++ b/config/config.go
@@ -38,8 +38,8 @@ const DefaultNamespace = "default"
 const ResultsDatastreamIndexPrefix = "logs-cloud_security_posture.findings"
 
 const (
-	InputTypeVanillaK8s = "cloudbeat/vanilla"
-	InputTypeEks        = "cloudbeat/eks"
+	InputTypeVanillaK8s = "cloudbeat/cis_k8s"
+	InputTypeEks        = "cloudbeat/cis_eks"
 )
 
 type Fetcher struct {
@@ -62,7 +62,7 @@ type Config struct {
 
 type Stream struct {
 	AWSConfig  aws.ConfigAWS  `config:",inline"`
-	RuntimeCfg *RuntimeConfig `config:"data_yaml"`
+	RuntimeCfg *RuntimeConfig `config:"runtime_cfg"`
 }
 
 type RuntimeConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -58,7 +58,7 @@ func (s *ConfigTestSuite) TestNew() {
 			`
    type : cloudbeat/cis_k8s
    streams:
-    - data_yaml:
+    - runtime_cfg:
         activated_rules:
           cis_k8s:
             - a
@@ -93,7 +93,7 @@ func (s *ConfigTestSuite) TestNew() {
 	}
 }
 
-func (s *ConfigTestSuite) TestDataYamlExists() {
+func (s *ConfigTestSuite) TestRuntimeCfgExists() {
 	var tests = []struct {
 		config   string
 		expected bool
@@ -101,7 +101,7 @@ func (s *ConfigTestSuite) TestDataYamlExists() {
 		{
 			`
   streams:
-    - data_yaml:
+    - runtime_cfg:
         activated_rules:
           cis_k8s:
             - a
@@ -115,7 +115,7 @@ func (s *ConfigTestSuite) TestDataYamlExists() {
 		{
 			`
   streams:
-    - not_data_yaml:
+    - not_runtime_cfg:
         something: true
 `,
 			false,
@@ -136,7 +136,7 @@ func (s *ConfigTestSuite) TestDataYamlExists() {
 func (s *ConfigTestSuite) TestConfigUpdate() {
 	configYml := `
     streams:
-      - data_yaml:
+      - runtime_cfg:
           activated_rules:
             cis_k8s:
               - a
@@ -158,7 +158,7 @@ func (s *ConfigTestSuite) TestConfigUpdate() {
 		{
 			`
           streams:
-            - data_yaml:
+            - runtime_cfg:
                 activated_rules:
                   cis_k8s:
                     - a	
@@ -177,7 +177,7 @@ func (s *ConfigTestSuite) TestConfigUpdate() {
 		{
 			`
           streams:
-            - data_yaml:
+            - runtime_cfg:
                 activated_rules:
                   cis_k8s:
                     - b	
@@ -197,7 +197,7 @@ func (s *ConfigTestSuite) TestConfigUpdate() {
 		{
 			`
           streams:
-            - data_yaml:
+            - runtime_cfg:
                 activated_rules:
                   cis_k8s: []
               access_key_id: 
@@ -215,7 +215,7 @@ func (s *ConfigTestSuite) TestConfigUpdate() {
 		{
 			`
           streams:
-            - data_yaml:
+            - runtime_cfg:
                 activated_rules:
                   cis_k8s:
                     - x	
@@ -224,7 +224,7 @@ func (s *ConfigTestSuite) TestConfigUpdate() {
               access_key_id: first_stream_key
               secret_access_key: first_stream_secret
               session_token: first_stream_session  
-            - data_yaml:
+            - runtime_cfg:
                 activated_rules:
                   cis_k8s:
                     - f	
@@ -271,7 +271,7 @@ func (s *ConfigTestSuite) TestConfigUpdateIsolated() {
     period: 10s
     kube_config: some_path
     streams:
-      - data_yaml:
+      - runtime_cfg:
           activated_rules:
             cis_k8s:
               - a
@@ -295,7 +295,7 @@ func (s *ConfigTestSuite) TestConfigUpdateIsolated() {
 		{
 			update: `
            streams:
-             - data_yaml:
+             - runtime_cfg:
                  activated_rules:
                    cis_k8s:
                      - a
@@ -325,7 +325,7 @@ func (s *ConfigTestSuite) TestConfigUpdateIsolated() {
 			update: `
            kube_config: some_other_path
            streams:
-             - data_yaml:
+             - runtime_cfg:
                  activated_rules:
                    cis_k8s:
                      - a
@@ -364,7 +364,7 @@ func (s *ConfigTestSuite) TestConfigUpdateIsolated() {
 	}
 }
 
-func (s *ConfigTestSuite) TestConfigDataYaml() {
+func (s *ConfigTestSuite) TestRuntimeConfig() {
 	var tests = []struct {
 		config   string
 		expected []string
@@ -372,7 +372,7 @@ func (s *ConfigTestSuite) TestConfigDataYaml() {
 		{
 			`
   streams:
-    - data_yaml:
+    - runtime_cfg:
         activated_rules:
           cis_k8s:
             - a
@@ -429,7 +429,7 @@ func (s *ConfigTestSuite) TestActivatedRulesFrameWork() {
 			`
 type: cloudbeat/cis_k8s
 streams:
-  - data_yaml:
+  - runtime_cfg:
       activated_rules:
         cis_k8s:
           - a
@@ -443,7 +443,7 @@ streams:
 			`
 type: cloudbeat/cis_eks
 streams:
-  - data_yaml:
+  - runtime_cfg:
       activated_rules:
         cis_eks:
           - a

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,7 +56,7 @@ func (s *ConfigTestSuite) TestNew() {
 	}{
 		{
 			`
-   type : cloudbeat/vanilla
+   type : cloudbeat/cis_k8s
    streams:
     - data_yaml:
         activated_rules:
@@ -71,7 +71,7 @@ func (s *ConfigTestSuite) TestNew() {
       session_token: session
 `,
 			[]string{"a", "b", "c", "d", "e"},
-			"cloudbeat/vanilla",
+			"cloudbeat/cis_k8s",
 			"key",
 			"secret",
 			"session",
@@ -427,7 +427,7 @@ func (s *ConfigTestSuite) TestActivatedRulesFrameWork() {
 	}{
 		{
 			`
-type: cloudbeat/vanilla
+type: cloudbeat/cis_k8s
 streams:
   - data_yaml:
       activated_rules:
@@ -437,11 +437,11 @@ streams:
 `,
 			[]string{"a", "b"},
 			nil,
-			"cloudbeat/vanilla",
+			"cloudbeat/cis_k8s",
 		},
 		{
 			`
-type: cloudbeat/eks
+type: cloudbeat/cis_eks
 streams:
   - data_yaml:
       activated_rules:
@@ -451,7 +451,7 @@ streams:
 `,
 			nil,
 			[]string{"a", "b"},
-			"cloudbeat/eks",
+			"cloudbeat/cis_eks",
 		},
 	}
 

--- a/evaluator/bundle_test.go
+++ b/evaluator/bundle_test.go
@@ -186,7 +186,7 @@ func (s *BundleTestSuite) TestCreateServerWithRuntimeConfig() {
 // TestCreateServerWithRuntimeConfig tests the creation of a server with a valid config
 func (s *BundleTestSuite) TestCreateServerWithFetchersConfig() {
 	validStreamsVanilla := agentconfig.MustNewConfigFrom(`
-    type: cloudbeat/vanilla
+    type: cloudbeat/cis_k8s
     streams:
       - data_yaml:
           activated_rules:
@@ -198,7 +198,7 @@ func (s *BundleTestSuite) TestCreateServerWithFetchersConfig() {
 	s.NoError(err)
 
 	validStreamsEks := agentconfig.MustNewConfigFrom(`
-    type: cloudbeat/eks
+    type: cloudbeat/cis_eks
     streams:
       - data_yaml:
           activated_rules:

--- a/resources/fetchersManager/factory_test.go
+++ b/resources/fetchersManager/factory_test.go
@@ -159,9 +159,9 @@ func (s *FactoriesTestSuite) TestRegisterFetchers() {
 		integrationType string
 	}{
 		{"new_fetcher", 6, ""},
-		{"new_fetcher", 6, "cloudbeat/vanilla"},
+		{"new_fetcher", 6, "cloudbeat/cis_k8s"},
 		{"other_fetcher", 4, ""},
-		{"other_fetcher", 4, "cloudbeat/vanilla"},
+		{"other_fetcher", 4, "cloudbeat/cis_k8s"},
 	}
 
 	for _, test := range tests {
@@ -219,7 +219,7 @@ func (s *FactoriesTestSuite) TestRegisterFromFullConfig() {
 	}{
 		{
 			`
-type: cloudbeat/vanilla
+type: cloudbeat/cis_k8s
 streams:
   - not_data_yaml:
       activated_rules:
@@ -232,7 +232,7 @@ fetchers:
 		},
 		{
 			`
-type: cloudbeat/eks
+type: cloudbeat/cis_eks
 streams:
   - not_data_yaml:
       activated_rules:


### PR DESCRIPTION
This PR updates the expected integration's input types and rename `dataYaml` to `runtimeCfg`.

Related:
- https://github.com/elastic/integrations/pull/3968