### PR TITLE
Receive beat configuration from Fleet

### DIFF
--- a/beater/validator.go
+++ b/beater/validator.go
@@ -35,12 +35,8 @@ func (v *validator) Validate(cfg *agentconfig.C) error {
 	if err != nil {
 		return fmt.Errorf("Could not parse reconfiguration %v, skipping with error: %v", cfg.FlattenedKeys(), err)
 	}
-
-	if len(c.Streams) == 0 {
-		return fmt.Errorf("No streams received in reconfiguration %v", cfg.FlattenedKeys())
-	}
-
-	if c.Streams[0].RuntimeCfg == nil {
+	
+	if c.RuntimeCfg == nil {
 		return fmt.Errorf("RuntimeCfg is not present in reconfiguration %v", cfg.FlattenedKeys())
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -72,17 +72,18 @@ type Benchmarks struct {
 	CisEks []string `config:"cis_eks,omitempty" yaml:"cis_eks,omitempty" json:"cis_eks,omitempty"`
 }
 
+var DefaultConfig = AgentInput{
+	Streams: []Stream{{
+		Period: 4 * time.Hour,
+	}},
+}
+
 func New(cfg *config.C) (Config, error) {
-	c := AgentInput{
-		Streams: []Stream{{
-			Period: 4 * time.Hour,
-		}},
-	}
+	c := DefaultConfig
 
 	if err := cfg.Unpack(&c); err != nil {
 		return Config{}, err
 	}
-
 	if c.Streams == nil || len(c.Streams) == 0 {
 		return Config{}, fmt.Errorf("could not find streams config")
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -23,14 +23,12 @@ package config
 import (
 	"context"
 	"fmt"
+	"github.com/elastic/beats/v7/libbeat/processors"
 	"time"
 
-	"github.com/elastic/beats/v7/libbeat/processors"
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/logp"
-
-	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 )
 
 const DefaultNamespace = "default"
@@ -46,23 +44,23 @@ type Fetcher struct {
 	Name string `config:"name"` // Name of the fetcher
 }
 
-type Fetchers struct {
-	Vanilla []*config.C `config:"vanilla"` // Vanilla fetchers
-	Eks     []*config.C `config:"eks"`     // EKS fetchers
-}
-
-type Config struct {
-	Fetchers   Fetchers                `config:"fetchers"`
-	KubeConfig string                  `config:"kube_config"`
-	Period     time.Duration           `config:"period"`
-	Processors processors.PluginConfig `config:"processors"`
-	Streams    []Stream                `config:"streams"`
-	Type       string                  `config:"type"`
+type AgentInput struct {
+	Streams []Stream `config:"streams"`
+	Type    string   `config:"type"`
 }
 
 type Stream struct {
-	AWSConfig  aws.ConfigAWS  `config:",inline"`
-	RuntimeCfg *RuntimeConfig `config:"runtime_cfg"`
+	AWSConfig  aws.ConfigAWS           `config:",inline"`
+	RuntimeCfg *RuntimeConfig          `config:"runtime_cfg"`
+	Fetchers   []*config.C             `config:"fetchers"`
+	KubeConfig string                  `config:"kube_config"`
+	Period     time.Duration           `config:"period"`
+	Processors processors.PluginConfig `config:"processors"`
+}
+
+type Config struct {
+	Stream
+	Type string `config:"type"`
 }
 
 type RuntimeConfig struct {
@@ -74,53 +72,25 @@ type Benchmarks struct {
 	CisEks []string `config:"cis_eks,omitempty" yaml:"cis_eks,omitempty" json:"cis_eks,omitempty"`
 }
 
-var DefaultConfig = Config{
-	Period: 4 * time.Hour,
-}
-
 func New(cfg *config.C) (Config, error) {
-	c := DefaultConfig
+	c := AgentInput{
+		Streams: []Stream{{
+			Period: 4 * time.Hour,
+		}},
+	}
 
 	if err := cfg.Unpack(&c); err != nil {
-		return c, err
+		return Config{}, err
 	}
 
-	return c, nil
-}
-
-// Update replaces values of those keys in the current config which are
-// present in the incoming config.
-//
-// NOTE(yashtewari): This will be removed with the planned update to restart the
-// beat with the new config.
-func (c *Config) Update(log *logp.Logger, cfg *config.C) error {
-	log.Infof("Updating config with the following keys: %v", cfg.FlattenedKeys())
-
-	if err := cfg.Unpack(&c); err != nil {
-		return err
+	if c.Streams == nil || len(c.Streams) == 0 {
+		return Config{}, fmt.Errorf("could not find streams config")
 	}
 
-	// Check if the incoming config has streams.
-	if cfg.HasField("streams") {
-		uc, err := New(cfg)
-		if err != nil {
-			return err
-		}
-
-		c.Streams = uc.Streams
-	}
-
-	return nil
-}
-
-// GetActivatedRules returns the activated rules from the config.
-func (c *Config) GetActivatedRules() (*Benchmarks, error) {
-	cfgStream := c.Streams
-	if len(cfgStream) == 0 || cfgStream[0].RuntimeCfg == nil {
-		return nil, fmt.Errorf("could not find runtime cfg")
-	}
-
-	return cfgStream[0].RuntimeCfg.ActivatedRules, nil
+	return Config{
+		Stream: c.Streams[0],
+		Type:   c.Type,
+	}, nil
 }
 
 // Datastream function to generate the datastream value

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -86,10 +86,10 @@ func (s *ConfigTestSuite) TestNew() {
 		s.NoError(err)
 
 		s.Equal(test.expectedType, c.Type)
-		s.Equal(test.expectedActivatedRules, c.Streams[0].RuntimeCfg.ActivatedRules.CisK8s)
-		s.Equal(test.expectedAccessKey, c.Streams[0].AWSConfig.AccessKeyID)
-		s.Equal(test.expectedSecret, c.Streams[0].AWSConfig.SecretAccessKey)
-		s.Equal(test.expectedSessionToken, c.Streams[0].AWSConfig.SessionToken)
+		s.Equal(test.expectedActivatedRules, c.RuntimeCfg.ActivatedRules.CisK8s)
+		s.Equal(test.expectedAccessKey, c.AWSConfig.AccessKeyID)
+		s.Equal(test.expectedSecret, c.AWSConfig.SecretAccessKey)
+		s.Equal(test.expectedSessionToken, c.AWSConfig.SessionToken)
 	}
 }
 
@@ -129,238 +129,7 @@ func (s *ConfigTestSuite) TestRuntimeCfgExists() {
 		c, err := New(cfg)
 		s.NoError(err)
 
-		s.Equal(test.expected, c.Streams[0].RuntimeCfg != nil)
-	}
-}
-
-func (s *ConfigTestSuite) TestConfigUpdate() {
-	configYml := `
-    streams:
-      - runtime_cfg:
-          activated_rules:
-            cis_k8s:
-              - a
-              - b
-              - c
-              - d
-              - e
-        access_key_id: old_key
-        secret_access_key: old_secret
-        session_token: old_session`
-
-	var tests = []struct {
-		update                 string
-		expectedActivatedRules []string
-		expectedAccessKey      string
-		expectedSecret         string
-		expectedSessionToken   string
-	}{
-		{
-			`
-          streams:
-            - runtime_cfg:
-                activated_rules:
-                  cis_k8s:
-                    - a	
-                    - b
-                    - c
-                    - d
-              access_key_id: new_key
-              secret_access_key: new_secret
-              session_token: new_session
-        `,
-			[]string{"a", "b", "c", "d"},
-			"new_key",
-			"new_secret",
-			"new_session",
-		},
-		{
-			`
-          streams:
-            - runtime_cfg:
-                activated_rules:
-                  cis_k8s:
-                    - b	
-                    - c
-                    - d
-                    - e
-                    - f
-              access_key_id: new_key1
-              secret_access_key: new_secret1
-              session_token: new_session1
-        `,
-			[]string{"b", "c", "d", "e", "f"},
-			"new_key1",
-			"new_secret1",
-			"new_session1",
-		},
-		{
-			`
-          streams:
-            - runtime_cfg:
-                activated_rules:
-                  cis_k8s: []
-              access_key_id: 
-              secret_access_key:
-              session_token:
-        `,
-			[]string{},
-			"",
-			"",
-			"",
-		},
-		//We're not currently aware of a scenario where we receive
-		//multiple input streams, but still to make sure that it doesn't
-		//break for this scenario.
-		{
-			`
-          streams:
-            - runtime_cfg:
-                activated_rules:
-                  cis_k8s:
-                    - x	
-                    -  "y" # Just YAML 1.1 things
-                    - z
-              access_key_id: first_stream_key
-              secret_access_key: first_stream_secret
-              session_token: first_stream_session  
-            - runtime_cfg:
-                activated_rules:
-                  cis_k8s:
-                    - f	
-                    - g
-                    - h
-                    - i
-                    - j
-              access_key_id: second_stream_key
-              secret_access_key: second_stream_secret
-              session_token: second_stream_session
-        `,
-			[]string{"x", "y", "z"},
-			"first_stream_key",
-			"first_stream_secret",
-			"first_stream_session",
-		},
-	}
-
-	cfg, err := config.NewConfigFrom(configYml)
-	s.NoError(err)
-
-	c, err := New(cfg)
-	s.NoError(err)
-
-	for _, test := range tests {
-		cfg, err := config.NewConfigFrom(test.update)
-		s.NoError(err)
-
-		err = c.Update(s.log, cfg)
-		s.NoError(err)
-
-		s.Equal(test.expectedActivatedRules, c.Streams[0].RuntimeCfg.ActivatedRules.CisK8s)
-		s.Equal(test.expectedAccessKey, c.Streams[0].AWSConfig.AccessKeyID)
-		s.Equal(test.expectedSecret, c.Streams[0].AWSConfig.SecretAccessKey)
-		s.Equal(test.expectedSessionToken, c.Streams[0].AWSConfig.SessionToken)
-	}
-}
-
-// TestConfigUpdateIsolated tests whether updates made to a config from
-// are isolated; only those parts of the config specified in the incoming
-// config should get updated.
-func (s *ConfigTestSuite) TestConfigUpdateIsolated() {
-	configYml := `
-    period: 10s
-    kube_config: some_path
-    streams:
-      - runtime_cfg:
-          activated_rules:
-            cis_k8s:
-              - a
-              - b
-              - c
-              - d
-              - e
-        access_key_id: old_key
-        secret_access_key: old_secret
-        session_token: old_session`
-
-	var tests = []struct {
-		update               string
-		expectedPeriod       time.Duration
-		expectedKubeConfig   string
-		expectedCISK8S       []string
-		expectedAccessKey    string
-		expectedSecret       string
-		expectedSessionToken string
-	}{
-		{
-			update: `
-           streams:
-             - runtime_cfg:
-                 activated_rules:
-                   cis_k8s:
-                     - a
-                     - b
-                     - c
-                     - d
-               access_key_id: new_key
-               secret_access_key: new_secret
-               session_token: new_session`,
-			expectedPeriod:       10 * time.Second,
-			expectedKubeConfig:   "some_path",
-			expectedCISK8S:       []string{"a", "b", "c", "d"},
-			expectedAccessKey:    "new_key",
-			expectedSecret:       "new_secret",
-			expectedSessionToken: "new_session",
-		},
-		{
-			update:               `period: 4h`,
-			expectedPeriod:       4 * time.Hour,
-			expectedKubeConfig:   "some_path",
-			expectedCISK8S:       []string{"a", "b", "c", "d"},
-			expectedAccessKey:    "new_key",
-			expectedSecret:       "new_secret",
-			expectedSessionToken: "new_session",
-		},
-		{
-			update: `
-           kube_config: some_other_path
-           streams:
-             - runtime_cfg:
-                 activated_rules:
-                   cis_k8s:
-                     - a
-                     - b
-                     - c
-                     - d
-                     - e`,
-			expectedPeriod:       4 * time.Hour,
-			expectedKubeConfig:   "some_other_path",
-			expectedCISK8S:       []string{"a", "b", "c", "d", "e"},
-			expectedAccessKey:    "",
-			expectedSecret:       "",
-			expectedSessionToken: "",
-		},
-	}
-
-	cfg, err := config.NewConfigFrom(configYml)
-	s.NoError(err)
-
-	c, err := New(cfg)
-	s.NoError(err)
-
-	for _, test := range tests {
-		cfg, err := config.NewConfigFrom(test.update)
-		s.NoError(err)
-
-		err = c.Update(s.log, cfg)
-		s.NoError(err)
-
-		s.Equal(test.expectedPeriod, c.Period)
-		s.Equal(test.expectedKubeConfig, c.KubeConfig)
-		s.Equal(test.expectedCISK8S, c.Streams[0].RuntimeCfg.ActivatedRules.CisK8s)
-		s.Equal(test.expectedAccessKey, c.Streams[0].AWSConfig.AccessKeyID)
-		s.Equal(test.expectedSecret, c.Streams[0].AWSConfig.SecretAccessKey)
-		s.Equal(test.expectedSessionToken, c.Streams[0].AWSConfig.SessionToken)
+		s.Equal(test.expected, c.RuntimeCfg != nil)
 	}
 }
 
@@ -389,10 +158,9 @@ func (s *ConfigTestSuite) TestRuntimeConfig() {
 		c, err := New(cfg)
 		s.NoError(err)
 
-		dy, err := c.GetActivatedRules()
-		s.NoError(err)
+		rules := c.RuntimeCfg.ActivatedRules
 
-		s.Equal(test.expected, dy.CisK8s)
+		s.Equal(test.expected, rules.CisK8s)
 	}
 }
 
@@ -402,9 +170,21 @@ func (s *ConfigTestSuite) TestConfigPeriod() {
 		expectedPeriod time.Duration
 	}{
 		{"", 4 * time.Hour},
-		{"period: 50s", 50 * time.Second},
-		{"period: 5m", 5 * time.Minute},
-		{"period: 2h", 2 * time.Hour},
+		{
+			`
+   streams:
+    - period: 50s
+`, 50 * time.Second},
+		{
+			`
+   streams:
+    - period: 5m
+`, 5 * time.Minute},
+		{
+			`
+   streams:
+    - period: 2h
+`, 2 * time.Hour},
 	}
 
 	for _, test := range tests {
@@ -463,7 +243,7 @@ streams:
 		s.NoError(err)
 
 		s.Equal(test.expectedType, c.Type)
-		s.Equal(test.expectedActivatedRules, c.Streams[0].RuntimeCfg.ActivatedRules.CisK8s)
-		s.Equal(test.expectedEksActivatedRules, c.Streams[0].RuntimeCfg.ActivatedRules.CisEks)
+		s.Equal(test.expectedActivatedRules, c.RuntimeCfg.ActivatedRules.CisK8s)
+		s.Equal(test.expectedEksActivatedRules, c.RuntimeCfg.ActivatedRules.CisEks)
 	}
 }

--- a/deploy/kustomize/overlays/cloudbeat-eks/config-map.yml
+++ b/deploy/kustomize/overlays/cloudbeat-eks/config-map.yml
@@ -19,28 +19,15 @@ data:
             - name: process
               directory: "/hostfs"
               processes:
-                etcd:
-                kube-apiserver:
-                kube-controller:
-                kube-scheduler:
                 kubelet:
                   config-file-arguments:
                     - config
+            - name: aws-ecr
+            - name: aws-elb
             - name: file-system
               patterns: [
-                "/hostfs/etc/kubernetes/scheduler.conf",
-                "/hostfs/etc/kubernetes/controller-manager.conf",
-                "/hostfs/etc/kubernetes/admin.conf",
-                "/hostfs/etc/kubernetes/kubelet.conf",
-                "/hostfs/etc/kubernetes/manifests/etcd.yaml",
-                "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
-                "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
-                "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
-                "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-                "/hostfs/etc/kubernetes/pki/*",
-                "/hostfs/var/lib/kubelet/config.yaml",
-                "/hostfs/var/lib/etcd",
-                "/hostfs/etc/kubernetes/pki"
+                "/hostfs/etc/kubernetes/kubelet/kubelet-config.json",
+                "/hostfs/var/lib/kubelet/kubeconfig",
               ]
     # =================================== Kibana ===================================
     setup.kibana:

--- a/deploy/kustomize/overlays/cloudbeat-eks/kustomization.yml
+++ b/deploy/kustomize/overlays/cloudbeat-eks/kustomization.yml
@@ -14,3 +14,4 @@ secretGenerator:
 
 patchesStrategicMerge:
   - daemonset.yml
+  - config-map.yml

--- a/evaluator/bundle_test.go
+++ b/evaluator/bundle_test.go
@@ -47,7 +47,12 @@ func TestBundleTestSuite(t *testing.T) {
 }
 
 func (s *BundleTestSuite) TestCreateServer() {
-	_, err := StartServer(context.Background(), config.DefaultConfig)
+	_, err := StartServer(context.Background(), config.Config{
+		Stream: config.Stream{
+			Period: 4 * time.Hour,
+		},
+		Type: config.InputTypeVanillaK8s,
+	})
 	s.NoError(err)
 
 	var tests = []struct {
@@ -132,13 +137,11 @@ func (s *BundleTestSuite) TestCreateServerWithRuntimeConfig() {
 			"valid config struct", "/bundles/bundle.tar.gz", "200 OK",
 			config.Config{
 				Type: config.InputTypeVanillaK8s,
-				Streams: []config.Stream{
-					{
-						RuntimeCfg: &config.RuntimeConfig{
-							ActivatedRules: &config.Benchmarks{
-								CisK8s: []string{
-									"cis_1_1_1",
-								},
+				Stream: config.Stream{
+					RuntimeCfg: &config.RuntimeConfig{
+						ActivatedRules: &config.Benchmarks{
+							CisK8s: []string{
+								"cis_1_1_1",
 							},
 						},
 					},
@@ -149,13 +152,11 @@ func (s *BundleTestSuite) TestCreateServerWithRuntimeConfig() {
 			"valid config struct", "/bundles/bundle.tar.gz", "200 OK",
 			config.Config{
 				Type: config.InputTypeEks,
-				Streams: []config.Stream{
-					{
-						RuntimeCfg: &config.RuntimeConfig{
-							ActivatedRules: &config.Benchmarks{
-								CisEks: []string{
-									"cis_1_1_1",
-								},
+				Stream: config.Stream{
+					RuntimeCfg: &config.RuntimeConfig{
+						ActivatedRules: &config.Benchmarks{
+							CisEks: []string{
+								"cis_1_1_1",
 							},
 						},
 					},
@@ -225,13 +226,12 @@ func (s *BundleTestSuite) TestCreateServerWithFetchersConfig() {
 			"valid config struct", "/bundles/bundle.tar.gz", "200 OK",
 			config.Config{
 				Type: config.InputTypeVanillaK8s,
-				Streams: []config.Stream{
-					{
-						RuntimeCfg: &config.RuntimeConfig{
-							ActivatedRules: &config.Benchmarks{
-								CisK8s: []string{
-									"cis_1_1_1",
-								},
+				Stream: config.Stream{
+
+					RuntimeCfg: &config.RuntimeConfig{
+						ActivatedRules: &config.Benchmarks{
+							CisK8s: []string{
+								"cis_1_1_1",
 							},
 						},
 					},
@@ -242,13 +242,11 @@ func (s *BundleTestSuite) TestCreateServerWithFetchersConfig() {
 			"valid config struct", "/bundles/bundle.tar.gz", "200 OK",
 			config.Config{
 				Type: config.InputTypeEks,
-				Streams: []config.Stream{
-					{
-						RuntimeCfg: &config.RuntimeConfig{
-							ActivatedRules: &config.Benchmarks{
-								CisEks: []string{
-									"cis_1_1_1",
-								},
+				Stream: config.Stream{
+					RuntimeCfg: &config.RuntimeConfig{
+						ActivatedRules: &config.Benchmarks{
+							CisEks: []string{
+								"cis_1_1_1",
 							},
 						},
 					},

--- a/resources/fetchersManager/factory.go
+++ b/resources/fetchersManager/factory.go
@@ -62,8 +62,7 @@ func (fa *factories) CreateFetcher(log *logp.Logger, name string, c *agentconfig
 func (fa *factories) ParseConfigFetchers(log *logp.Logger, cfg config.Config, ch chan fetching.ResourceInfo) ([]*ParsedFetcher, error) {
 	var arr []*ParsedFetcher
 
-	fetchers := fa.loadFetchers(cfg)
-	for _, fcfg := range fetchers {
+	for _, fcfg := range cfg.Fetchers {
 		addCredentialsToFetcherConfiguration(log, cfg, fcfg)
 		p, err := fa.parseConfigFetcher(log, fcfg, ch)
 		if err != nil {
@@ -74,16 +73,6 @@ func (fa *factories) ParseConfigFetchers(log *logp.Logger, cfg config.Config, ch
 	}
 
 	return arr, nil
-}
-
-func (fa *factories) loadFetchers(cfg config.Config) []*agentconfig.C {
-	var fetchers []*agentconfig.C
-	if cfg.Type == config.InputTypeEks {
-		fetchers = cfg.Fetchers.Eks
-	} else {
-		fetchers = cfg.Fetchers.Vanilla
-	}
-	return fetchers
 }
 
 func (fa *factories) parseConfigFetcher(log *logp.Logger, fcfg *agentconfig.C, ch chan fetching.ResourceInfo) (*ParsedFetcher, error) {
@@ -106,7 +95,7 @@ func (fa *factories) parseConfigFetcher(log *logp.Logger, fcfg *agentconfig.C, c
 // and depending on the input type, extract the relevant credentials and add them to the fetcher config
 func addCredentialsToFetcherConfiguration(log *logp.Logger, cfg config.Config, fcfg *agentconfig.C) {
 	if cfg.Type == config.InputTypeEks {
-		err := fcfg.Merge(cfg.Streams[0].AWSConfig)
+		err := fcfg.Merge(cfg.AWSConfig)
 		if err != nil {
 			log.Errorf("Failed to merge aws configuration to fetcher configuration", err)
 		}

--- a/resources/fetchersManager/factory_aws_test.go
+++ b/resources/fetchersManager/factory_aws_test.go
@@ -167,16 +167,17 @@ func (s *FactoriesTestSuite) TestRegisterFetchersWithAwsCredentials() {
 }
 
 func createEksAgentConfig(s *FactoriesTestSuite, awsConfig aws.ConfigAWS, fetcherName string) config.Config {
-	conf := config.DefaultConfig
+	conf := config.Config{}
 	conf.Type = config.InputTypeEks
 	fetcherConfig := agentconfig.NewConfig()
 	err := fetcherConfig.SetString("name", -1, fetcherName)
 	s.NoError(err)
-	conf.Fetchers.Eks = append(conf.Fetchers.Eks, fetcherConfig)
-	stream := config.Stream{
+
+	conf.Stream = config.Stream{
 		AWSConfig:  awsConfig,
 		RuntimeCfg: nil,
+		Fetchers:   []*agentconfig.C{fetcherConfig},
 	}
-	conf.Streams = append(conf.Streams, stream)
+
 	return conf
 }


### PR DESCRIPTION
This PR introduces support for receiving beat configuration from Fleet.
The `cloudbeat.yml` config file is still supported when deployed as a standalone.

### HOW TO TEST:
Build an integration from the following branch:
- https://github.com/elastic/integrations/pull/4145