### PR TITLE
fix cloudbeat commit SHA field format

### DIFF
--- a/version/settings.go
+++ b/version/settings.go
@@ -47,7 +47,7 @@ func cloudbeatCommitHash() string {
 
 // cloudbeatCommitTime returns the timestamp of the commit used for the build.
 func cloudbeatCommitTime() string {
-	return vcsTime.String()
+	return vcsTime.Format(time.RFC3339Nano)
 }
 
 // CloudbeatSemanticVersion returns the current cloudbeat version.


### PR DESCRIPTION
**What does this PR do?**
Fixing commit SHA time format to support mapping it in ES as `date` type

**Related Issues**

- Related: https://github.com/elastic/integrations/pull/4923

**Screenshots**

<img width="566" alt="image" src="https://user-images.githubusercontent.com/85433724/210395918-abddb989-5102-47e8-82ce-997d49afd7aa.png">
<img width="305" alt="image" src="https://user-images.githubusercontent.com/85433724/210395976-cf1761b0-beeb-41cd-8f2d-b34ae7783849.png">


**Checklist**
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
