### PR TITLE
feat: connect kind to elk network

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ create-kind-cluster:
 install-kind:
   brew install kind
 
-setup-env: install-kind create-kind-cluster
+setup-env: install-kind create-kind-cluster elastic-stack-connect-kind
 
 # Vanilla
 


### PR DESCRIPTION
**Motivation**
ELK local stack and cloudbeat (in kind cluster) do not share a network by default.
So the following setup will cause the cloudbeat to throw `DNS error` to stderr
```bash
elastic-package stack up -vd
just deploy-cloudbeat
```
To resolve this it is required to connect the kind container network to ELK by running`just elastic-stack-connect-kind`
