### PR TITLE
Move launcher errors under launcher package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,8 +26,7 @@ import (
 	"path/filepath"
 	"time"
 
-	cb_errors "github.com/elastic/cloudbeat/errors"
-
+	"github.com/elastic/cloudbeat/launcher"
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/beats/v7/libbeat/processors"
@@ -41,7 +40,7 @@ const DefaultNamespace = "default"
 
 const ResultsDatastreamIndexPrefix = "logs-cloud_security_posture.findings"
 
-var ErrBenchmarkNotSupported = cb_errors.NewUnhealthyError("benchmark is not supported")
+var ErrBenchmarkNotSupported = launcher.NewUnhealthyError("benchmark is not supported")
 
 type Fetcher struct {
 	Name string `config:"name"` // Name of the fetcher

--- a/launcher/errors.go
+++ b/launcher/errors.go
@@ -18,21 +18,20 @@
 // Config is put into a different package to prevent cyclic imports in case
 // it is needed in several locations
 
-package errors
+package launcher
 
-import (
-	"errors"
-	"fmt"
-	"testing"
+// BeaterUnhealthyError error is an error that is desgined to have an information that
+// can help to end user to operate cloudbeat health issues.
+// For example, when a cloudbeat configuration is invalid, the error will include
+// more information about what is missing/expected and might have links to external sources as well
+type BeaterUnhealthyError struct {
+	msg string
+}
 
-	"github.com/stretchr/testify/assert"
-)
+func NewUnhealthyError(msg string) BeaterUnhealthyError {
+	return BeaterUnhealthyError{msg}
+}
 
-func TestUnwrapError(t *testing.T) {
-	e1 := NewUnhealthyError("error_1")
-	e2 := fmt.Errorf("error 2 = %w", e1)
-	healthErr := &BeaterUnhealthyError{}
-	assert.False(t, errors.Is(e1, healthErr))
-	assert.True(t, errors.As(e2, healthErr))
-	assert.Equal(t, "error_1", healthErr.Error())
+func (c BeaterUnhealthyError) Error() string {
+	return c.msg
 }

--- a/launcher/errors_test.go
+++ b/launcher/errors_test.go
@@ -18,20 +18,21 @@
 // Config is put into a different package to prevent cyclic imports in case
 // it is needed in several locations
 
-package errors
+package launcher
 
-// BeaterUnhealthyError error is an error that is desgined to have an information that
-// can help to end user to operate cloudbeat health issues.
-// For example, when a cloudbeat configuration is invalid, the error will include
-// more information about what is missing/expected and might have links to external sources as well
-type BeaterUnhealthyError struct {
-	msg string
-}
+import (
+	"errors"
+	"fmt"
+	"testing"
 
-func NewUnhealthyError(msg string) BeaterUnhealthyError {
-	return BeaterUnhealthyError{msg}
-}
+	"github.com/stretchr/testify/assert"
+)
 
-func (c BeaterUnhealthyError) Error() string {
-	return c.msg
+func TestUnwrapError(t *testing.T) {
+	e1 := NewUnhealthyError("error_1")
+	e2 := fmt.Errorf("error 2 = %w", e1)
+	healthErr := &BeaterUnhealthyError{}
+	assert.False(t, errors.Is(e1, healthErr))
+	assert.True(t, errors.As(e2, healthErr))
+	assert.Equal(t, "error_1", healthErr.Error())
 }

--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -241,7 +241,7 @@ func (l *launcher) reconfigureWait(timeout time.Duration) (*config.C, error) {
 				err := l.validator.Validate(update)
 				if err != nil {
 					l.log.Errorf("Config update validation failed: %v", err)
-					heatlhErr := &BeaterUnhealthyError{}
+					healthErr := &BeaterUnhealthyError{}
 					if errors.As(err, heatlhErr) {
 						l.beat.Manager.UpdateStatus(management.Degraded, heatlhErr.Error())
 					}

--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -242,8 +242,8 @@ func (l *launcher) reconfigureWait(timeout time.Duration) (*config.C, error) {
 				if err != nil {
 					l.log.Errorf("Config update validation failed: %v", err)
 					healthErr := &BeaterUnhealthyError{}
-					if errors.As(err, heatlhErr) {
-						l.beat.Manager.UpdateStatus(management.Degraded, heatlhErr.Error())
+					if errors.As(err, healthErr) {
+						l.beat.Manager.UpdateStatus(management.Degraded, healthErr.Error())
 					}
 					continue
 				}

--- a/launcher/launcher.go
+++ b/launcher/launcher.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/management"
-	cb_errors "github.com/elastic/cloudbeat/errors"
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/go-ucfg"
@@ -242,7 +241,7 @@ func (l *launcher) reconfigureWait(timeout time.Duration) (*config.C, error) {
 				err := l.validator.Validate(update)
 				if err != nil {
 					l.log.Errorf("Config update validation failed: %v", err)
-					heatlhErr := &cb_errors.BeaterUnhealthyError{}
+					heatlhErr := &BeaterUnhealthyError{}
 					if errors.As(err, heatlhErr) {
 						l.beat.Manager.UpdateStatus(management.Degraded, heatlhErr.Error())
 					}


### PR DESCRIPTION
**What does this PR do?**
Moving launcher errors to be defined on the same package as the launcher.
The motivation behind maintaining the two on the same package is that the launcher already has the errors as a dependency. The launcher can report a different status to the fleet based on the returned error. Which means, the errors better be defined on the same package.


**Related Issues**
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

**Checklist**
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
