### PR TITLE
Enrich decision log message with OPA fields

### DIFF
--- a/evaluator/debug_logger/plugin.go
+++ b/evaluator/debug_logger/plugin.go
@@ -70,8 +70,24 @@ func (p *plugin) Log(ctx context.Context, event logs.EventV1) error {
 		p.manager.UpdatePluginStatus(PluginName, &plugins.Status{State: plugins.StateErr})
 		return nil
 	}
+
+	messageFields := createMessage(event)
+	messageBytes, err := json.Marshal(messageFields)
+	if err != nil {
+		p.manager.UpdatePluginStatus(PluginName, &plugins.Status{State: plugins.StateErr})
+		return nil
+	}
 	p.manager.ConsoleLogger().WithFields(fields).WithFields(map[string]interface{}{
 		"type": "openpolicyagent.org/decision_logs",
-	}).Debug("Decision Log")
+	}).Debug(string(messageBytes))
 	return nil
+}
+
+func createMessage(event logs.EventV1) map[string]interface{} {
+	return map[string]interface{}{
+		"decision_id": event.DecisionID,
+		"message":     "Decision Log",
+		"input":       event.Input,
+		"result":      event.Result,
+	}
 }

--- a/evaluator/opa_test.go
+++ b/evaluator/opa_test.go
@@ -151,5 +151,5 @@ func (s *OpaTestSuite) getTestConfig() *config.Config {
 }
 
 func findDecisionLogs() []observer.LoggedEntry {
-	return logp.ObserverLogs().FilterMessage("Decision Log").TakeAll()
+	return logp.ObserverLogs().FilterMessageSnippet("Decision Log").TakeAll()
 }


### PR DESCRIPTION
**What does this PR do?**
Add more information about the decision log cloudbeat prints.
- decision id
- decision input
- decision result

**Related Issues**
Resolves https://github.com/elastic/cloudbeat/issues/533

**Checklist**
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
