### PR TITLE
fix: connect kind cluster to elastic-package network

### DIFF
--- a/JUSTFILE
+++ b/JUSTFILE
@@ -5,8 +5,6 @@ kustomizeEksOverlay := "deploy/kustomize/overlays/cloudbeat-eks"
 
 create-kind-cluster:
   kind create cluster --config deploy/k8s/kind/kind-config.yml --wait 30s
-  ID=$( docker ps --filter name=kind-mono-control-plane --format "{{{{.ID}}" ) && \
-  docker network connect elastic-package-stack_default $ID
 
 install-kind:
   brew install kind
@@ -63,6 +61,10 @@ elastic-stack-up:
 
 elastic-stack-down:
   elastic-package stack down
+
+elastic-stack-connect-kind:
+  ID=$( docker ps --filter name=kind-mono-control-plane --format "{{{{.ID}}" ) && \
+  docker network connect elastic-package-stack_default $ID
 
 ssh-cloudbeat:
     CLOUDBEAT_POD=$( kubectl get pods --no-headers -o custom-columns=":metadata.name" -n kube-system | grep "cloudbeat" ) && \


### PR DESCRIPTION
Separate `create-kind-cluster` to `elastic-stack-connect-kind`.
This fix the dependency `cleanup-create-local-helm-cluster` has on `create-kind-cluster` but it should not be connected to the stack network.

Thanks @yashtewari 