### PR TITLE
Bug fix - init kube watchers upon reconfiguration

### DIFF
--- a/resources/fetchers/kube_factory.go
+++ b/resources/fetchers/kube_factory.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	k8s "k8s.io/client-go/kubernetes"
+	"sync"
 )
 
 type KubeFactory struct {
@@ -51,6 +52,7 @@ func (f *KubeFactory) CreateFrom(log *logp.Logger, cfg KubeApiFetcherConfig, ch 
 		log:            log,
 		cfg:            cfg,
 		clientProvider: provider,
+		watcherLock:    &sync.Once{},
 		watchers:       make([]kubernetes.Watcher, 0),
 		resourceCh:     ch,
 	}

--- a/resources/fetchers/kube_fetcher_test.go
+++ b/resources/fetchers/kube_fetcher_test.go
@@ -33,7 +33,6 @@ import (
 	k8s "k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"reflect"
-	"sync"
 	"testing"
 )
 
@@ -72,7 +71,6 @@ func MockProvider(client *k8sfake.Clientset) KubeClientProvider {
 func clean(fetcher fetching.Fetcher) func() {
 	return func() {
 		fetcher.Stop()
-		watcherlock = sync.Once{}
 	}
 }
 


### PR DESCRIPTION
The launcher interface is responsible for receiving config updates from Fleet.
When we get a new config, the launcher is stopping the existing cloudbeat and creates a new one with the new config.
The kube-fetcher is being re-created as part of this process, yet, the k8s watchers are not initiated because the sync object is global.
This PR solves this issue by creating a new sync object every time we re-create the kube-fetcher.