### PR TITLE
Remote config editing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,12 @@ Create an agent policy and install the CSP integration. Now, when adding a new a
 ### Update settings
 Update cloudbeat settings on a runnign elastic-agent can be done by running the [script](/scripts/remote_edit_config.sh).
 The script still requires a second step of trigerring the agent to re-run cloudbeat.
-This can be done on Fleet UI by renaming the integration or even changing the agent log level.
+This can be done on Fleet UI by changing the agent log level.
+Another option is through CLI on the agent by running 
+```
+kill -9 `pidof cloudbeat`
+```
+
 
 
 ## Code guidelines

--- a/beater/cloudbeat.go
+++ b/beater/cloudbeat.go
@@ -20,8 +20,9 @@ package beater
 import (
 	"context"
 	"fmt"
-	"github.com/elastic/cloudbeat/leaderelection"
 	"time"
+
+	"github.com/elastic/cloudbeat/leaderelection"
 
 	"github.com/elastic/cloudbeat/config"
 	"github.com/elastic/cloudbeat/evaluator"
@@ -86,7 +87,7 @@ func NewCloudbeat(_ *beat.Beat, cfg *agentconfig.C) (beat.Beater, error) {
 		return nil, fmt.Errorf("error reading config file: %w", err)
 	}
 
-	log.Info("Config initiated.")
+	log.Info("Config initiated with cycle period of ", c.Period)
 
 	resourceCh := make(chan fetching.ResourceInfo, resourceChBuffer)
 

--- a/scripts/remote_edit_config.sh
+++ b/scripts/remote_edit_config.sh
@@ -1,19 +1,56 @@
 #!/bin/bash
-ARCH=$(uname -a | rev | cut -d " " -f 1 | rev) # This should return arm64 on m1 and x86_64 on regular mac
-PREFIX="/usr/share/elastic-agent/data/"
-CLOUDBEAT_VERSION=$(grep defaultBeatVersion ../cmd/version.go | cut -d'=' -f2 | tr -d '" ')
-SUFFIX="/install/cloudbeat-${CLOUDBEAT_VERSION}-SNAPSHOT-linux-${ARCH}/cloudbeat.yml"
+# set -x
+find_in_folder() {
+  POD=$1
+  FOLDER=$2
+  PATTERN=$3
+  RES=$(kubectl -n kube-system exec $POD -- ls -1 $FOLDER)
+  if [ -z "$RES" ]
+  then
+    return
+  fi
+
+  RES=$(echo "$RES" | grep $PATTERN)
+  if [ -z "$RES" ]
+  then
+    return
+  fi
+
+  echo "${RES}"
+}
+
+find_config_file() {
+  POD=$1
+  PREFIX="/usr/share/elastic-agent/data"
+  PATH_PARTS=("elastic-agent-" "install" "cloudbeat-" "cloudbeat.yml")
+  for NEXT in ${PATH_PARTS[@]}; do
+    FOUND=$(find_in_folder $POD $PREFIX $NEXT)
+    if [ -z "$FOUND" ]
+    then
+      return
+    fi
+    PREFIX="${PREFIX}/${FOUND}"
+  done
+
+  echo $PREFIX
+}
+
 TMP_LOCAL="/tmp/cloudbeat.yml"
 
 PODS=$(kubectl -n kube-system get pod -l app=elastic-agent -o name)
 for P in $PODS; do
   POD=$(echo "$P" | cut -d '/' -f 2)
-  FOLDER=$(kubectl -n kube-system exec $POD -- ls $PREFIX)
-  FULL_PATH="${PREFIX}${FOLDER}${SUFFIX}"
-  kubectl -n kube-system cp "$POD":"$FULL_PATH" $TMP_LOCAL
+  CONFIG_FILEPATH="$(find_config_file $POD)"
+  if [ -z "$CONFIG_FILEPATH" ]
+  then
+    echo "could not find remote config file"
+    exit 1
+  fi
+
+  kubectl -n kube-system cp "$POD":"$CONFIG_FILEPATH" $TMP_LOCAL
   vi $TMP_LOCAL
-  kubectl -n kube-system cp $TMP_LOCAL "$POD":"$FULL_PATH"
-  kubectl -n kube-system exec "$POD" -- chmod go-w "$FULL_PATH"
-  kubectl -n kube-system exec "$POD" -- chown root:root "$FULL_PATH"
+  kubectl -n kube-system cp $TMP_LOCAL "$POD":"$CONFIG_FILEPATH"
+  kubectl -n kube-system exec "$POD" -- chmod go-w "$CONFIG_FILEPATH"
+  kubectl -n kube-system exec "$POD" -- chown root:root "$CONFIG_FILEPATH"
   rm $TMP_LOCAL
 done


### PR DESCRIPTION
Resolves https://github.com/elastic/cloudbeat/issues/242

This PR changes the way the `remote_edit_config.sh` works.
In order to find the configuration file path:
Instead of assuming the architecture and the version being run remote, we iteratively find the next folder name by its expected prefix.