### PR TITLE
Event sequence mismatch between fetchers of same cycle

### DIFF
--- a/resources/fetchersManager/data.go
+++ b/resources/fetchersManager/data.go
@@ -89,7 +89,7 @@ func (d *Data) fetchIteration(ctx context.Context) {
 		d.wg.Add(1)
 		go func(k string) {
 			defer d.wg.Done()
-			err := d.fetchSingle(ctx, k, fetching.CycleMetadata{Sequence: time.Now().Unix()})
+			err := d.fetchSingle(ctx, k, fetching.CycleMetadata{Sequence: seq})
 			if err != nil {
 				d.log.Errorf("Error running fetcher for key %s: %v", k, err)
 			}


### PR DESCRIPTION
We've replaced cycle_id with event.sequence variable.
This variable marks the cycle of the fetched resources and should allow us to get a complete picture of system posture.
Previously we've used a unique id and now we've switched to UNIX timestamps.
Notice that in the current code we are triggering multiple goroutines for every fetching cycle (routine per fetcher).
Passing the UNIX timestamp that is being pulled for every fetcher will cause a scenario where we might have fetchers from the same cycle having different sequence numbers (due to golang timing of calling the goroutines and context switches).
I've unified the UNIX timestamp in order to avoid mismatched cycles for fetchers.
This also affects our CI testing infrastructure that queries the event.sequence variable and makes decisions upon it.
Might resolve some of the flakiness that we are having.