### PR TITLE
fix depedency scanner on push event

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - 'depedency-review-fix'
 
 env:
   K8S_MANIFEST_DIR: deploy

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - 'depedency-review-fix'
 
 env:
   K8S_MANIFEST_DIR: deploy
@@ -94,7 +93,7 @@ jobs:
 
   dependency-review:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -93,8 +93,10 @@ jobs:
 
   dependency-review:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
+
       - name: Dependency Review
         uses: actions/dependency-review-action@v2


### PR DESCRIPTION
Limits dependency reviews to pr only
https://github.com/elastic/cloudbeat/actions/runs/3050543387/jobs/4917744157