### PR TITLE
Remove streams struct

### DIFF
--- a/_meta/config/cloudbeat.common.yml.tmpl
+++ b/_meta/config/cloudbeat.common.yml.tmpl
@@ -7,164 +7,163 @@
 {{end -}}
 cloudbeat:
   type: {{$type}}
-  streams:
-    # Defines how often an event is sent to the output
-    period: 4h
-    fetchers:
-      - name: kube-api
-      - name: process
-        directory: "/hostfs"
-        processes:
-          etcd:
-          kube-apiserver:
-          kube-controller:
-          kube-scheduler:
-          kubelet:
-            config-file-arguments:
-              - config
-      - name: file-system
-        patterns: [
-          "/hostfs/etc/kubernetes/scheduler.conf",
-          "/hostfs/etc/kubernetes/controller-manager.conf",
-          "/hostfs/etc/kubernetes/admin.conf",
-          "/hostfs/etc/kubernetes/kubelet.conf",
-          "/hostfs/etc/kubernetes/manifests/etcd.yaml",
-          "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
-          "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
-          "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
-          "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-          "/hostfs/etc/kubernetes/pki/*",
-          "/hostfs/var/lib/kubelet/config.yaml",
-          "/hostfs/var/lib/etcd",
-          "/hostfs/etc/kubernetes/pki"
-        ]
+  # Defines how often an event is sent to the output
+  period: 4h
+  fetchers:
+    - name: kube-api
+    - name: process
+      directory: "/hostfs"
+      processes:
+        etcd:
+        kube-apiserver:
+        kube-controller:
+        kube-scheduler:
+        kubelet:
+          config-file-arguments:
+            - config
+    - name: file-system
+      patterns: [
+        "/hostfs/etc/kubernetes/scheduler.conf",
+        "/hostfs/etc/kubernetes/controller-manager.conf",
+        "/hostfs/etc/kubernetes/admin.conf",
+        "/hostfs/etc/kubernetes/kubelet.conf",
+        "/hostfs/etc/kubernetes/manifests/etcd.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
+        "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
+        "/hostfs/etc/kubernetes/pki/*",
+        "/hostfs/var/lib/kubelet/config.yaml",
+        "/hostfs/var/lib/etcd",
+        "/hostfs/etc/kubernetes/pki"
+      ]
 {{if eq $type $SELF_MANAGED_TYPE }}
-    runtime_cfg:
-      activated_rules:
-        cis_k8s:
-          - cis_1_1_1
-          - cis_1_1_2
-          - cis_1_1_3
-          - cis_1_1_4
-          - cis_1_1_5
-          - cis_1_1_6
-          - cis_1_1_7
-          - cis_1_1_8
-          - cis_1_1_11
-          - cis_1_1_12
-          - cis_1_1_13
-          - cis_1_1_14
-          - cis_1_1_15
-          - cis_1_1_16
-          - cis_1_1_17
-          - cis_1_1_18
-          - cis_1_1_19
-          - cis_1_1_20
-          - cis_1_1_21
-          - cis_1_2_2
-          - cis_1_2_4
-          - cis_1_2_5
-          - cis_1_2_6
-          - cis_1_2_7
-          - cis_1_2_8
-          - cis_1_2_9
-          - cis_1_2_10
-          - cis_1_2_11
-          - cis_1_2_12
-          - cis_1_2_13
-          - cis_1_2_14
-          - cis_1_2_15
-          - cis_1_2_16
-          - cis_1_2_17
-          - cis_1_2_18
-          - cis_1_2_19
-          - cis_1_2_20
-          - cis_1_2_21
-          - cis_1_2_22
-          - cis_1_2_23
-          - cis_1_2_24
-          - cis_1_2_25
-          - cis_1_2_26
-          - cis_1_2_27
-          - cis_1_2_28
-          - cis_1_2_29
-          - cis_1_2_32
-          - cis_1_3_2
-          - cis_1_3_3
-          - cis_1_3_4
-          - cis_1_3_5
-          - cis_1_3_6
-          - cis_1_3_7
-          - cis_1_4_1
-          - cis_1_4_2
-          - cis_2_1
-          - cis_2_2
-          - cis_2_3
-          - cis_2_4
-          - cis_2_5
-          - cis_2_6
-          - cis_4_1_1
-          - cis_4_1_2
-          - cis_4_1_5
-          - cis_4_1_6
-          - cis_4_1_9
-          - cis_4_1_10
-          - cis_4_2_1
-          - cis_4_2_2
-          - cis_4_2_3
-          - cis_4_2_4
-          - cis_4_2_5
-          - cis_4_2_6
-          - cis_4_2_7
-          - cis_4_2_8
-          - cis_4_2_9
-          - cis_4_2_10
-          - cis_4_2_11
-          - cis_4_2_12
-          - cis_4_2_13
-          - cis_5_1_3
-          - cis_5_1_5
-          - cis_5_1_6
-          - cis_5_2_2
-          - cis_5_2_3
-          - cis_5_2_4
-          - cis_5_2_5
-          - cis_5_2_6
-          - cis_5_2_7
-          - cis_5_2_8
-          - cis_5_2_9
-          - cis_5_2_10
+  runtime_cfg:
+    activated_rules:
+      cis_k8s:
+        - cis_1_1_1
+        - cis_1_1_2
+        - cis_1_1_3
+        - cis_1_1_4
+        - cis_1_1_5
+        - cis_1_1_6
+        - cis_1_1_7
+        - cis_1_1_8
+        - cis_1_1_11
+        - cis_1_1_12
+        - cis_1_1_13
+        - cis_1_1_14
+        - cis_1_1_15
+        - cis_1_1_16
+        - cis_1_1_17
+        - cis_1_1_18
+        - cis_1_1_19
+        - cis_1_1_20
+        - cis_1_1_21
+        - cis_1_2_2
+        - cis_1_2_4
+        - cis_1_2_5
+        - cis_1_2_6
+        - cis_1_2_7
+        - cis_1_2_8
+        - cis_1_2_9
+        - cis_1_2_10
+        - cis_1_2_11
+        - cis_1_2_12
+        - cis_1_2_13
+        - cis_1_2_14
+        - cis_1_2_15
+        - cis_1_2_16
+        - cis_1_2_17
+        - cis_1_2_18
+        - cis_1_2_19
+        - cis_1_2_20
+        - cis_1_2_21
+        - cis_1_2_22
+        - cis_1_2_23
+        - cis_1_2_24
+        - cis_1_2_25
+        - cis_1_2_26
+        - cis_1_2_27
+        - cis_1_2_28
+        - cis_1_2_29
+        - cis_1_2_32
+        - cis_1_3_2
+        - cis_1_3_3
+        - cis_1_3_4
+        - cis_1_3_5
+        - cis_1_3_6
+        - cis_1_3_7
+        - cis_1_4_1
+        - cis_1_4_2
+        - cis_2_1
+        - cis_2_2
+        - cis_2_3
+        - cis_2_4
+        - cis_2_5
+        - cis_2_6
+        - cis_4_1_1
+        - cis_4_1_2
+        - cis_4_1_5
+        - cis_4_1_6
+        - cis_4_1_9
+        - cis_4_1_10
+        - cis_4_2_1
+        - cis_4_2_2
+        - cis_4_2_3
+        - cis_4_2_4
+        - cis_4_2_5
+        - cis_4_2_6
+        - cis_4_2_7
+        - cis_4_2_8
+        - cis_4_2_9
+        - cis_4_2_10
+        - cis_4_2_11
+        - cis_4_2_12
+        - cis_4_2_13
+        - cis_5_1_3
+        - cis_5_1_5
+        - cis_5_1_6
+        - cis_5_2_2
+        - cis_5_2_3
+        - cis_5_2_4
+        - cis_5_2_5
+        - cis_5_2_6
+        - cis_5_2_7
+        - cis_5_2_8
+        - cis_5_2_9
+        - cis_5_2_10
 {{else if eq $type $EKS_TYPE}}
-    runtime_cfg:
-      activated_rules:
-        cis_eks:
-          - cis_3_1_1
-          - cis_3_1_2
-          - cis_3_1_3
-          - cis_3_1_4
-          - cis_3_2_1
-          - cis_3_2_2
-          - cis_3_2_3
-          - cis_3_2_4
-          - cis_3_2_5
-          - cis_3_2_6
-          - cis_3_2_7
-          - cis_3_2_8
-          - cis_3_2_9
-          - cis_3_2_10
-          - cis_3_2_11
-          - cis_4_2_1
-          - cis_4_2_2
-          - cis_4_2_3
-          - cis_4_2_4
-          - cis_4_2_5
-          - cis_4_2_6
-          - cis_4_2_7
-          - cis_4_2_8
-          - cis_4_2_9
-          - cis_5_1_1
-          - cis_5_4_3
-          - cis_5_4_5
+  runtime_cfg:
+    activated_rules:
+      cis_eks:
+        - cis_3_1_1
+        - cis_3_1_2
+        - cis_3_1_3
+        - cis_3_1_4
+        - cis_3_2_1
+        - cis_3_2_2
+        - cis_3_2_3
+        - cis_3_2_4
+        - cis_3_2_5
+        - cis_3_2_6
+        - cis_3_2_7
+        - cis_3_2_8
+        - cis_3_2_9
+        - cis_3_2_10
+        - cis_3_2_11
+        - cis_4_2_1
+        - cis_4_2_2
+        - cis_4_2_3
+        - cis_4_2_4
+        - cis_4_2_5
+        - cis_4_2_6
+        - cis_4_2_7
+        - cis_4_2_8
+        - cis_4_2_9
+        - cis_5_1_1
+        - cis_5_4_3
+        - cis_5_4_5
 {{end}}
 #    # EKS Fetchers configuration
 #      - name: kube-api

--- a/beater/cloudbeat.go
+++ b/beater/cloudbeat.go
@@ -50,7 +50,7 @@ const (
 type cloudbeat struct {
 	ctx         context.Context
 	cancel      context.CancelFunc
-	config      config.Config
+	config      *config.Config
 	client      beat.Client
 	data        *fetchersManager.Data
 	evaluator   evaluator.Evaluator
@@ -211,7 +211,7 @@ func (bt *cloudbeat) Run(b *beat.Beat) error {
 	}
 }
 
-func initRegistry(log *logp.Logger, cfg config.Config, ch chan fetching.ResourceInfo, le leaderelection.ElectionManager) (fetchersManager.FetchersRegistry, error) {
+func initRegistry(log *logp.Logger, cfg *config.Config, ch chan fetching.ResourceInfo, le leaderelection.ElectionManager) (fetchersManager.FetchersRegistry, error) {
 	registry := fetchersManager.NewFetcherRegistry(log)
 
 	parsedList, err := fetchersManager.Factories.ParseConfigFetchers(log, cfg, ch)

--- a/cloudbeat.reference.yml
+++ b/cloudbeat.reference.yml
@@ -9,133 +9,132 @@
 
 cloudbeat:
   type: cloudbeat/cis_k8s
-  streams:
     # Defines how often an event is sent to the output
-    period: 4h
-    fetchers:
-      - name: kube-api
-      - name: process
-        directory: "/hostfs"
-        processes:
-          etcd:
-          kube-apiserver:
-          kube-controller:
-          kube-scheduler:
-          kubelet:
-            config-file-arguments:
-              - config
-      - name: file-system
-        patterns: [
-          "/hostfs/etc/kubernetes/scheduler.conf",
-          "/hostfs/etc/kubernetes/controller-manager.conf",
-          "/hostfs/etc/kubernetes/admin.conf",
-          "/hostfs/etc/kubernetes/kubelet.conf",
-          "/hostfs/etc/kubernetes/manifests/etcd.yaml",
-          "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
-          "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
-          "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
-          "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-          "/hostfs/etc/kubernetes/pki/*",
-          "/hostfs/var/lib/kubelet/config.yaml",
-          "/hostfs/var/lib/etcd",
-          "/hostfs/etc/kubernetes/pki"
-        ]
+  period: 4h
+  fetchers:
+    - name: kube-api
+    - name: process
+      directory: "/hostfs"
+      processes:
+        etcd:
+        kube-apiserver:
+        kube-controller:
+        kube-scheduler:
+        kubelet:
+          config-file-arguments:
+            - config
+    - name: file-system
+      patterns: [
+        "/hostfs/etc/kubernetes/scheduler.conf",
+        "/hostfs/etc/kubernetes/controller-manager.conf",
+        "/hostfs/etc/kubernetes/admin.conf",
+        "/hostfs/etc/kubernetes/kubelet.conf",
+        "/hostfs/etc/kubernetes/manifests/etcd.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
+        "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
+        "/hostfs/etc/kubernetes/pki/*",
+        "/hostfs/var/lib/kubelet/config.yaml",
+        "/hostfs/var/lib/etcd",
+        "/hostfs/etc/kubernetes/pki"
+      ]
 
-    runtime_cfg:
-      activated_rules:
-        cis_k8s:
-          - cis_1_1_1
-          - cis_1_1_2
-          - cis_1_1_3
-          - cis_1_1_4
-          - cis_1_1_5
-          - cis_1_1_6
-          - cis_1_1_7
-          - cis_1_1_8
-          - cis_1_1_11
-          - cis_1_1_12
-          - cis_1_1_13
-          - cis_1_1_14
-          - cis_1_1_15
-          - cis_1_1_16
-          - cis_1_1_17
-          - cis_1_1_18
-          - cis_1_1_19
-          - cis_1_1_20
-          - cis_1_1_21
-          - cis_1_2_2
-          - cis_1_2_4
-          - cis_1_2_5
-          - cis_1_2_6
-          - cis_1_2_7
-          - cis_1_2_8
-          - cis_1_2_9
-          - cis_1_2_10
-          - cis_1_2_11
-          - cis_1_2_12
-          - cis_1_2_13
-          - cis_1_2_14
-          - cis_1_2_15
-          - cis_1_2_16
-          - cis_1_2_17
-          - cis_1_2_18
-          - cis_1_2_19
-          - cis_1_2_20
-          - cis_1_2_21
-          - cis_1_2_22
-          - cis_1_2_23
-          - cis_1_2_24
-          - cis_1_2_25
-          - cis_1_2_26
-          - cis_1_2_27
-          - cis_1_2_28
-          - cis_1_2_29
-          - cis_1_2_32
-          - cis_1_3_2
-          - cis_1_3_3
-          - cis_1_3_4
-          - cis_1_3_5
-          - cis_1_3_6
-          - cis_1_3_7
-          - cis_1_4_1
-          - cis_1_4_2
-          - cis_2_1
-          - cis_2_2
-          - cis_2_3
-          - cis_2_4
-          - cis_2_5
-          - cis_2_6
-          - cis_4_1_1
-          - cis_4_1_2
-          - cis_4_1_5
-          - cis_4_1_6
-          - cis_4_1_9
-          - cis_4_1_10
-          - cis_4_2_1
-          - cis_4_2_2
-          - cis_4_2_3
-          - cis_4_2_4
-          - cis_4_2_5
-          - cis_4_2_6
-          - cis_4_2_7
-          - cis_4_2_8
-          - cis_4_2_9
-          - cis_4_2_10
-          - cis_4_2_11
-          - cis_4_2_12
-          - cis_4_2_13
-          - cis_5_1_3
-          - cis_5_1_5
-          - cis_5_1_6
-          - cis_5_2_2
-          - cis_5_2_3
-          - cis_5_2_4
-          - cis_5_2_5
-          - cis_5_2_6
-          - cis_5_2_7
-          - cis_5_2_8
-          - cis_5_2_9
-          - cis_5_2_10
+  runtime_cfg:
+    activated_rules:
+      cis_k8s:
+        - cis_1_1_1
+        - cis_1_1_2
+        - cis_1_1_3
+        - cis_1_1_4
+        - cis_1_1_5
+        - cis_1_1_6
+        - cis_1_1_7
+        - cis_1_1_8
+        - cis_1_1_11
+        - cis_1_1_12
+        - cis_1_1_13
+        - cis_1_1_14
+        - cis_1_1_15
+        - cis_1_1_16
+        - cis_1_1_17
+        - cis_1_1_18
+        - cis_1_1_19
+        - cis_1_1_20
+        - cis_1_1_21
+        - cis_1_2_2
+        - cis_1_2_4
+        - cis_1_2_5
+        - cis_1_2_6
+        - cis_1_2_7
+        - cis_1_2_8
+        - cis_1_2_9
+        - cis_1_2_10
+        - cis_1_2_11
+        - cis_1_2_12
+        - cis_1_2_13
+        - cis_1_2_14
+        - cis_1_2_15
+        - cis_1_2_16
+        - cis_1_2_17
+        - cis_1_2_18
+        - cis_1_2_19
+        - cis_1_2_20
+        - cis_1_2_21
+        - cis_1_2_22
+        - cis_1_2_23
+        - cis_1_2_24
+        - cis_1_2_25
+        - cis_1_2_26
+        - cis_1_2_27
+        - cis_1_2_28
+        - cis_1_2_29
+        - cis_1_2_32
+        - cis_1_3_2
+        - cis_1_3_3
+        - cis_1_3_4
+        - cis_1_3_5
+        - cis_1_3_6
+        - cis_1_3_7
+        - cis_1_4_1
+        - cis_1_4_2
+        - cis_2_1
+        - cis_2_2
+        - cis_2_3
+        - cis_2_4
+        - cis_2_5
+        - cis_2_6
+        - cis_4_1_1
+        - cis_4_1_2
+        - cis_4_1_5
+        - cis_4_1_6
+        - cis_4_1_9
+        - cis_4_1_10
+        - cis_4_2_1
+        - cis_4_2_2
+        - cis_4_2_3
+        - cis_4_2_4
+        - cis_4_2_5
+        - cis_4_2_6
+        - cis_4_2_7
+        - cis_4_2_8
+        - cis_4_2_9
+        - cis_4_2_10
+        - cis_4_2_11
+        - cis_4_2_12
+        - cis_4_2_13
+        - cis_5_1_3
+        - cis_5_1_5
+        - cis_5_1_6
+        - cis_5_2_2
+        - cis_5_2_3
+        - cis_5_2_4
+        - cis_5_2_5
+        - cis_5_2_6
+        - cis_5_2_7
+        - cis_5_2_8
+        - cis_5_2_9
+        - cis_5_2_10
 
 #    # EKS Fetchers configuration
 #      - name: kube-api

--- a/cloudbeat.yml
+++ b/cloudbeat.yml
@@ -12,133 +12,132 @@
 
 cloudbeat:
   type: cloudbeat/cis_k8s
-  streams:
-    # Defines how often an event is sent to the output
-    period: 4h
-    fetchers:
-      - name: kube-api
-      - name: process
-        directory: "/hostfs"
-        processes:
-          etcd:
-          kube-apiserver:
-          kube-controller:
-          kube-scheduler:
-          kubelet:
-            config-file-arguments:
-              - config
-      - name: file-system
-        patterns: [
-          "/hostfs/etc/kubernetes/scheduler.conf",
-          "/hostfs/etc/kubernetes/controller-manager.conf",
-          "/hostfs/etc/kubernetes/admin.conf",
-          "/hostfs/etc/kubernetes/kubelet.conf",
-          "/hostfs/etc/kubernetes/manifests/etcd.yaml",
-          "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
-          "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
-          "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
-          "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-          "/hostfs/etc/kubernetes/pki/*",
-          "/hostfs/var/lib/kubelet/config.yaml",
-          "/hostfs/var/lib/etcd",
-          "/hostfs/etc/kubernetes/pki"
-        ]
+  # Defines how often an event is sent to the output
+  period: 4h
+  fetchers:
+    - name: kube-api
+    - name: process
+      directory: "/hostfs"
+      processes:
+        etcd:
+        kube-apiserver:
+        kube-controller:
+        kube-scheduler:
+        kubelet:
+          config-file-arguments:
+            - config
+    - name: file-system
+      patterns: [
+        "/hostfs/etc/kubernetes/scheduler.conf",
+        "/hostfs/etc/kubernetes/controller-manager.conf",
+        "/hostfs/etc/kubernetes/admin.conf",
+        "/hostfs/etc/kubernetes/kubelet.conf",
+        "/hostfs/etc/kubernetes/manifests/etcd.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
+        "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
+        "/hostfs/etc/kubernetes/pki/*",
+        "/hostfs/var/lib/kubelet/config.yaml",
+        "/hostfs/var/lib/etcd",
+        "/hostfs/etc/kubernetes/pki"
+      ]
 
-    runtime_cfg:
-      activated_rules:
-        cis_k8s:
-          - cis_1_1_1
-          - cis_1_1_2
-          - cis_1_1_3
-          - cis_1_1_4
-          - cis_1_1_5
-          - cis_1_1_6
-          - cis_1_1_7
-          - cis_1_1_8
-          - cis_1_1_11
-          - cis_1_1_12
-          - cis_1_1_13
-          - cis_1_1_14
-          - cis_1_1_15
-          - cis_1_1_16
-          - cis_1_1_17
-          - cis_1_1_18
-          - cis_1_1_19
-          - cis_1_1_20
-          - cis_1_1_21
-          - cis_1_2_2
-          - cis_1_2_4
-          - cis_1_2_5
-          - cis_1_2_6
-          - cis_1_2_7
-          - cis_1_2_8
-          - cis_1_2_9
-          - cis_1_2_10
-          - cis_1_2_11
-          - cis_1_2_12
-          - cis_1_2_13
-          - cis_1_2_14
-          - cis_1_2_15
-          - cis_1_2_16
-          - cis_1_2_17
-          - cis_1_2_18
-          - cis_1_2_19
-          - cis_1_2_20
-          - cis_1_2_21
-          - cis_1_2_22
-          - cis_1_2_23
-          - cis_1_2_24
-          - cis_1_2_25
-          - cis_1_2_26
-          - cis_1_2_27
-          - cis_1_2_28
-          - cis_1_2_29
-          - cis_1_2_32
-          - cis_1_3_2
-          - cis_1_3_3
-          - cis_1_3_4
-          - cis_1_3_5
-          - cis_1_3_6
-          - cis_1_3_7
-          - cis_1_4_1
-          - cis_1_4_2
-          - cis_2_1
-          - cis_2_2
-          - cis_2_3
-          - cis_2_4
-          - cis_2_5
-          - cis_2_6
-          - cis_4_1_1
-          - cis_4_1_2
-          - cis_4_1_5
-          - cis_4_1_6
-          - cis_4_1_9
-          - cis_4_1_10
-          - cis_4_2_1
-          - cis_4_2_2
-          - cis_4_2_3
-          - cis_4_2_4
-          - cis_4_2_5
-          - cis_4_2_6
-          - cis_4_2_7
-          - cis_4_2_8
-          - cis_4_2_9
-          - cis_4_2_10
-          - cis_4_2_11
-          - cis_4_2_12
-          - cis_4_2_13
-          - cis_5_1_3
-          - cis_5_1_5
-          - cis_5_1_6
-          - cis_5_2_2
-          - cis_5_2_3
-          - cis_5_2_4
-          - cis_5_2_5
-          - cis_5_2_6
-          - cis_5_2_7
-          - cis_5_2_8
-          - cis_5_2_9
-          - cis_5_2_10
+  runtime_cfg:
+    activated_rules:
+      cis_k8s:
+        - cis_1_1_1
+        - cis_1_1_2
+        - cis_1_1_3
+        - cis_1_1_4
+        - cis_1_1_5
+        - cis_1_1_6
+        - cis_1_1_7
+        - cis_1_1_8
+        - cis_1_1_11
+        - cis_1_1_12
+        - cis_1_1_13
+        - cis_1_1_14
+        - cis_1_1_15
+        - cis_1_1_16
+        - cis_1_1_17
+        - cis_1_1_18
+        - cis_1_1_19
+        - cis_1_1_20
+        - cis_1_1_21
+        - cis_1_2_2
+        - cis_1_2_4
+        - cis_1_2_5
+        - cis_1_2_6
+        - cis_1_2_7
+        - cis_1_2_8
+        - cis_1_2_9
+        - cis_1_2_10
+        - cis_1_2_11
+        - cis_1_2_12
+        - cis_1_2_13
+        - cis_1_2_14
+        - cis_1_2_15
+        - cis_1_2_16
+        - cis_1_2_17
+        - cis_1_2_18
+        - cis_1_2_19
+        - cis_1_2_20
+        - cis_1_2_21
+        - cis_1_2_22
+        - cis_1_2_23
+        - cis_1_2_24
+        - cis_1_2_25
+        - cis_1_2_26
+        - cis_1_2_27
+        - cis_1_2_28
+        - cis_1_2_29
+        - cis_1_2_32
+        - cis_1_3_2
+        - cis_1_3_3
+        - cis_1_3_4
+        - cis_1_3_5
+        - cis_1_3_6
+        - cis_1_3_7
+        - cis_1_4_1
+        - cis_1_4_2
+        - cis_2_1
+        - cis_2_2
+        - cis_2_3
+        - cis_2_4
+        - cis_2_5
+        - cis_2_6
+        - cis_4_1_1
+        - cis_4_1_2
+        - cis_4_1_5
+        - cis_4_1_6
+        - cis_4_1_9
+        - cis_4_1_10
+        - cis_4_2_1
+        - cis_4_2_2
+        - cis_4_2_3
+        - cis_4_2_4
+        - cis_4_2_5
+        - cis_4_2_6
+        - cis_4_2_7
+        - cis_4_2_8
+        - cis_4_2_9
+        - cis_4_2_10
+        - cis_4_2_11
+        - cis_4_2_12
+        - cis_4_2_13
+        - cis_5_1_3
+        - cis_5_1_5
+        - cis_5_1_6
+        - cis_5_2_2
+        - cis_5_2_3
+        - cis_5_2_4
+        - cis_5_2_5
+        - cis_5_2_6
+        - cis_5_2_7
+        - cis_5_2_8
+        - cis_5_2_9
+        - cis_5_2_10
 
 #    # EKS Fetchers configuration
 #      - name: kube-api

--- a/config/config.go
+++ b/config/config.go
@@ -85,6 +85,7 @@ func New(cfg *config.C) (*Config, error) {
 func defaultConfig() (*Config, error) {
 	ret := &Config{
 		Period: 4 * time.Hour,
+		Type:   InputTypeVanillaK8s,
 	}
 
 	bundle, err := getBundlePath()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -113,17 +114,19 @@ fetchers:
 		},
 	}
 
-	for _, test := range tests {
-		cfg, err := config.NewConfigFrom(test.config)
-		s.NoError(err)
+	for i, test := range tests {
+		s.Run(fmt.Sprint(i), func() {
+			cfg, err := config.NewConfigFrom(test.config)
+			s.NoError(err)
 
-		c, err := New(cfg)
-		s.NoError(err)
+			c, err := New(cfg)
+			s.NoError(err)
 
-		s.Equal(test.expectedType, c.Type)
-		s.EqualValues(test.expectedActivatedRules, c.RuntimeCfg.ActivatedRules)
-		s.Equal(test.expectedAWSConfig, c.AWSConfig)
-		s.Equal(test.expectedFetchers, len(c.Fetchers))
+			s.Equal(test.expectedType, c.Type)
+			s.EqualValues(test.expectedActivatedRules, c.RuntimeCfg.ActivatedRules)
+			s.Equal(test.expectedAWSConfig, c.AWSConfig)
+			s.Equal(test.expectedFetchers, len(c.Fetchers))
+		})
 	}
 }
 
@@ -154,14 +157,16 @@ not_runtime_cfg:
 		},
 	}
 
-	for _, test := range tests {
-		cfg, err := config.NewConfigFrom(test.config)
-		s.NoError(err)
+	for i, test := range tests {
+		s.Run(fmt.Sprint(i), func() {
+			cfg, err := config.NewConfigFrom(test.config)
+			s.NoError(err)
 
-		c, err := New(cfg)
-		s.NoError(err)
+			c, err := New(cfg)
+			s.NoError(err)
 
-		s.Equal(test.expected, c.RuntimeCfg != nil)
+			s.Equal(test.expected, c.RuntimeCfg != nil)
+		})
 	}
 }
 
@@ -183,16 +188,18 @@ runtime_cfg:
 		},
 	}
 
-	for _, test := range tests {
-		cfg, err := config.NewConfigFrom(test.config)
-		s.NoError(err)
+	for i, test := range tests {
+		s.Run(fmt.Sprint(i), func() {
+			cfg, err := config.NewConfigFrom(test.config)
+			s.NoError(err)
 
-		c, err := New(cfg)
-		s.NoError(err)
+			c, err := New(cfg)
+			s.NoError(err)
 
-		rules := c.RuntimeCfg.ActivatedRules
+			rules := c.RuntimeCfg.ActivatedRules
 
-		s.Equal(test.expected, rules.CisK8s)
+			s.Equal(test.expected, rules.CisK8s)
+		})
 	}
 }
 
@@ -219,14 +226,16 @@ func (s *ConfigTestSuite) TestConfigPeriod() {
 		},
 	}
 
-	for _, test := range tests {
-		cfg, err := config.NewConfigFrom(test.config)
-		s.NoError(err)
+	for i, test := range tests {
+		s.Run(fmt.Sprint(i), func() {
+			cfg, err := config.NewConfigFrom(test.config)
+			s.NoError(err)
 
-		c, err := New(cfg)
-		s.NoError(err)
+			c, err := New(cfg)
+			s.NoError(err)
 
-		s.Equal(test.expectedPeriod, c.Period)
+			s.Equal(test.expectedPeriod, c.Period)
+		})
 	}
 }
 
@@ -263,15 +272,17 @@ runtime_cfg:
 		},
 	}
 
-	for _, test := range tests {
-		cfg, err := config.NewConfigFrom(test.config)
-		s.NoError(err)
+	for i, test := range tests {
+		s.Run(fmt.Sprint(i), func() {
+			cfg, err := config.NewConfigFrom(test.config)
+			s.NoError(err)
 
-		c, err := New(cfg)
-		s.NoError(err)
+			c, err := New(cfg)
+			s.NoError(err)
 
-		s.Equal(test.expectedType, c.Type)
-		s.Equal(test.expectedActivatedRules, c.RuntimeCfg.ActivatedRules.CisK8s)
-		s.Equal(test.expectedEksActivatedRules, c.RuntimeCfg.ActivatedRules.CisEks)
+			s.Equal(test.expectedType, c.Type)
+			s.Equal(test.expectedActivatedRules, c.RuntimeCfg.ActivatedRules.CisK8s)
+			s.Equal(test.expectedEksActivatedRules, c.RuntimeCfg.ActivatedRules.CisEks)
+		})
 	}
 }

--- a/deploy/kustomize/overlays/cloudbeat-eks/cloudbeat.yml
+++ b/deploy/kustomize/overlays/cloudbeat-eks/cloudbeat.yml
@@ -1,55 +1,54 @@
 cloudbeat:
   type: cloudbeat/cis_eks
-  streams:
-    - access_key_id: ${AWS_ACCESS_KEY_ID:no_access_key_was_set}
-      secret_access_key: ${AWS_SECRET_ACCESS_KEY:no_secret_was_set}
-      # Defines how often an event is sent to the output
-      period: 30s
-      runtime_cfg:
-        activated_rules:
-          cis_eks:
-            - cis_3_1_1
-            - cis_3_1_2
-            - cis_3_1_3
-            - cis_3_1_4
-            - cis_3_2_1
-            - cis_3_2_2
-            - cis_3_2_3
-            - cis_3_2_4
-            - cis_3_2_5
-            - cis_3_2_6
-            - cis_3_2_7
-            - cis_3_2_8
-            - cis_3_2_9
-            - cis_3_2_10
-            - cis_3_2_11
-            - cis_4_2_1
-            - cis_4_2_2
-            - cis_4_2_3
-            - cis_4_2_4
-            - cis_4_2_5
-            - cis_4_2_6
-            - cis_4_2_7
-            - cis_4_2_8
-            - cis_4_2_9
-            - cis_5_1_1
-            - cis_5_4_3
-            - cis_5_4_5
-      fetchers:
-        - name: kube-api
-        - name: process
-          directory: "/hostfs"
-          processes:
-            kubelet:
-              config-file-arguments:
-                - config
-        - name: aws-ecr
-        - name: aws-elb
-        - name: file-system
-          patterns: [
-            "/hostfs/etc/kubernetes/kubelet/kubelet-config.json",
-            "/hostfs/var/lib/kubelet/kubeconfig",
-          ]
+  access_key_id: ${AWS_ACCESS_KEY_ID:no_access_key_was_set}
+  secret_access_key: ${AWS_SECRET_ACCESS_KEY:no_secret_was_set}
+  # Defines how often an event is sent to the output
+  period: 30s
+  runtime_cfg:
+    activated_rules:
+      cis_eks:
+        - cis_3_1_1
+        - cis_3_1_2
+        - cis_3_1_3
+        - cis_3_1_4
+        - cis_3_2_1
+        - cis_3_2_2
+        - cis_3_2_3
+        - cis_3_2_4
+        - cis_3_2_5
+        - cis_3_2_6
+        - cis_3_2_7
+        - cis_3_2_8
+        - cis_3_2_9
+        - cis_3_2_10
+        - cis_3_2_11
+        - cis_4_2_1
+        - cis_4_2_2
+        - cis_4_2_3
+        - cis_4_2_4
+        - cis_4_2_5
+        - cis_4_2_6
+        - cis_4_2_7
+        - cis_4_2_8
+        - cis_4_2_9
+        - cis_5_1_1
+        - cis_5_4_3
+        - cis_5_4_5
+  fetchers:
+    - name: kube-api
+    - name: process
+      directory: "/hostfs"
+      processes:
+        kubelet:
+          config-file-arguments:
+            - config
+    - name: aws-ecr
+    - name: aws-elb
+    - name: file-system
+      patterns: [
+        "/hostfs/etc/kubernetes/kubelet/kubelet-config.json",
+        "/hostfs/var/lib/kubelet/kubeconfig",
+      ]
 # =================================== Kibana ===================================
 setup.kibana:
 

--- a/deploy/kustomize/overlays/cloudbeat-vanilla/cloudbeat.yml
+++ b/deploy/kustomize/overlays/cloudbeat-vanilla/cloudbeat.yml
@@ -1,132 +1,131 @@
 cloudbeat:
   type: cloudbeat/cis_k8s
-  streams:
     # Defines how often an event is sent to the output
-    - period: 30s
-      runtime_cfg:
-        activated_rules:
-          cis_k8s:
-            - cis_1_1_1
-            - cis_1_1_2
-            - cis_1_1_3
-            - cis_1_1_4
-            - cis_1_1_5
-            - cis_1_1_6
-            - cis_1_1_7
-            - cis_1_1_8
-            - cis_1_1_11
-            - cis_1_1_12
-            - cis_1_1_13
-            - cis_1_1_14
-            - cis_1_1_15
-            - cis_1_1_16
-            - cis_1_1_17
-            - cis_1_1_18
-            - cis_1_1_19
-            - cis_1_1_20
-            - cis_1_1_21
-            - cis_1_2_2
-            - cis_1_2_4
-            - cis_1_2_5
-            - cis_1_2_6
-            - cis_1_2_7
-            - cis_1_2_8
-            - cis_1_2_9
-            - cis_1_2_10
-            - cis_1_2_11
-            - cis_1_2_12
-            - cis_1_2_13
-            - cis_1_2_14
-            - cis_1_2_15
-            - cis_1_2_16
-            - cis_1_2_17
-            - cis_1_2_18
-            - cis_1_2_19
-            - cis_1_2_20
-            - cis_1_2_21
-            - cis_1_2_22
-            - cis_1_2_23
-            - cis_1_2_24
-            - cis_1_2_25
-            - cis_1_2_26
-            - cis_1_2_27
-            - cis_1_2_28
-            - cis_1_2_29
-            - cis_1_2_32
-            - cis_1_3_2
-            - cis_1_3_3
-            - cis_1_3_4
-            - cis_1_3_5
-            - cis_1_3_6
-            - cis_1_3_7
-            - cis_1_4_1
-            - cis_1_4_2
-            - cis_2_1
-            - cis_2_2
-            - cis_2_3
-            - cis_2_4
-            - cis_2_5
-            - cis_2_6
-            - cis_4_1_1
-            - cis_4_1_2
-            - cis_4_1_5
-            - cis_4_1_6
-            - cis_4_1_9
-            - cis_4_1_10
-            - cis_4_2_1
-            - cis_4_2_2
-            - cis_4_2_3
-            - cis_4_2_4
-            - cis_4_2_5
-            - cis_4_2_6
-            - cis_4_2_7
-            - cis_4_2_8
-            - cis_4_2_9
-            - cis_4_2_10
-            - cis_4_2_11
-            - cis_4_2_12
-            - cis_4_2_13
-            - cis_5_1_3
-            - cis_5_1_5
-            - cis_5_1_6
-            - cis_5_2_2
-            - cis_5_2_3
-            - cis_5_2_4
-            - cis_5_2_5
-            - cis_5_2_6
-            - cis_5_2_7
-            - cis_5_2_8
-            - cis_5_2_9
-            - cis_5_2_10
+  period: 30s
+  runtime_cfg:
+    activated_rules:
+      cis_k8s:
+        - cis_1_1_1
+        - cis_1_1_2
+        - cis_1_1_3
+        - cis_1_1_4
+        - cis_1_1_5
+        - cis_1_1_6
+        - cis_1_1_7
+        - cis_1_1_8
+        - cis_1_1_11
+        - cis_1_1_12
+        - cis_1_1_13
+        - cis_1_1_14
+        - cis_1_1_15
+        - cis_1_1_16
+        - cis_1_1_17
+        - cis_1_1_18
+        - cis_1_1_19
+        - cis_1_1_20
+        - cis_1_1_21
+        - cis_1_2_2
+        - cis_1_2_4
+        - cis_1_2_5
+        - cis_1_2_6
+        - cis_1_2_7
+        - cis_1_2_8
+        - cis_1_2_9
+        - cis_1_2_10
+        - cis_1_2_11
+        - cis_1_2_12
+        - cis_1_2_13
+        - cis_1_2_14
+        - cis_1_2_15
+        - cis_1_2_16
+        - cis_1_2_17
+        - cis_1_2_18
+        - cis_1_2_19
+        - cis_1_2_20
+        - cis_1_2_21
+        - cis_1_2_22
+        - cis_1_2_23
+        - cis_1_2_24
+        - cis_1_2_25
+        - cis_1_2_26
+        - cis_1_2_27
+        - cis_1_2_28
+        - cis_1_2_29
+        - cis_1_2_32
+        - cis_1_3_2
+        - cis_1_3_3
+        - cis_1_3_4
+        - cis_1_3_5
+        - cis_1_3_6
+        - cis_1_3_7
+        - cis_1_4_1
+        - cis_1_4_2
+        - cis_2_1
+        - cis_2_2
+        - cis_2_3
+        - cis_2_4
+        - cis_2_5
+        - cis_2_6
+        - cis_4_1_1
+        - cis_4_1_2
+        - cis_4_1_5
+        - cis_4_1_6
+        - cis_4_1_9
+        - cis_4_1_10
+        - cis_4_2_1
+        - cis_4_2_2
+        - cis_4_2_3
+        - cis_4_2_4
+        - cis_4_2_5
+        - cis_4_2_6
+        - cis_4_2_7
+        - cis_4_2_8
+        - cis_4_2_9
+        - cis_4_2_10
+        - cis_4_2_11
+        - cis_4_2_12
+        - cis_4_2_13
+        - cis_5_1_3
+        - cis_5_1_5
+        - cis_5_1_6
+        - cis_5_2_2
+        - cis_5_2_3
+        - cis_5_2_4
+        - cis_5_2_5
+        - cis_5_2_6
+        - cis_5_2_7
+        - cis_5_2_8
+        - cis_5_2_9
+        - cis_5_2_10
 
-      fetchers:
-        - name: kube-api
-        - name: process
-          directory: "/hostfs"
-          processes:
-            etcd:
-            kube-apiserver:
-            kube-controller:
-            kube-scheduler:
-            kubelet:
-              config-file-arguments:
-                - config
-        - name: file-system
-          patterns: [
-            "/hostfs/etc/kubernetes/scheduler.conf",
-            "/hostfs/etc/kubernetes/controller-manager.conf",
-            "/hostfs/etc/kubernetes/admin.conf",
-            "/hostfs/etc/kubernetes/kubelet.conf",
-            "/hostfs/etc/kubernetes/manifests/etcd.yaml",
-            "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
-            "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
-            "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
-            "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-            "/hostfs/etc/kubernetes/pki/*",
-            "/hostfs/var/lib/kubelet/config.yaml",
-            "/hostfs/var/lib/etcd",
-            "/hostfs/etc/kubernetes/pki"
-          ]
+  fetchers:
+    - name: kube-api
+    - name: process
+      directory: "/hostfs"
+      processes:
+        etcd:
+        kube-apiserver:
+        kube-controller:
+        kube-scheduler:
+        kubelet:
+          config-file-arguments:
+            - config
+    - name: file-system
+      patterns: [
+        "/hostfs/etc/kubernetes/scheduler.conf",
+        "/hostfs/etc/kubernetes/controller-manager.conf",
+        "/hostfs/etc/kubernetes/admin.conf",
+        "/hostfs/etc/kubernetes/kubelet.conf",
+        "/hostfs/etc/kubernetes/manifests/etcd.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
+        "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
+        "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
+        "/hostfs/etc/kubernetes/pki/*",
+        "/hostfs/var/lib/kubelet/config.yaml",
+        "/hostfs/var/lib/etcd",
+        "/hostfs/etc/kubernetes/pki"
+      ]
 # =================================== Kibana ===================================
 setup.kibana:
 

--- a/evaluator/opa.go
+++ b/evaluator/opa.go
@@ -63,7 +63,7 @@ var logPlugin = `
 		"%s": {}
 	}`
 
-func NewOpaEvaluator(ctx context.Context, log *logp.Logger, cfg config.Config) (Evaluator, error) {
+func NewOpaEvaluator(ctx context.Context, log *logp.Logger, cfg *config.Config) (Evaluator, error) {
 	// provide the OPA configuration which specifies
 	// fetching policy bundle and logging decisions locally to the console
 

--- a/evaluator/opa_test.go
+++ b/evaluator/opa_test.go
@@ -142,13 +142,11 @@ func (s *OpaTestSuite) TestOpaEvaluatorWithDecisionLogs() {
 	}
 }
 
-func (s *OpaTestSuite) getTestConfig() config.Config {
+func (s *OpaTestSuite) getTestConfig() *config.Config {
 	path, err := filepath.Abs("bundle.tar.gz")
 	s.NoError(err)
-	return config.Config{
-		Stream: config.Stream{
-			BundlePath: path,
-		},
+	return &config.Config{
+		BundlePath: path,
 	}
 }
 

--- a/justfile
+++ b/justfile
@@ -14,7 +14,7 @@ setup-env: create-kind-cluster elastic-stack-connect-kind
 create-vanilla-deployment-file:
    kustomize build {{kustomizeVanillaOverlay}} --output deploy/k8s/cloudbeat-ds.yaml
 
-build-deploy-cloudbeat: build-cloudbeat load-cloudbeat-image
+build-deploy-cloudbeat: build-cloudbeat load-cloudbeat-image deploy-cloudbeat
 
 build-load-both: build-deploy-cloudbeat load-pytest-kind
 

--- a/leaderelection/leaderelection.go
+++ b/leaderelection/leaderelection.go
@@ -23,6 +23,11 @@ package leaderelection
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/elastic/cloudbeat/config"
 	"github.com/elastic/cloudbeat/resources/providers"
 	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
@@ -33,10 +38,6 @@ import (
 	k8s "k8s.io/client-go/kubernetes"
 	le "k8s.io/client-go/tools/leaderelection"
 	rl "k8s.io/client-go/tools/leaderelection/resourcelock"
-	"os"
-	"strings"
-	"sync"
-	"time"
 )
 
 type ElectionManager interface {
@@ -53,7 +54,7 @@ type Manager struct {
 	kubeClient k8s.Interface
 }
 
-func NewLeaderElector(log *logp.Logger, cfg config.Config) (ElectionManager, error) {
+func NewLeaderElector(log *logp.Logger, cfg *config.Config) (ElectionManager, error) {
 	kubeClient, err := providers.KubernetesProvider{}.GetClient(cfg.KubeConfig, kubernetes.KubeClientOptions{})
 	if err != nil {
 		log.Errorf("NewLeaderElector error in GetClient: %v", err)

--- a/resources/fetchersManager/factory.go
+++ b/resources/fetchersManager/factory.go
@@ -60,7 +60,7 @@ func (fa *factories) CreateFetcher(log *logp.Logger, name string, c *agentconfig
 	return factory.Create(log, c, ch)
 }
 
-func (fa *factories) ParseConfigFetchers(log *logp.Logger, cfg config.Config, ch chan fetching.ResourceInfo) ([]*ParsedFetcher, error) {
+func (fa *factories) ParseConfigFetchers(log *logp.Logger, cfg *config.Config, ch chan fetching.ResourceInfo) ([]*ParsedFetcher, error) {
 	var arr []*ParsedFetcher
 
 	for _, fcfg := range cfg.Fetchers {
@@ -94,7 +94,7 @@ func (fa *factories) parseConfigFetcher(log *logp.Logger, fcfg *agentconfig.C, c
 // addCredentialsToFetcherConfiguration adds the relevant credentials to the `fcfg`- the fetcher config
 // This function takes the configuration file provided by the integration the `cfg` file
 // and depending on the input type, extract the relevant credentials and add them to the fetcher config
-func addCredentialsToFetcherConfiguration(log *logp.Logger, cfg config.Config, fcfg *agentconfig.C) {
+func addCredentialsToFetcherConfiguration(log *logp.Logger, cfg *config.Config, fcfg *agentconfig.C) {
 	if cfg.Type == config.InputTypeEks {
 		err := fcfg.Merge(cfg.AWSConfig)
 		if err != nil {

--- a/resources/fetchersManager/factory_aws_test.go
+++ b/resources/fetchersManager/factory_aws_test.go
@@ -19,6 +19,7 @@ package fetchersManager
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 	"github.com/elastic/cloudbeat/config"
@@ -166,16 +167,12 @@ func (s *FactoriesTestSuite) TestRegisterFetchersWithAwsCredentials() {
 	}
 }
 
-func createEksAgentConfig(s *FactoriesTestSuite, awsConfig aws.ConfigAWS, fetcherName string) config.Config {
-	conf := config.Config{Type: config.InputTypeEks}
-	fetcherConfig := agentconfig.NewConfig()
-	err := fetcherConfig.SetString("name", -1, fetcherName)
-	s.NoError(err)
-
-	conf.Stream = config.Stream{
+func createEksAgentConfig(s *FactoriesTestSuite, awsConfig aws.ConfigAWS, fetcherName string) *config.Config {
+	conf := &config.Config{
+		Type:       config.InputTypeEks,
 		AWSConfig:  awsConfig,
 		RuntimeCfg: nil,
-		Fetchers:   []*agentconfig.C{fetcherConfig},
+		Fetchers:   []*agentconfig.C{agentconfig.MustNewConfigFrom(fmt.Sprint("name: ", fetcherName))},
 	}
 
 	return conf

--- a/resources/fetchersManager/factory_test.go
+++ b/resources/fetchersManager/factory_test.go
@@ -172,8 +172,8 @@ func (s *FactoriesTestSuite) TestRegisterFetchers() {
 		err := numCfg.SetString("name", -1, test.key)
 		s.NoError(err, "Could not set name: %v", err)
 
-		conf := config.Config{Type: test.integrationType}
-		conf.Stream.Fetchers = []*agentconfig.C{numCfg}
+		conf := &config.Config{Type: test.integrationType}
+		conf.Fetchers = []*agentconfig.C{numCfg}
 
 		parsedList, err := s.F.ParseConfigFetchers(s.log, conf, s.resourceCh)
 		s.NoError(err)
@@ -201,12 +201,12 @@ func (s *FactoriesTestSuite) TestRegisterNotFoundFetchers() {
 	}
 
 	for _, test := range tests {
-		conf := config.Config{}
+		conf := &config.Config{}
 		numCfg := numberConfig(test.value)
 		err := numCfg.SetString("name", -1, test.key)
 		s.NoError(err, "Could not set name: %v", err)
 
-		conf.Stream.Fetchers = []*agentconfig.C{numCfg}
+		conf.Fetchers = []*agentconfig.C{numCfg}
 
 		_, err = s.F.ParseConfigFetchers(s.log, conf, s.resourceCh)
 		s.Error(err)

--- a/tests/deploy/cloudbeat-eks-pytest.yaml
+++ b/tests/deploy/cloudbeat-eks-pytest.yaml
@@ -173,56 +173,55 @@ data:
   cloudbeat.yml: |
     cloudbeat:
       type: cloudbeat/cis_eks
-      streams:
-        - access_key_id: ${AWS_ACCESS_KEY_ID:no_access_key_was_set}
-          secret_access_key: ${AWS_SECRET_ACCESS_KEY:no_secret_was_set}
-          # Defines how often an event is sent to the output
-          period: 30s
-          fetchers:
-            - name: kube-api
-            - name: process
-              directory: "/hostfs"
-              processes:
-                kubelet:
-                  config-file-arguments:
-                    - config
-            - name: aws-ecr
-            - name: aws-elb
-            - name: file-system
-              patterns: [
-                "/hostfs/etc/kubernetes/kubelet/kubelet-config.json",
-                "/hostfs/var/lib/kubelet/kubeconfig",
-              ]
-          runtime_cfg:
-            activated_rules:
-              cis_eks:
-                - cis_3_1_1
-                - cis_3_1_2
-                - cis_3_1_3
-                - cis_3_1_4
-                - cis_3_2_1
-                - cis_3_2_2
-                - cis_3_2_3
-                - cis_3_2_4
-                - cis_3_2_5
-                - cis_3_2_6
-                - cis_3_2_7
-                - cis_3_2_8
-                - cis_3_2_9
-                - cis_3_2_10
-                - cis_3_2_11
-                - cis_4_2_1
-                - cis_4_2_2
-                - cis_4_2_3
-                - cis_4_2_4
-                - cis_4_2_5
-                - cis_4_2_6
-                - cis_4_2_7
-                - cis_4_2_8
-                - cis_4_2_9
-                - cis_5_1_1
-                - cis_5_4_3
-                - cis_5_4_5
+      access_key_id: ${AWS_ACCESS_KEY_ID:no_access_key_was_set}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:no_secret_was_set}
+      # Defines how often an event is sent to the output
+      period: 30s
+      fetchers:
+        - name: kube-api
+        - name: process
+          directory: "/hostfs"
+          processes:
+            kubelet:
+              config-file-arguments:
+                - config
+        - name: aws-ecr
+        - name: aws-elb
+        - name: file-system
+          patterns: [
+            "/hostfs/etc/kubernetes/kubelet/kubelet-config.json",
+            "/hostfs/var/lib/kubelet/kubeconfig",
+          ]
+      runtime_cfg:
+        activated_rules:
+          cis_eks:
+            - cis_3_1_1
+            - cis_3_1_2
+            - cis_3_1_3
+            - cis_3_1_4
+            - cis_3_2_1
+            - cis_3_2_2
+            - cis_3_2_3
+            - cis_3_2_4
+            - cis_3_2_5
+            - cis_3_2_6
+            - cis_3_2_7
+            - cis_3_2_8
+            - cis_3_2_9
+            - cis_3_2_10
+            - cis_3_2_11
+            - cis_4_2_1
+            - cis_4_2_2
+            - cis_4_2_3
+            - cis_4_2_4
+            - cis_4_2_5
+            - cis_4_2_6
+            - cis_4_2_7
+            - cis_4_2_8
+            - cis_4_2_9
+            - cis_5_1_1
+            - cis_5_4_3
+            - cis_5_4_5
     # =================================== Kibana ===================================
     setup.kibana:
 

--- a/tests/deploy/cloudbeat-pytest.yml
+++ b/tests/deploy/cloudbeat-pytest.yml
@@ -143,132 +143,131 @@ data:
   cloudbeat.yml: |-
     cloudbeat:
       type: cloudbeat/cis_k8s
-      streams:
-          # Defines how often an event is sent to the output
-        - period: 30s
-          fetchers:
-            - name: kube-api
-            - name: process
-              directory: "/hostfs"
-              processes:
-                etcd:
-                kube-apiserver:
-                kube-controller:
-                kube-scheduler:
-                kubelet:
-                  config-file-arguments:
-                    - config
-            - name: file-system
-              patterns: [
-                "/hostfs/etc/kubernetes/scheduler.conf",
-                "/hostfs/etc/kubernetes/controller-manager.conf",
-                "/hostfs/etc/kubernetes/admin.conf",
-                "/hostfs/etc/kubernetes/kubelet.conf",
-                "/hostfs/etc/kubernetes/manifests/etcd.yaml",
-                "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
-                "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
-                "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
-                "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-                "/hostfs/etc/kubernetes/pki/*",
-                "/hostfs/var/lib/kubelet/config.yaml",
-                "/hostfs/var/lib/etcd",
-                "/hostfs/etc/kubernetes/pki"
-              ]
-          runtime_cfg:
-            activated_rules:
-              cis_k8s:
-                - cis_1_1_1
-                - cis_1_1_2
-                - cis_1_1_3
-                - cis_1_1_4
-                - cis_1_1_5
-                - cis_1_1_6
-                - cis_1_1_7
-                - cis_1_1_8
-                - cis_1_1_11
-                - cis_1_1_12
-                - cis_1_1_13
-                - cis_1_1_14
-                - cis_1_1_15
-                - cis_1_1_16
-                - cis_1_1_17
-                - cis_1_1_18
-                - cis_1_1_19
-                - cis_1_1_20
-                - cis_1_1_21
-                - cis_1_2_2
-                - cis_1_2_4
-                - cis_1_2_5
-                - cis_1_2_6
-                - cis_1_2_7
-                - cis_1_2_8
-                - cis_1_2_9
-                - cis_1_2_10
-                - cis_1_2_11
-                - cis_1_2_12
-                - cis_1_2_13
-                - cis_1_2_14
-                - cis_1_2_15
-                - cis_1_2_16
-                - cis_1_2_17
-                - cis_1_2_18
-                - cis_1_2_19
-                - cis_1_2_20
-                - cis_1_2_21
-                - cis_1_2_22
-                - cis_1_2_23
-                - cis_1_2_24
-                - cis_1_2_25
-                - cis_1_2_26
-                - cis_1_2_27
-                - cis_1_2_28
-                - cis_1_2_29
-                - cis_1_2_32
-                - cis_1_3_2
-                - cis_1_3_3
-                - cis_1_3_4
-                - cis_1_3_5
-                - cis_1_3_6
-                - cis_1_3_7
-                - cis_1_4_1
-                - cis_1_4_2
-                - cis_2_1
-                - cis_2_2
-                - cis_2_3
-                - cis_2_4
-                - cis_2_5
-                - cis_2_6
-                - cis_4_1_1
-                - cis_4_1_2
-                - cis_4_1_5
-                - cis_4_1_6
-                - cis_4_1_9
-                - cis_4_1_10
-                - cis_4_2_1
-                - cis_4_2_2
-                - cis_4_2_3
-                - cis_4_2_4
-                - cis_4_2_5
-                - cis_4_2_6
-                - cis_4_2_7
-                - cis_4_2_8
-                - cis_4_2_9
-                - cis_4_2_10
-                - cis_4_2_11
-                - cis_4_2_12
-                - cis_4_2_13
-                - cis_5_1_3
-                - cis_5_1_5
-                - cis_5_1_6
-                - cis_5_2_2
-                - cis_5_2_3
-                - cis_5_2_4
-                - cis_5_2_5
-                - cis_5_2_6
-                - cis_5_2_7
-                - cis_5_2_8
-                - cis_5_2_9
-                - cis_5_2_10
+      # Defines how often an event is sent to the output
+      period: 30s
+      fetchers:
+        - name: kube-api
+        - name: process
+          directory: "/hostfs"
+          processes:
+            etcd:
+            kube-apiserver:
+            kube-controller:
+            kube-scheduler:
+            kubelet:
+              config-file-arguments:
+                - config
+        - name: file-system
+          patterns: [
+            "/hostfs/etc/kubernetes/scheduler.conf",
+            "/hostfs/etc/kubernetes/controller-manager.conf",
+            "/hostfs/etc/kubernetes/admin.conf",
+            "/hostfs/etc/kubernetes/kubelet.conf",
+            "/hostfs/etc/kubernetes/manifests/etcd.yaml",
+            "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
+            "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
+            "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
+            "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
+            "/hostfs/etc/kubernetes/pki/*",
+            "/hostfs/var/lib/kubelet/config.yaml",
+            "/hostfs/var/lib/etcd",
+            "/hostfs/etc/kubernetes/pki"
+          ]
+      runtime_cfg:
+        activated_rules:
+          cis_k8s:
+            - cis_1_1_1
+            - cis_1_1_2
+            - cis_1_1_3
+            - cis_1_1_4
+            - cis_1_1_5
+            - cis_1_1_6
+            - cis_1_1_7
+            - cis_1_1_8
+            - cis_1_1_11
+            - cis_1_1_12
+            - cis_1_1_13
+            - cis_1_1_14
+            - cis_1_1_15
+            - cis_1_1_16
+            - cis_1_1_17
+            - cis_1_1_18
+            - cis_1_1_19
+            - cis_1_1_20
+            - cis_1_1_21
+            - cis_1_2_2
+            - cis_1_2_4
+            - cis_1_2_5
+            - cis_1_2_6
+            - cis_1_2_7
+            - cis_1_2_8
+            - cis_1_2_9
+            - cis_1_2_10
+            - cis_1_2_11
+            - cis_1_2_12
+            - cis_1_2_13
+            - cis_1_2_14
+            - cis_1_2_15
+            - cis_1_2_16
+            - cis_1_2_17
+            - cis_1_2_18
+            - cis_1_2_19
+            - cis_1_2_20
+            - cis_1_2_21
+            - cis_1_2_22
+            - cis_1_2_23
+            - cis_1_2_24
+            - cis_1_2_25
+            - cis_1_2_26
+            - cis_1_2_27
+            - cis_1_2_28
+            - cis_1_2_29
+            - cis_1_2_32
+            - cis_1_3_2
+            - cis_1_3_3
+            - cis_1_3_4
+            - cis_1_3_5
+            - cis_1_3_6
+            - cis_1_3_7
+            - cis_1_4_1
+            - cis_1_4_2
+            - cis_2_1
+            - cis_2_2
+            - cis_2_3
+            - cis_2_4
+            - cis_2_5
+            - cis_2_6
+            - cis_4_1_1
+            - cis_4_1_2
+            - cis_4_1_5
+            - cis_4_1_6
+            - cis_4_1_9
+            - cis_4_1_10
+            - cis_4_2_1
+            - cis_4_2_2
+            - cis_4_2_3
+            - cis_4_2_4
+            - cis_4_2_5
+            - cis_4_2_6
+            - cis_4_2_7
+            - cis_4_2_8
+            - cis_4_2_9
+            - cis_4_2_10
+            - cis_4_2_11
+            - cis_4_2_12
+            - cis_4_2_13
+            - cis_5_1_3
+            - cis_5_1_5
+            - cis_5_1_6
+            - cis_5_2_2
+            - cis_5_2_3
+            - cis_5_2_4
+            - cis_5_2_5
+            - cis_5_2_6
+            - cis_5_2_7
+            - cis_5_2_8
+            - cis_5_2_9
+            - cis_5_2_10
 
       #    # EKS Fetchers configuration
       #      - name: kube-api

--- a/tests/deploy/k8s-cloudbeat-tests/templates/cloudbeat-ds.yml
+++ b/tests/deploy/k8s-cloudbeat-tests/templates/cloudbeat-ds.yml
@@ -137,134 +137,133 @@ data:
   cloudbeat.yml: |-
     cloudbeat:
       type: cloudbeat/cis_k8s
-      streams:
-        - access_key_id: ${AWS_ACCESS_KEY_ID:no_access_key_was_set}
-          secret_access_key: ${AWS_SECRET_ACCESS_KEY:no_secret_was_set}
-          # Defines how often an event is sent to the output
-          period: 30s
-          fetchers:
-            - name: kube-api
-            - name: process
-              directory: "/hostfs"
-              processes:
-                etcd:
-                kube-apiserver:
-                kube-controller:
-                kube-scheduler:
-                kubelet:
-                  config-file-arguments:
-                    - config
-            - name: file-system
-              patterns: [
-                "/hostfs/etc/kubernetes/scheduler.conf",
-                "/hostfs/etc/kubernetes/controller-manager.conf",
-                "/hostfs/etc/kubernetes/admin.conf",
-                "/hostfs/etc/kubernetes/kubelet.conf",
-                "/hostfs/etc/kubernetes/manifests/etcd.yaml",
-                "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
-                "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
-                "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
-                "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-                "/hostfs/etc/kubernetes/pki/*",
-                "/hostfs/var/lib/kubelet/config.yaml",
-                "/hostfs/var/lib/etcd",
-                "/hostfs/etc/kubernetes/pki"
-              ]
-          runtime_cfg:
-            activated_rules:
-              cis_k8s:
-                - cis_1_1_1
-                - cis_1_1_2
-                - cis_1_1_3
-                - cis_1_1_4
-                - cis_1_1_5
-                - cis_1_1_6
-                - cis_1_1_7
-                - cis_1_1_8
-                - cis_1_1_11
-                - cis_1_1_12
-                - cis_1_1_13
-                - cis_1_1_14
-                - cis_1_1_15
-                - cis_1_1_16
-                - cis_1_1_17
-                - cis_1_1_18
-                - cis_1_1_19
-                - cis_1_1_20
-                - cis_1_1_21
-                - cis_1_2_2
-                - cis_1_2_4
-                - cis_1_2_5
-                - cis_1_2_6
-                - cis_1_2_7
-                - cis_1_2_8
-                - cis_1_2_9
-                - cis_1_2_10
-                - cis_1_2_11
-                - cis_1_2_12
-                - cis_1_2_13
-                - cis_1_2_14
-                - cis_1_2_15
-                - cis_1_2_16
-                - cis_1_2_17
-                - cis_1_2_18
-                - cis_1_2_19
-                - cis_1_2_20
-                - cis_1_2_21
-                - cis_1_2_22
-                - cis_1_2_23
-                - cis_1_2_24
-                - cis_1_2_25
-                - cis_1_2_26
-                - cis_1_2_27
-                - cis_1_2_28
-                - cis_1_2_29
-                - cis_1_2_32
-                - cis_1_3_2
-                - cis_1_3_3
-                - cis_1_3_4
-                - cis_1_3_5
-                - cis_1_3_6
-                - cis_1_3_7
-                - cis_1_4_1
-                - cis_1_4_2
-                - cis_2_1
-                - cis_2_2
-                - cis_2_3
-                - cis_2_4
-                - cis_2_5
-                - cis_2_6
-                - cis_4_1_1
-                - cis_4_1_2
-                - cis_4_1_5
-                - cis_4_1_6
-                - cis_4_1_9
-                - cis_4_1_10
-                - cis_4_2_1
-                - cis_4_2_2
-                - cis_4_2_3
-                - cis_4_2_4
-                - cis_4_2_5
-                - cis_4_2_6
-                - cis_4_2_7
-                - cis_4_2_8
-                - cis_4_2_9
-                - cis_4_2_10
-                - cis_4_2_11
-                - cis_4_2_12
-                - cis_4_2_13
-                - cis_5_1_3
-                - cis_5_1_5
-                - cis_5_1_6
-                - cis_5_2_2
-                - cis_5_2_3
-                - cis_5_2_4
-                - cis_5_2_5
-                - cis_5_2_6
-                - cis_5_2_7
-                - cis_5_2_8
-                - cis_5_2_9
-                - cis_5_2_10
+      access_key_id: ${AWS_ACCESS_KEY_ID:no_access_key_was_set}
+      secret_access_key: ${AWS_SECRET_ACCESS_KEY:no_secret_was_set}
+      # Defines how often an event is sent to the output
+      period: 30s
+      fetchers:
+        - name: kube-api
+        - name: process
+          directory: "/hostfs"
+          processes:
+            etcd:
+            kube-apiserver:
+            kube-controller:
+            kube-scheduler:
+            kubelet:
+              config-file-arguments:
+                - config
+        - name: file-system
+          patterns: [
+            "/hostfs/etc/kubernetes/scheduler.conf",
+            "/hostfs/etc/kubernetes/controller-manager.conf",
+            "/hostfs/etc/kubernetes/admin.conf",
+            "/hostfs/etc/kubernetes/kubelet.conf",
+            "/hostfs/etc/kubernetes/manifests/etcd.yaml",
+            "/hostfs/etc/kubernetes/manifests/kube-apiserver.yaml",
+            "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
+            "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
+            "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
+            "/hostfs/etc/kubernetes/pki/*",
+            "/hostfs/var/lib/kubelet/config.yaml",
+            "/hostfs/var/lib/etcd",
+            "/hostfs/etc/kubernetes/pki"
+          ]
+      runtime_cfg:
+        activated_rules:
+          cis_k8s:
+            - cis_1_1_1
+            - cis_1_1_2
+            - cis_1_1_3
+            - cis_1_1_4
+            - cis_1_1_5
+            - cis_1_1_6
+            - cis_1_1_7
+            - cis_1_1_8
+            - cis_1_1_11
+            - cis_1_1_12
+            - cis_1_1_13
+            - cis_1_1_14
+            - cis_1_1_15
+            - cis_1_1_16
+            - cis_1_1_17
+            - cis_1_1_18
+            - cis_1_1_19
+            - cis_1_1_20
+            - cis_1_1_21
+            - cis_1_2_2
+            - cis_1_2_4
+            - cis_1_2_5
+            - cis_1_2_6
+            - cis_1_2_7
+            - cis_1_2_8
+            - cis_1_2_9
+            - cis_1_2_10
+            - cis_1_2_11
+            - cis_1_2_12
+            - cis_1_2_13
+            - cis_1_2_14
+            - cis_1_2_15
+            - cis_1_2_16
+            - cis_1_2_17
+            - cis_1_2_18
+            - cis_1_2_19
+            - cis_1_2_20
+            - cis_1_2_21
+            - cis_1_2_22
+            - cis_1_2_23
+            - cis_1_2_24
+            - cis_1_2_25
+            - cis_1_2_26
+            - cis_1_2_27
+            - cis_1_2_28
+            - cis_1_2_29
+            - cis_1_2_32
+            - cis_1_3_2
+            - cis_1_3_3
+            - cis_1_3_4
+            - cis_1_3_5
+            - cis_1_3_6
+            - cis_1_3_7
+            - cis_1_4_1
+            - cis_1_4_2
+            - cis_2_1
+            - cis_2_2
+            - cis_2_3
+            - cis_2_4
+            - cis_2_5
+            - cis_2_6
+            - cis_4_1_1
+            - cis_4_1_2
+            - cis_4_1_5
+            - cis_4_1_6
+            - cis_4_1_9
+            - cis_4_1_10
+            - cis_4_2_1
+            - cis_4_2_2
+            - cis_4_2_3
+            - cis_4_2_4
+            - cis_4_2_5
+            - cis_4_2_6
+            - cis_4_2_7
+            - cis_4_2_8
+            - cis_4_2_9
+            - cis_4_2_10
+            - cis_4_2_11
+            - cis_4_2_12
+            - cis_4_2_13
+            - cis_5_1_3
+            - cis_5_1_5
+            - cis_5_1_6
+            - cis_5_2_2
+            - cis_5_2_3
+            - cis_5_2_4
+            - cis_5_2_5
+            - cis_5_2_6
+            - cis_5_2_7
+            - cis_5_2_8
+            - cis_5_2_9
+            - cis_5_2_10
 
       #    # EKS Fetchers configuration
       #      - name: kube-api

--- a/transformer/common_data_provider.go
+++ b/transformer/common_data_provider.go
@@ -19,6 +19,7 @@ package transformer
 
 import (
 	"context"
+
 	"github.com/elastic/cloudbeat/config"
 	"github.com/elastic/cloudbeat/resources/fetchers"
 	"github.com/elastic/cloudbeat/resources/fetching"
@@ -36,7 +37,7 @@ const (
 
 var uuidNamespace = uuid.Must(uuid.FromString("971a1103-6b5d-4b60-ab3d-8a339a58c6c8"))
 
-func NewCommonDataProvider(log *logp.Logger, cfg config.Config) (CommonDataProvider, error) {
+func NewCommonDataProvider(log *logp.Logger, cfg *config.Config) (CommonDataProvider, error) {
 	KubeClient, err := providers.KubernetesProvider{}.GetClient(cfg.KubeConfig, kubernetes.KubeClientOptions{})
 	if err != nil {
 		log.Errorf("NewCommonDataProvider error in GetClient: %v", err)

--- a/transformer/common_data_provider_test.go
+++ b/transformer/common_data_provider_test.go
@@ -40,7 +40,7 @@ func TestCommonDataProvider_FetchCommonData(t *testing.T) {
 	cdProvider := CommonDataProvider{
 		log:        logp.NewLogger("cloudbeat_common_data_provider_test"),
 		kubeClient: k8sFake.NewSimpleClientset(),
-		cfg:        config.Config{},
+		cfg:        &config.Config{},
 	}
 
 	type args struct {

--- a/transformer/transformer.go
+++ b/transformer/transformer.go
@@ -33,7 +33,7 @@ type ResourceTypeMetadata struct {
 type CommonDataProvider struct {
 	log        *logp.Logger
 	kubeClient kubernetes.Interface
-	cfg        config.Config
+	cfg        *config.Config
 }
 
 type CommonData struct {


### PR DESCRIPTION
**What does this PR do?**
As part of elastic-agent V2 changes, the beat no longer receives configuration as an array of streams (where only the first one is populated). Instead, it accepts the config itself right away.
This PR removes the stream abstraction from our code for all different running methods.

**Related Issues**
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

**Checklist**
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
