### PR TITLE
Map concurrent access panic for events metadata

### DIFF
--- a/transformer/events_creator.go
+++ b/transformer/events_creator.go
@@ -39,9 +39,9 @@ const (
 )
 
 type Transformer struct {
-	log           *logp.Logger
-	eventMetadata mapstr.M
-	commonData    CommonDataInterface
+	log        *logp.Logger
+	index      string
+	commonData CommonDataInterface
 }
 
 type ECSEvent struct {
@@ -55,12 +55,10 @@ type ECSEvent struct {
 }
 
 func NewTransformer(log *logp.Logger, cd CommonDataInterface, index string) Transformer {
-	eventMetadata := mapstr.M{libevents.FieldMetaIndex: index}
-
 	return Transformer{
-		log:           log,
-		eventMetadata: eventMetadata,
-		commonData:    cd,
+		log:        log,
+		index:      index,
+		commonData: cd,
 	}
 }
 
@@ -84,7 +82,7 @@ func (t *Transformer) CreateBeatEvents(ctx context.Context, eventData evaluator.
 
 	for _, finding := range eventData.Findings {
 		event := beat.Event{
-			Meta:      t.eventMetadata,
+			Meta:      mapstr.M{libevents.FieldMetaIndex: t.index},
 			Timestamp: timestamp,
 			Fields: mapstr.M{
 				resMetadata.ECSFormat: eventData.GetElasticCommonData(),


### PR DESCRIPTION
Transformer allocated the `eventMetadata` once and re-used it for all of the events that it sends to ES.
The underlying `elastic-agent-libs/mapstr` implementation is non-concurrent.
This causes a panic of concurrent read/writes in race scenarios when sending events.

Fixes 
- #461 