### PR TITLE
Unwrap errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,16 @@
+# https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml
+run:
+  timeout: 10m
+
+linters-settings:
+  govet:
+    settings:
+      printf:
+        funcs:
+          - Infof
+          - Debugf
+          - Warnf
+          - Errorf
+          - Fatalf
+          - Panicf
+          - DPanicf

--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -104,13 +104,13 @@ func (l *launcher) run() error {
 	l.log.Info("Beater launcher is running")
 	err := l.runBeater()
 	if err != nil {
-		l.log.Errorf("Could not run Beater: %w", err)
+		l.log.Errorf("Could not run Beater: %v", err)
 		return err
 	}
 
 	err = l.waitForUpdates()
 	if err != nil {
-		l.log.Errorf("Beater launcher is stopping: %w", err)
+		l.log.Errorf("Beater launcher is stopping: %v", err)
 	} else {
 		l.log.Info("Beater launcher was shutted down gracefully")
 	}
@@ -126,7 +126,7 @@ func (l *launcher) runBeater() error {
 	l.log.Info("Launcher is creating a new Beater")
 	beater, err := l.creator(l.beat, l.latest)
 	if err != nil {
-		return fmt.Errorf("Could not create beater: %w", err)
+		return fmt.Errorf("could not create beater: %w", err)
 	}
 
 	l.wg.Add(1)
@@ -164,7 +164,7 @@ func (l *launcher) waitForUpdates() error {
 
 		case err := <-l.beaterErr:
 			if err != nil {
-				return fmt.Errorf("Beater returned an error:  %w", err)
+				return fmt.Errorf("beater returned an error:  %w", err)
 			}
 
 		case update, ok := <-l.reloader.Channel():
@@ -223,7 +223,7 @@ func (l *launcher) reconfigureWait(timeout time.Duration) (*config.C, error) {
 			if l.validator != nil {
 				err := l.validator.Validate(update)
 				if err != nil {
-					l.log.Errorf("Config update validation failed: %w", err)
+					l.log.Errorf("Config update validation failed: %v", err)
 					continue
 				}
 			}

--- a/resources/fetchers/ecr_fetcher.go
+++ b/resources/fetchers/ecr_fetcher.go
@@ -20,8 +20,9 @@ package fetchers
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"regexp"
+
+	"github.com/pkg/errors"
 
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	v1 "k8s.io/api/core/v1"
@@ -72,7 +73,7 @@ func (f *EcrFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata
 
 	podsList, err := f.kubeClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
 	if err != nil {
-		logp.Error(fmt.Errorf("failed to get pods  - %w", err))
+		f.log.Errorf("failed to get pods - %v", err)
 		return err
 	}
 
@@ -97,7 +98,7 @@ func (f *EcrFetcher) describePodImagesRepositories(ctx context.Context, podsList
 		// Add configuration
 		describedRepo, err := describer.Provider.DescribeRepositories(ctx, f.awsConfig, repositories, region)
 		if err != nil {
-			f.log.Errorf("could not retrieve pod's aws repositories for region %s: %w", region, err)
+			f.log.Errorf("could not retrieve pod's aws repositories for region %s: %v", region, err)
 		} else {
 			awsRepositories = append(awsRepositories, describedRepo...)
 		}

--- a/resources/fetchers/process_fetcher.go
+++ b/resources/fetchers/process_fetcher.go
@@ -215,7 +215,7 @@ func (f *ProcessesFetcher) getProcessConfigurationFile(processConfig ProcessInpu
 		regex := fmt.Sprintf(CMDArgumentMatcher, argument)
 		matcher := regexp.MustCompile(regex)
 		if !matcher.MatchString(cmd) {
-			f.log.Infof("Couldn't find a configuration file associated with flag %s for process %s from cmd", argument, processName, cmd)
+			f.log.Infof("Couldn't find a configuration file associated with flag %s for process %s from cmd %s", argument, processName, cmd)
 			continue
 		}
 

--- a/resources/fetchersManager/factory.go
+++ b/resources/fetchersManager/factory.go
@@ -20,6 +20,7 @@ package fetchersManager
 import (
 	"errors"
 	"fmt"
+
 	"github.com/elastic/cloudbeat/config"
 	"github.com/elastic/cloudbeat/resources/fetching"
 	agentconfig "github.com/elastic/elastic-agent-libs/config"
@@ -97,7 +98,7 @@ func addCredentialsToFetcherConfiguration(log *logp.Logger, cfg config.Config, f
 	if cfg.Type == config.InputTypeEks {
 		err := fcfg.Merge(cfg.AWSConfig)
 		if err != nil {
-			log.Errorf("Failed to merge aws configuration to fetcher configuration", err)
+			log.Errorf("Failed to merge aws configuration to fetcher configuration: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Related to #388 

This PR includes also:
1. Update all the logger calls where the regular `go vet` would report
2. Update the CI script `golangci-lint` configuration to run custom `print.funcs`

### Why update vet with print.funcs?
Normally `go vet` runs on a lot of functions signatures (the full list `go tool vet help printf`), but not the one that in [logp](https://github.com/elastic/elastic-agent-libs/blob/main/logp/logger.go)
To overcome this `go vet` allow to add additional functions to check.
By setting `-printfuncs="Infof,Debugf,Warnf,Errorf,Fatalf,Panicf,DPanicf"` we can make sure that all the logger calls are covered

### Run locally
* Install [golangci-lint ](https://golangci-lint.run/usage/install/#macos)
* Run `golangci-lint run`

### Output
When having formatting issues, for example `l.log.Infof("Waiting for initial reconfiguration from Fleet server... %s")`
You would see
<img width="1228" alt="image" src="https://user-images.githubusercontent.com/23185631/191427437-57802010-a00f-44bd-8fd6-0f1acf7c5e21.png">


### Additional Reading
* [go vet cmd](https://pkg.go.dev/cmd/vet)
* [wrap-unwrap-errors](https://gosamples.dev/wrap-unwrap-errors/)
* [golang ci - go vet](https://golangci-lint.run/usage/linters/#govet)

