### PR TITLE
Mend CI with resource identifiers, increased timeout.

### DIFF
--- a/.github/workflows/cloudbeat-ci.yml
+++ b/.github/workflows/cloudbeat-ci.yml
@@ -115,15 +115,35 @@ jobs:
         include:
           - test-target: pre_merge
           - test-target: file_system_rules
-            range: '0..15'
+            range: '0..5'
           - test-target: file_system_rules
-            range: '15..30'
+            range: '5..10'
           - test-target: file_system_rules
-            range: '30..45'
+            range: '10..15'
           - test-target: file_system_rules
-            range: '45..60'
+            range: '15..20'
           - test-target: file_system_rules
-            range: '60..'
+            range: '20..25'
+          - test-target: file_system_rules
+            range: '25..30'
+          - test-target: file_system_rules
+            range: '30..35'
+          - test-target: file_system_rules
+            range: '35..40'
+          - test-target: file_system_rules
+            range: '40..45'
+          - test-target: file_system_rules
+            range: '45..50'
+          - test-target: file_system_rules
+            range: '50..55'
+          - test-target: file_system_rules
+            range: '55..60'
+          - test-target: file_system_rules
+            range: '60..65'
+          - test-target: file_system_rules
+            range: '65..70'
+          - test-target: file_system_rules
+            range: '70..'
           - test-target: k8s_object_rules
             range: '0..6'
           - test-target: k8s_object_rules

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20220726163833-e8a0da132f1f
-	github.com/elastic/csp-security-policies v1.2.0
+	github.com/elastic/csp-security-policies v1.2.1
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ini/ini v1.66.6 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -537,6 +537,8 @@ github.com/elastic/csp-security-policies v1.0.8 h1:Wy13f5kFlwoJLMhnhS8O5gmP3EnGE
 github.com/elastic/csp-security-policies v1.0.8/go.mod h1:iiMuf3IRjGmWD+a88MGen0qeYgReNd2EUqDDb+LZJGc=
 github.com/elastic/csp-security-policies v1.2.0 h1:o0FP379xv8xF/HUcow4cSoswtORV6CLzbri001ioI2U=
 github.com/elastic/csp-security-policies v1.2.0/go.mod h1:3fA3X9OiyP7IRNyacOGnWqt1eHSMVZRx7p3bmZm98oE=
+github.com/elastic/csp-security-policies v1.2.1 h1:exmKOXId1rT1P/SUYweuwCkuZMaxGD0/1ex8yv3JqXs=
+github.com/elastic/csp-security-policies v1.2.1/go.mod h1:3fA3X9OiyP7IRNyacOGnWqt1eHSMVZRx7p3bmZm98oE=
 github.com/elastic/e2e-testing v1.99.2-0.20220117192005-d3365c99b9c4 h1:uYT+Krd8dsvnhnLK9pe/JHZkYtXEGPfbV4Wt1JPPol0=
 github.com/elastic/e2e-testing v1.99.2-0.20220117192005-d3365c99b9c4/go.mod h1:UcNuf4pX/qDVNQr0zybm1NL2YoWik+jKBaINZqQCA40=
 github.com/elastic/elastic-agent-autodiscover v0.2.1 h1:Nbeayh3vq2FNm6xaFo34mhUdOu0EVlpj53CqCsbU0E4=

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -11,7 +11,7 @@ from munch import Munch
 agent = Munch()
 agent.name = os.getenv('AGENT_NAME', 'elastic-agent')
 agent.namespace = os.getenv('AGENT_NAMESPACE', 'kube-system')
-agent.findings_timeout = 30
+agent.findings_timeout = 500
 
 # --- Kubernetes environment definition --------------------
 kubernetes = Munch()

--- a/tests/product/tests/data/process/process_test_cases.py
+++ b/tests/product/tests/data/process/process_test_cases.py
@@ -1365,7 +1365,12 @@ scheduler_rules = [
 kubelet_rules = [
     *cis_4_2_1,
     *cis_4_2_2,
-    *cis_4_2_3,
+    *skip_param_case(skip_list=[*cis_4_2_3],
+                    data_to_report=SkipReportData(
+                        skip_reason="Known issue",
+                        url_link="https://github.com/elastic/security-team/issues/5106",
+                        url_title="security-team #5106",
+                    )),
     *cis_4_2_4,
     *cis_4_2_5,
     *cis_4_2_6,

--- a/tests/product/tests/data/process/process_test_cases.py
+++ b/tests/product/tests/data/process/process_test_cases.py
@@ -1363,18 +1363,14 @@ scheduler_rules = [
 ]
 
 kubelet_rules = [
-    *skip_param_case(skip_list=[*cis_4_2_1,
-                                *cis_4_2_2,
-                                *cis_4_2_3,
-                                *cis_4_2_4,
-                                *cis_4_2_5,
-                                *cis_4_2_6,
-                                *cis_4_2_7,
-                                *cis_4_2_9,
-                                ],
-                     data_to_report=SkipReportData(
-                         skip_reason="Dangling tests"
-                     )),
+    *cis_4_2_1,
+    *cis_4_2_2,
+    *cis_4_2_3,
+    *cis_4_2_4,
+    *cis_4_2_5,
+    *cis_4_2_6,
+    *cis_4_2_7,
+    *cis_4_2_9,
     # *cis_4_2_8, # TODO setting is not configurable via the Kubelet config file.
     *cis_4_2_10,
     *cis_4_2_11,

--- a/tests/product/tests/test_process_api_server_rules.py
+++ b/tests/product/tests/test_process_api_server_rules.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import time
 import pytest
 
-from commonlib.utils import get_ES_evaluation
+from commonlib.utils import get_ES_evaluation, command_contains_arguments
 from product.tests.data.process.process_test_cases import api_server_rules
 from product.tests.parameters import register_params, Parameters
 
@@ -46,11 +46,15 @@ def test_process_api_server(elastic_client,
     # TODO: Implement a more optimal way of waiting
     time.sleep(60)
 
+    def identifier(eval_resource):
+        return command_contains_arguments(eval_resource.command, dictionary)
+
     evaluation = get_ES_evaluation(
         elastic_client=elastic_client,
         timeout=cloudbeat_agent.findings_timeout,
         rule_tag=rule_tag,
         exec_timestamp=datetime.utcnow(),
+        resource_identifier=identifier,
     )
 
     assert evaluation is not None, f"No evaluation for rule {rule_tag} could be found"

--- a/tests/product/tests/test_process_controller_manager_rules.py
+++ b/tests/product/tests/test_process_controller_manager_rules.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import time
 import pytest
 
-from commonlib.utils import get_ES_evaluation
+from commonlib.utils import get_ES_evaluation, command_contains_arguments
 from product.tests.data.process.process_test_cases import controller_manager_rules
 from product.tests.parameters import register_params, Parameters
 
@@ -46,11 +46,15 @@ def test_process_controller_manager(elastic_client,
     # TODO: Implement a more optimal way of waiting
     time.sleep(60)
 
+    def identifier(eval_resource):
+        return command_contains_arguments(eval_resource.command, dictionary)
+
     evaluation = get_ES_evaluation(
         elastic_client=elastic_client,
         timeout=cloudbeat_agent.findings_timeout,
         rule_tag=rule_tag,
         exec_timestamp=datetime.utcnow(),
+        resource_identifier=identifier,
     )
 
     assert evaluation is not None, f"No evaluation for rule {rule_tag} could be found"

--- a/tests/product/tests/test_process_etcd_rules.py
+++ b/tests/product/tests/test_process_etcd_rules.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import time
 import pytest
 
-from commonlib.utils import get_ES_evaluation
+from commonlib.utils import get_ES_evaluation, command_contains_arguments
 from product.tests.data.process.process_test_cases import etcd_rules
 from product.tests.parameters import register_params, Parameters
 
@@ -46,11 +46,15 @@ def test_process_etcd(elastic_client,
     # TODO: Implement a more optimal way of waiting
     time.sleep(60)
 
+    def identifier(eval_resource):
+        return command_contains_arguments(eval_resource.command, dictionary)
+
     evaluation = get_ES_evaluation(
         elastic_client=elastic_client,
         timeout=cloudbeat_agent.findings_timeout,
         rule_tag=rule_tag,
         exec_timestamp=datetime.utcnow(),
+        resource_identifier=identifier,
     )
 
     assert evaluation is not None, f"No evaluation for rule {rule_tag} could be found"

--- a/tests/product/tests/test_process_kubelet_rules.py
+++ b/tests/product/tests/test_process_kubelet_rules.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import time
 import pytest
 
-from commonlib.utils import get_ES_evaluation
+from commonlib.utils import get_ES_evaluation, config_contains_arguments
 from product.tests.data.process.process_test_cases import kubelet_rules
 from product.tests.parameters import register_params, Parameters
 
@@ -46,11 +46,20 @@ def test_process_kubelet(elastic_client,
     # TODO: Implement a more optimal way of waiting
     time.sleep(60)
 
+    def identifier(eval_resource):
+        # Needs to be done because EKS findings are showing up in vanilla K8S tests,
+        # leading to unexpected findings structure.
+        if 'external_data' not in eval_resource.keys():
+            return False
+
+        return config_contains_arguments(eval_resource.external_data.config, dictionary)
+
     evaluation = get_ES_evaluation(
         elastic_client=elastic_client,
         timeout=cloudbeat_agent.findings_timeout,
         rule_tag=rule_tag,
         exec_timestamp=datetime.utcnow(),
+        resource_identifier=identifier,
     )
 
     assert evaluation is not None, f"No evaluation for rule {rule_tag} could be found"

--- a/tests/product/tests/test_process_kubelet_rules.py
+++ b/tests/product/tests/test_process_kubelet_rules.py
@@ -49,6 +49,7 @@ def test_process_kubelet(elastic_client,
     def identifier(eval_resource):
         # Needs to be done because EKS findings are showing up in vanilla K8S tests,
         # leading to unexpected findings structure.
+        # See: https://github.com/elastic/security-team/issues/5107
         if 'external_data' not in eval_resource.keys():
             return False
 

--- a/tests/product/tests/test_process_scheduler_rules.py
+++ b/tests/product/tests/test_process_scheduler_rules.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import time
 import pytest
 
-from commonlib.utils import get_ES_evaluation
+from commonlib.utils import get_ES_evaluation, command_contains_arguments
 from product.tests.data.process.process_test_cases import scheduler_rules
 from product.tests.parameters import register_params, Parameters
 
@@ -46,11 +46,15 @@ def test_process_scheduler(elastic_client,
     # TODO: Implement a more optimal way of waiting
     time.sleep(60)
 
+    def identifier(eval_resource):
+        return command_contains_arguments(eval_resource.command, dictionary)
+
     evaluation = get_ES_evaluation(
         elastic_client=elastic_client,
         timeout=cloudbeat_agent.findings_timeout,
         rule_tag=rule_tag,
         exec_timestamp=datetime.utcnow(),
+        resource_identifier=identifier,
     )
 
     assert evaluation is not None, f"No evaluation for rule {rule_tag} could be found"


### PR DESCRIPTION
The timeout bump is a workaround until we figure out why some findings are taking a long time to show up in the ES index after [this change](https://github.com/elastic/cloudbeat/commit/3c17c16c80c4ab6b78efa6bfaed8e9ec90fcecb2).