### PR TITLE
Cloudformation script for elastic-agent on EC2

### DIFF
--- a/deploy/cloudformation/elastic-agent-ec2.yml
+++ b/deploy/cloudformation/elastic-agent-ec2.yml
@@ -1,0 +1,200 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Creates an EC2 instance with permissions to run elastic-agent
+
+Parameters:
+  LatestAmiId:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/canonical/ubuntu/server/jammy/stable/current/amd64/hvm/ebs-gp2/ami-id'
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Description: SSH Keypair to login to the instance
+    Default: amir-build
+  InstanceType:
+    Type: String
+    Default: t2.micro
+    AllowedValues:
+    - t2.micro
+    - t2.small
+    - t2.medium
+    Description: The type of EC2 instance to create
+  EnrollmentToken:
+    Type: String
+    Description: The enrollment token of elasitc-agent
+  FleetUrl:
+    Type: String
+    Description: The fleet URL of elastic-agent
+  ElasticAgentVersion:
+    Type: String
+    Description: The version of elastic-agent to install
+    Default: elastic-agent-8.5.0-linux-x86_64
+
+Resources:
+  # Security Group for EC2 instance
+  ElasticAgentSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupName: elastic-agent-security-group
+      GroupDescription: Allow incoming SSH traffic
+      VpcId: !Ref ElasticAgentVpc
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp: 0.0.0.0/0
+
+  # Subnet for EC2 instance
+  ElasticAgentSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref ElasticAgentVpc
+      CidrBlock: 192.168.0.0/24
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: Ealstic Agent
+
+  # VPC for EC2 instance
+  ElasticAgentVpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 192.168.0.0/24
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      Tags:
+        - Key: Name
+          Value: Ealstic Agent
+
+  # Internet Gateway for VPC
+  ElasticAgentInternetGateway:
+    Type: AWS::EC2::InternetGateway
+    DependsOn: ElasticAgentVpc
+    Properties:
+      Tags:
+        - Key: Name
+          Value: Ealstic Agent
+
+  # Internet Attachment for VPC
+  ElasticAgentAttachGateway:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref ElasticAgentVpc
+      InternetGatewayId: !Ref ElasticAgentInternetGateway
+
+  ElasticAgentSubnetRouteTable:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties: 
+      RouteTableId: !Ref ElasticAgentRouteTable
+      SubnetId: !Ref ElasticAgentSubnet
+
+  ElasticAgentRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref ElasticAgentVpc
+      Tags:
+        - Key: Name
+          Value: Elastic Agent Public Routes
+
+  DefaultPublicRoute:
+    Type: AWS::EC2::Route
+    DependsOn: ElasticAgentAttachGateway
+    Properties:
+      RouteTableId: !Ref ElasticAgentRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref ElasticAgentInternetGateway
+
+  # IAM Role for EC2 instance
+  ElasticAgentRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service:
+            - ec2.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: /
+      Policies:
+      - PolicyName: snapshot-permissions
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Action:
+            - ec2:CreateSnapshot
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - ec2:DescribeSnapshots
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - ec2:DescribeInstances
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - ec2:DescribeImages
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - ec2:DescribeTags
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - ec2:DescribeSnapshots
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - ebs:ListSnapshotBlocks
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - ebs:ListChangedBlocks
+            Resource: "*"
+          - Effect: Allow
+            Action:
+            - ebs:GetSnapshotBlock
+            Resource: "*"
+
+  # Instance profile to attach to EC2 instance
+  ElasticAgentInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties: 
+      InstanceProfileName: elastic-agent-instance-profile
+      Path: /
+      Roles: 
+       - !Ref ElasticAgentRole
+
+  # EC2 Instance to run elastic-agent
+  ElasticAgentEc2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      ImageId: !Ref LatestAmiId
+      InstanceType: !Ref InstanceType
+      IamInstanceProfile: !Ref ElasticAgentInstanceProfile
+      KeyName: !Ref KeyName
+      NetworkInterfaces:
+      - DeviceIndex: 0
+        AssociatePublicIpAddress: true
+        SubnetId: !Ref ElasticAgentSubnet
+        GroupSet:
+        - !Ref ElasticAgentSecurityGroup
+      UserData:
+        Fn::Base64: 
+          !Sub |
+            #!/bin/bash
+            curl -L -O https://artifacts.elastic.co/downloads/beats/elastic-agent/${ElasticAgentVersion}.tar.gz
+            tar xzvf ${ElasticAgentVersion}.tar.gz
+            cd ${ElasticAgentVersion}
+            sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken}
+
+Outputs:
+  Ec2InstanceId:
+    Value: !Ref ElasticAgentEc2Instance
+    Description: The EC2 instance ID
+  Ec2InstancePublicIp:
+    Value: !GetAtt ElasticAgentEc2Instance.PublicIp
+    Description: The EC2 instance public IP


### PR DESCRIPTION
**What does this PR do?**
Add CloudFormation script for deploying elastic-agent on an EC2 instance.
The script creates a role for that EC2 with the relevant permissions to run vulnerability management and attaches the newly created role to the EC2.
The EC2 instance will be accessed by ssh from everywhere given the ssh key.

**Related Issues**
- Resolves: https://github.com/elastic/security-team/issues/5659

**Checklist**
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
