### PR TITLE
chore: use docker registry

### DIFF
--- a/.github/workflows/cloudbeat-ci.yml
+++ b/.github/workflows/cloudbeat-ci.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           version: latest
           args: BuildOpaBundle
-
+      
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/deploy/k8s/kind/kind-mono.yml
+++ b/deploy/k8s/kind/kind-mono.yml
@@ -8,5 +8,10 @@ nodes:
   extraMounts:
   - hostPath: ./tests/allure/results
     containerPath: /tmp/data
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+    endpoint = ["http://kind-registry:5000"]
+
 
 # Todo Enable EphemeralContainers on kind config for debug

--- a/deploy/k8s/kind/kind-multi.yml
+++ b/deploy/k8s/kind/kind-multi.yml
@@ -13,3 +13,7 @@ nodes:
   extraMounts:
   - hostPath: ./tests/allure/results
     containerPath: /tmp/data
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:5001"]
+    endpoint = ["http://kind-registry:5000"]

--- a/deploy/kustomize/base/daemonset.yml
+++ b/deploy/kustomize/base/daemonset.yml
@@ -18,7 +18,7 @@ spec:
       containers:
         - name: cloudbeat
           image: cloudbeat:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: ES_HOST
               value: "host.docker.internal:9200"

--- a/deploy/kustomize/overlays/cloudbeat-vanilla-agent/kustomization.yml
+++ b/deploy/kustomize/overlays/cloudbeat-vanilla-agent/kustomization.yml
@@ -23,5 +23,5 @@ secretGenerator:
 
 images:
   - name: docker.elastic.co/beats/elastic-agent:8.5.0-SNAPSHOT
-    newName: elastic-agent
-    newTag: 8.5.0-SNAPSHOT
+    newName: localhost:5001/elastic-agent
+    newTag: 8.6.0-SNAPSHOT

--- a/deploy/kustomize/overlays/cloudbeat-vanilla/kustomization.yml
+++ b/deploy/kustomize/overlays/cloudbeat-vanilla/kustomization.yml
@@ -6,6 +6,11 @@ namespace: kube-system
 resources:
   - ../../base
 
+images:
+  - name: cloudbeat:latest
+    newName: localhost:5001/cloudbeat
+    newTag: latest
+
 patches:
   - path: ./patches/patch-add-ssl-certs.yaml
     target:

--- a/scripts/create_local_cluster.sh
+++ b/scripts/create_local_cluster.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# create local volume
+volume_name="elastic-local"
+volume=$(docker volume ls | grep elastic-local | awk '{ print $2 }')
+if [ $volume != $volume_name ]; then
+  docker volume create $volume_name
+fi;
+
+
+# create registry container unless it already exists
+kind_name=$1
+reg_name="kind-registry"
+reg_port='5001'
+if [ "$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)" != 'true' ]; then
+  echo "creating docker registry"
+  docker run \
+  -d  \
+  --mount type=volume,src=$volume_name,dst=/var/lib/registry \
+  --restart=always \
+  -p "127.0.0.1:${reg_port}:5000" \
+  --name "${reg_name}" \
+  registry:2
+fi
+
+# create a cluster with the local registry enabled in containerd
+cluster=$(kind get clusters | grep $kind_name)
+if [[ $cluster == "" ]] || [[ $cluster == "No kind clusters found." ]] ; then
+  echo "creating cluster"
+  kind create cluster --config=deploy/k8s/kind/$kind_name.yml --wait 30s > /dev/null 2>&1
+fi
+
+# connect the registry to the cluster network if not already connected
+if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${reg_name}")" = 'null' ]; then
+  echo "connecting registry to cluster network"
+  docker network connect "kind" "${reg_name}"
+fi
+
+# Document the local registry
+# https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry
+cat <<EOF | kubectl apply -f - > /dev/null
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${reg_port}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+
+cat << EOF
+Cluster $kind_name is ready
+Usage:
+  $ kubectl config use-context $kind_name
+
+Local registry is available on port ${reg_port}
+  $ docker tag {IMAGE} localhost:${reg_port}/{IMAGE}
+  $ docker push localhost:${reg_port}/{IMAGE}
+Later to use from within a cluster use the image "localhost:${reg_port}/{IMAGE}" 
+EOF


### PR DESCRIPTION
# WIP

[Kind Registry](https://kind.sigs.k8s.io/docs/user/local-registry/)
Compare `kind load` vs `registry` [^1]

<details>
  <summary>Compare flow with Elastic-Agent</summary>


```bash
# Method 1
elastic-package stack up -vd --version=8.6.0-SNAPSHOT
just create-kind-cluster
just elastic-stack-connect-kind
docker tag docker.elastic.co/elastic-agent/elastic-agent:8.6.0-SNAPSHOT elastic-agent:8.6.0-SNAPSHOT
kind load docker-image elastic-agent:8.6.0-SNAPSHOT --name kind-multi
kubectl apply -k deploy/kustomize/overlays/cloudbeat-vanilla-agent
kubectl rollout status daemonset -n kube-system elastic-agent

# Method 2
elastic-package stack up -vd
just create-kind-cluster
just elastic-stack-connect-kind
docker tag docker.elastic.co/elastic-agent/elastic-agent:8.6.0-SNAPSHOT localhost:5001/elastic-agent:8.6.0-SNAPSHOT
docker push localhost:5001/elastic-agent:8.6.0-SNAPSHOT
kubectl apply -k deploy/kustomize/overlays/cloudbeat-vanilla-agent
kubectl rollout status daemonset -n kube-system elastic-agent
```



  | kind-load | registry
-- | -- | --
Cluster is running | 45s  |  45s
Agent is running | 7m30s  |  2m20s
Cloudbeat updated |   |  

</details>

---

<details>
  <summary>Compare flow with Cloudbeat standalone</summary>




```bash
elastic-package stack up -vd --version=8.6.0-SNAPSHOT
just create-kind-cluster
just elastic-stack-connect-kind
just build-deploy-cloudbeat
just deploy-cloudbeat
kubectl rollout status daemonset -n kube-system cloudbeat
```

  | kind-load | registry
-- | -- | --
Cluster is running | 45s  |  45s
Cloudbeat is running |  3m |  1m16s
Cloudbeat updated |  2m |  1m

Since the registry cache is preserved by a volume, the next time the phase of "Cloudbeat is running" will be faster.

</details>

---
[^1]: All images are pulled (elastic-agent, stack, kind), modules are downloaded.




