### PR TITLE
remove trigger type "assigned" on pr

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,14 +1,14 @@
 **What does this PR do?**
-<!-- 
+<!--
 Please provide a detailed description of the changes introduced by this Pull Request, what are the main changes, and any other information that the reviewer should be aware of before beginning the code review.
 -->
 
 **Related Issues**
-<!-- 
+<!--
 - Related: https://github.com/elastic/security-team/issues/
 - Fixes: https://github.com/elastic/security-team/issues/
 -->
 
 **Checklist**
-- [] I have added tests that prove my fix is effective or that my feature works
-- [] I have added necessary README/documentation (if appropriate)
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary README/documentation (if appropriate)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
-    types: [ assigned, opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - main

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
-    types: [assigned, opened, synchronize, reopened]
+    types: [opened, synchronize, reopened]
 
 env:
   DEV: true

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+'
-    types: [ assigned, opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - main


### PR DESCRIPTION
**What does this PR do?**
<!-- 
Please provide a detailed description of the changes introduced by this Pull Request, what are the main changes, and any other information that the reviewer should be aware of before beginning the code review.
-->
Removes trigger on pr assignment which causes an extra invocation when mergify processes a pr.

**Related Issues**
<!-- 
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
- Fixes:
https://github.com/elastic/cloudbeat/pull/437

**Checklist**
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary README/documentation (if appropriate)
