### PR TITLE
docs: update docs versions 8.5.1

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,4 +18,4 @@
 package cmd
 
 // name matches github.com/elastic/beats/v7/dev-tools/mage/settings.go parseBeatVersion
-const defaultBeatVersion = "8.5.2"
+const defaultBeatVersion = "8.5.1"


### PR DESCRIPTION
Updates docs versions to 8.5.1.

Merge before the final Release build.