### PR TITLE
Fixing the kubernetes version of `kind`

### DIFF
--- a/deploy/k8s/kind/kind-mono.yml
+++ b/deploy/k8s/kind/kind-mono.yml
@@ -4,6 +4,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: kind-mono
 nodes:
 - role: control-plane
+  image: kindest/node:v1.21.1
   extraMounts:
   - hostPath: ./tests/allure/results
     containerPath: /tmp/data

--- a/deploy/k8s/kind/kind-multi.yml
+++ b/deploy/k8s/kind/kind-multi.yml
@@ -4,10 +4,12 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: kind-multi
 nodes:
 - role: control-plane
+  image: kindest/node:v1.21.1
   extraMounts:
   - hostPath: ./tests/allure/results
     containerPath: /tmp/data
 - role: worker
+  image: kindest/node:v1.21.1
   extraMounts:
   - hostPath: ./tests/allure/results
     containerPath: /tmp/data


### PR DESCRIPTION
The motivation behind fixing the kubernetes version is to solve future issues with the unsupported version.

Currently, kind 0.0.16 deploys k8s version 1.25 by default, which is currently unsupported. Therefore we can't deploy `cloudbeat` properly