### PR TITLE
Pin GH workers ubuntu image to 20.04

### DIFF
--- a/.github/workflows/Periodic-CI.yml
+++ b/.github/workflows/Periodic-CI.yml
@@ -29,7 +29,7 @@ permissions:
   statuses: read
 jobs:
   Setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     timeout-minutes: 15
@@ -70,7 +70,7 @@ jobs:
 
   Build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     steps:
       - name: Check out the repo
@@ -162,7 +162,7 @@ jobs:
       matrix:
         test-target: ${{fromJson(needs.Setup.outputs.matrix)}}
     name: ${{ matrix.test-target }}-tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     steps:
       - name: Check out the repo
@@ -218,7 +218,7 @@ jobs:
     name: Publish Results
     needs: Test_Matrix
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/cloudbeat-ci.yml
+++ b/.github/workflows/cloudbeat-ci.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   Build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     steps:
       - name: Check out the repo
@@ -100,7 +100,7 @@ jobs:
   Test_Matrix:
     name: ${{ matrix.test-target }}-${{ matrix.range }}-tests
     needs: [Build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 55
     strategy:
       matrix:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   packag_beat:
     name: Package Cloudbeat
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -10,7 +10,7 @@ jobs:
   publish_results:
     timeout-minutes: 15
     name: Publish Results
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.event.workflow_run.conclusion != 'skipped'
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   unit_tests:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     steps:
       - name: Check out the repo
@@ -59,7 +59,7 @@ jobs:
   coverage:
     name: Coverage report
     needs: unit_tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
       - name: Check out the repo
@@ -83,7 +83,7 @@ jobs:
 
   manifest_tests:
     name: Manifest Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     steps:
       - name: Check out the repo
@@ -105,7 +105,7 @@ jobs:
 
   golangci:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 15
     steps:
       - name: Check out the repo
@@ -129,7 +129,7 @@ jobs:
           args: --timeout=10m --whole-files
 
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout Repository

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,6 @@ bench:
 
 #update: go-generate add-headers build-package notice $(MAGE)
 update: go-generate add-headers $(MAGE)
-	@$(MAGE) update
 	@go mod download all # make sure go.sum is complete
 
 config:

--- a/go.mod
+++ b/go.mod
@@ -267,3 +267,5 @@ replace (
 	github.com/golang/glog => github.com/elastic/glog v1.0.1-0.20210831205241-7d8b5c89dfc4
 	github.com/google/gopacket => github.com/elastic/gopacket v1.1.20-0.20211202005954-d412fca7f83a
 )
+
+exclude github.com/elastic/elastic-agent v0.0.0-20220831162706-5f1e54f40d3e


### PR DESCRIPTION
**What does this PR do?**
- Pin GH workers' ubuntu image to 20.04
- Exclude elastic-agent from our dependencies see https://github.com/elastic/apm-server/pull/9668 for ref

**Related Issues**
- Fixes: https://github.com/elastic/cloudbeat/issues/546


**Checklist**
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
