### PR TITLE
feat: deploy agent on kind cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tests/allure/reports/*
 bundle.tar.gz
 /deploy/eks/cloudbeat-ds.yaml
 /deploy/k8s/cloudbeat-ds.yaml
+/deploy/kustomize/overlays/cloudbeat-vanilla-agent/ca-cert.pem

--- a/deploy/kustomize/overlays/cloudbeat-vanilla-agent/.fleet-token.env
+++ b/deploy/kustomize/overlays/cloudbeat-vanilla-agent/.fleet-token.env
@@ -1,0 +1,2 @@
+# kustomize will read it and populate into the final manifests
+FLEET_ENROLLMENT_TOKEN

--- a/deploy/kustomize/overlays/cloudbeat-vanilla-agent/README.md
+++ b/deploy/kustomize/overlays/cloudbeat-vanilla-agent/README.md
@@ -1,0 +1,65 @@
+# Kustomize Vanilla Agent
+
+This manifests are used to deploy the agent on local kind cluster with dev image of the agent.
+So that later we can inject into that agent a custom binray of cloudbeat and run E2E flow.
+
+## How to use it
+
+### Build the Agent
+Note: this step might take a while
+**From cloudbeat repo**
+```bash
+make PackageAgent
+```
+
+### Setup ERP
+
+**From cloudbeat repo**
+#### Step 1
+Start your local ERP stack
+```bash
+elastic-package stack up -vd --version=8.5.0-SNAPSHOT
+just create-kind-cluster
+just elastic-stack-connect-kind
+kind load docker-image elastic-agent:8.5.0-SNAPSHOT --name kind-mono
+```
+
+#### Step 2 - Get the entrollment token
+To find the envorllment token, `app/fleet/enrollment-tokens` copy the token of the `Elastic-Agent (elastic-package)`
+Run `export FLEET_ENROLLMENT_TOKEN=$TOKEN`
+
+#### Step 3 - Take care of SSL
+The SSL certificate was created by `elastic-package` and stored in `ELASTIC_PACKAGE_CA_CERT`.
+Run 
+```bash
+eval "$(elastic-package stack shellinit)"
+cp $ELASTIC_PACKAGE_CA_CERT deploy/kustomize/overlays/cloudbeat-vanilla-agent
+```
+#### Step 4 - Complete ERP setup
+```bash
+kubectl apply -k deploy/kustomize/overlays/cloudbeat-vanilla-agent
+```
+
+#### Step 4 - Verify
+Go to `app/fleet/agents` and check that the new agent (`kind-mono-control-plane`) is healthy
+
+### Load custom cloudbeat binary
+
+**From cloudbeat repo**
+
+To use custom binray of cloudbeat you need
+1. Build binray + checksum
+2. Copy the files to agent pod
+3. Restart the cloudbeat process in the pod
+
+#### Step 1 - build cloudbeat
+```bash
+DEV=true PLATFORMS=linux/arm64 SNAPSHOT=true mage -v package
+```
+
+#### Step 2 - Copy and restart
+To copy all the assets and restart https://github.com/elastic/cloudbeat/blob/edfb7cad16eb7477a853f97c9a3d3cb906f5f6fb/scripts/remote_replace_cloudbeat.sh `scripts/remote_replace_cloudbeat.sh`
+```bash
+cd scripts
+./remote_replace_cloudbeat.sh
+```

--- a/deploy/kustomize/overlays/cloudbeat-vanilla-agent/kustomization.yml
+++ b/deploy/kustomize/overlays/cloudbeat-vanilla-agent/kustomization.yml
@@ -1,0 +1,27 @@
+# $COMMUNITY/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+
+resources:
+  - manifests.yaml 
+
+patches:
+  - path: ./patches/patchs.yaml
+    target:
+      kind: DaemonSet
+
+secretGenerator:
+  - behavior: create
+    name: elastic-package-certs
+    files:
+      - ./ca-cert.pem
+  - behavior: create
+    name: fleet
+    envs:
+      - .fleet-token.env
+
+images:
+  - name: docker.elastic.co/beats/elastic-agent:8.5.0-SNAPSHOT
+    newName: elastic-agent
+    newTag: 8.5.0-SNAPSHOT

--- a/deploy/kustomize/overlays/cloudbeat-vanilla-agent/manifests.yaml
+++ b/deploy/kustomize/overlays/cloudbeat-vanilla-agent/manifests.yaml
@@ -1,0 +1,293 @@
+---
+# For more information refer to https://www.elastic.co/guide/en/fleet/current/running-on-kubernetes-managed-by-fleet.html
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: elastic-agent
+  namespace: kube-system
+  labels:
+    app: elastic-agent
+spec:
+  selector:
+    matchLabels:
+      app: elastic-agent
+  template:
+    metadata:
+      labels:
+        app: elastic-agent
+    spec:
+      # Tolerations are needed to run Elastic Agent on Kubernetes control-plane nodes.
+      # Agents running on control-plane nodes collect metrics from the control plane components (scheduler, controller manager) of Kubernetes
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      serviceAccountName: elastic-agent
+      hostNetwork: true
+      # 'hostPID: true' enables the Elastic Security integration to observe all process exec events on the host.
+      # Sharing the host process ID namespace gives visibility of all processes running on the same host.
+      hostPID: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: elastic-agent
+          image: docker.elastic.co/beats/elastic-agent:8.5.0-SNAPSHOT
+          env:
+            # Set to 1 for enrollment into Fleet server. If not set, Elastic Agent is run in standalone mode
+            - name: FLEET_ENROLL
+              value: "1"
+            # Set to true to communicate with Fleet with either insecure HTTP or unverified HTTPS
+            - name: FLEET_INSECURE
+              value: "true"
+            # Fleet Server URL to enroll the Elastic Agent into
+            # FLEET_URL can be found in Kibana, go to Management > Fleet > Settings
+            - name: FLEET_URL
+              value: "https://fleet-server:8220"
+            # Elasticsearch API key used to enroll Elastic Agents in Fleet (https://www.elastic.co/guide/en/fleet/current/fleet-enrollment-tokens.html#fleet-enrollment-tokens)
+            # If FLEET_ENROLLMENT_TOKEN is empty then KIBANA_HOST, KIBANA_FLEET_USERNAME, KIBANA_FLEET_PASSWORD are needed
+            - name: FLEET_ENROLLMENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: fleet
+                  key: FLEET_ENROLLMENT_TOKEN
+              # value: "S"
+            - name: KIBANA_HOST
+              value: "http://kibana:5601"
+            # The basic authentication username used to connect to Kibana and retrieve a service_token to enable Fleet
+            - name: KIBANA_FLEET_USERNAME
+              value: "elastic"
+            # The basic authentication password used to connect to Kibana and retrieve a service_token to enable Fleet
+            - name: KIBANA_FLEET_PASSWORD
+              value: "changeme"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          securityContext:
+            runAsUser: 0
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: proc
+              mountPath: /hostfs/proc
+              readOnly: true
+            - name: cgroup
+              mountPath: /hostfs/sys/fs/cgroup
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: etc-kubernetes
+              mountPath: /hostfs/etc/kubernetes
+              readOnly: true
+            - name: var-lib
+              mountPath: /hostfs/var/lib
+              readOnly: true
+            - name: passwd
+              mountPath: /hostfs/etc/passwd
+              readOnly: true
+            - name: group
+              mountPath: /hostfs/etc/group
+              readOnly: true
+            - name: etcsysmd
+              mountPath: /hostfs/etc/systemd
+              readOnly: true
+            - name: etc-mid
+              mountPath: /etc/machine-id
+              readOnly: true
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: varlog
+          hostPath:
+            path: /var/log
+        # Needed for cloudbeat
+        - name: etc-kubernetes
+          hostPath:
+            path: /etc/kubernetes
+        # Needed for cloudbeat
+        - name: var-lib
+          hostPath:
+            path: /var/lib
+        # Needed for cloudbeat
+        - name: passwd
+          hostPath:
+            path: /etc/passwd
+        # Needed for cloudbeat
+        - name: group
+          hostPath:
+            path: /etc/group
+        # Needed for cloudbeat
+        - name: etcsysmd
+          hostPath:
+            path: /etc/systemd
+        # Mount /etc/machine-id from the host to determine host ID
+        # Needed for Elastic Security integration
+        - name: etc-mid
+          hostPath:
+            path: /etc/machine-id
+            type: File
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: elastic-agent
+subjects:
+  - kind: ServiceAccount
+    name: elastic-agent
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: elastic-agent
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-system
+  name: elastic-agent
+subjects:
+  - kind: ServiceAccount
+    name: elastic-agent
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: elastic-agent
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: elastic-agent-kubeadm-config
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: elastic-agent
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: elastic-agent-kubeadm-config
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: elastic-agent
+  labels:
+    k8s-app: elastic-agent
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - events
+      - pods
+      - services
+      - configmaps
+      # Needed for cloudbeat
+      - serviceaccounts
+      - persistentvolumes
+      - persistentvolumeclaims
+    verbs: ["get", "list", "watch"]
+  # Enable this rule only if planing to use kubernetes_secrets provider
+  #- apiGroups: [""]
+  #  resources:
+  #  - secrets
+  #  verbs: ["get"]
+  - apiGroups: ["extensions"]
+    resources:
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - statefulsets
+      - deployments
+      - replicasets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/stats
+    verbs:
+      - get
+  - apiGroups: [ "batch" ]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: [ "get", "list", "watch" ]
+  # Needed for apiserver
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get
+  # Needed for cloudbeat
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs: ["get", "list", "watch"]
+  # Needed for cloudbeat
+  - apiGroups: ["policy"]
+    resources:
+      - podsecuritypolicies
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: elastic-agent
+  # Should be the namespace where elastic-agent is running
+  namespace: kube-system
+  labels:
+    k8s-app: elastic-agent
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs: ["get", "create", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: elastic-agent-kubeadm-config
+  namespace: kube-system
+  labels:
+    k8s-app: elastic-agent
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    resourceNames:
+      - kubeadm-config
+    verbs: ["get"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elastic-agent
+  namespace: kube-system
+  labels:
+    k8s-app: elastic-agent
+---

--- a/deploy/kustomize/overlays/cloudbeat-vanilla-agent/patches/patchs.yaml
+++ b/deploy/kustomize/overlays/cloudbeat-vanilla-agent/patches/patchs.yaml
@@ -1,0 +1,17 @@
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: SSL_CERT_DIR
+    value: /etc/ssl/elastic-package
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: elastic-package-certs
+    secret:
+      defaultMode: 420
+      secretName: elastic-package-certs
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    name: elastic-package-certs
+    mountPath: /etc/ssl/elastic-package


### PR DESCRIPTION
# Motivation
It is hard to run development flow that requires the Agent deployment that runs custom Cloudbeat binary 

# Proposal
Add manifests and Kustomize files to setup the Agent in Kind cluster.
This is required when the agent is needed to be part of the dev flow 
The instructions are in the [README.md](https://github.com/olegsu/cloudbeat/blob/93f8cb797239c02556e1c690944aaed4a112a26c/deploy/kustomize/overlays/cloudbeat-vanilla-agent/README.md)

# DOD
- [ ] Add to [Onboarding](https://github.com/elastic/security-team/tree/main/docs/cloud-security-posture-team/Onboarding)
- [ ] Use prebuilt image of the Agent to reduce time