### PR TITLE
Add policy data to the IAM user [CSPM]

### DIFF
--- a/resources/providers/awslib/iam/client_mock.go
+++ b/resources/providers/awslib/iam/client_mock.go
@@ -349,6 +349,68 @@ func (_c *MockClient_GetRolePolicy_Call) Return(_a0 *serviceiam.GetRolePolicyOut
 	return _c
 }
 
+// GetUserPolicy provides a mock function with given fields: ctx, params, optFns
+func (_m *MockClient) GetUserPolicy(ctx context.Context, params *serviceiam.GetUserPolicyInput, optFns ...func(*serviceiam.Options)) (*serviceiam.GetUserPolicyOutput, error) {
+	_va := make([]interface{}, len(optFns))
+	for _i := range optFns {
+		_va[_i] = optFns[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, params)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *serviceiam.GetUserPolicyOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *serviceiam.GetUserPolicyInput, ...func(*serviceiam.Options)) *serviceiam.GetUserPolicyOutput); ok {
+		r0 = rf(ctx, params, optFns...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceiam.GetUserPolicyOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *serviceiam.GetUserPolicyInput, ...func(*serviceiam.Options)) error); ok {
+		r1 = rf(ctx, params, optFns...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClient_GetUserPolicy_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetUserPolicy'
+type MockClient_GetUserPolicy_Call struct {
+	*mock.Call
+}
+
+// GetUserPolicy is a helper method to define mock.On call
+//   - ctx context.Context
+//   - params *serviceiam.GetUserPolicyInput
+//   - optFns ...func(*serviceiam.Options)
+func (_e *MockClient_Expecter) GetUserPolicy(ctx interface{}, params interface{}, optFns ...interface{}) *MockClient_GetUserPolicy_Call {
+	return &MockClient_GetUserPolicy_Call{Call: _e.mock.On("GetUserPolicy",
+		append([]interface{}{ctx, params}, optFns...)...)}
+}
+
+func (_c *MockClient_GetUserPolicy_Call) Run(run func(ctx context.Context, params *serviceiam.GetUserPolicyInput, optFns ...func(*serviceiam.Options))) *MockClient_GetUserPolicy_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]func(*serviceiam.Options), len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(func(*serviceiam.Options))
+			}
+		}
+		run(args[0].(context.Context), args[1].(*serviceiam.GetUserPolicyInput), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClient_GetUserPolicy_Call) Return(_a0 *serviceiam.GetUserPolicyOutput, _a1 error) *MockClient_GetUserPolicy_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
 // ListAccessKeys provides a mock function with given fields: ctx, params, optFns
 func (_m *MockClient) ListAccessKeys(ctx context.Context, params *serviceiam.ListAccessKeysInput, optFns ...func(*serviceiam.Options)) (*serviceiam.ListAccessKeysOutput, error) {
 	_va := make([]interface{}, len(optFns))
@@ -473,6 +535,68 @@ func (_c *MockClient_ListAttachedRolePolicies_Call) Return(_a0 *serviceiam.ListA
 	return _c
 }
 
+// ListAttachedUserPolicies provides a mock function with given fields: ctx, params, optFns
+func (_m *MockClient) ListAttachedUserPolicies(ctx context.Context, params *serviceiam.ListAttachedUserPoliciesInput, optFns ...func(*serviceiam.Options)) (*serviceiam.ListAttachedUserPoliciesOutput, error) {
+	_va := make([]interface{}, len(optFns))
+	for _i := range optFns {
+		_va[_i] = optFns[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, params)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *serviceiam.ListAttachedUserPoliciesOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *serviceiam.ListAttachedUserPoliciesInput, ...func(*serviceiam.Options)) *serviceiam.ListAttachedUserPoliciesOutput); ok {
+		r0 = rf(ctx, params, optFns...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceiam.ListAttachedUserPoliciesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *serviceiam.ListAttachedUserPoliciesInput, ...func(*serviceiam.Options)) error); ok {
+		r1 = rf(ctx, params, optFns...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClient_ListAttachedUserPolicies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAttachedUserPolicies'
+type MockClient_ListAttachedUserPolicies_Call struct {
+	*mock.Call
+}
+
+// ListAttachedUserPolicies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - params *serviceiam.ListAttachedUserPoliciesInput
+//   - optFns ...func(*serviceiam.Options)
+func (_e *MockClient_Expecter) ListAttachedUserPolicies(ctx interface{}, params interface{}, optFns ...interface{}) *MockClient_ListAttachedUserPolicies_Call {
+	return &MockClient_ListAttachedUserPolicies_Call{Call: _e.mock.On("ListAttachedUserPolicies",
+		append([]interface{}{ctx, params}, optFns...)...)}
+}
+
+func (_c *MockClient_ListAttachedUserPolicies_Call) Run(run func(ctx context.Context, params *serviceiam.ListAttachedUserPoliciesInput, optFns ...func(*serviceiam.Options))) *MockClient_ListAttachedUserPolicies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]func(*serviceiam.Options), len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(func(*serviceiam.Options))
+			}
+		}
+		run(args[0].(context.Context), args[1].(*serviceiam.ListAttachedUserPoliciesInput), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClient_ListAttachedUserPolicies_Call) Return(_a0 *serviceiam.ListAttachedUserPoliciesOutput, _a1 error) *MockClient_ListAttachedUserPolicies_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
 // ListMFADevices provides a mock function with given fields: ctx, params, optFns
 func (_m *MockClient) ListMFADevices(ctx context.Context, params *serviceiam.ListMFADevicesInput, optFns ...func(*serviceiam.Options)) (*serviceiam.ListMFADevicesOutput, error) {
 	_va := make([]interface{}, len(optFns))
@@ -531,6 +655,68 @@ func (_c *MockClient_ListMFADevices_Call) Run(run func(ctx context.Context, para
 }
 
 func (_c *MockClient_ListMFADevices_Call) Return(_a0 *serviceiam.ListMFADevicesOutput, _a1 error) *MockClient_ListMFADevices_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+// ListUserPolicies provides a mock function with given fields: ctx, params, optFns
+func (_m *MockClient) ListUserPolicies(ctx context.Context, params *serviceiam.ListUserPoliciesInput, optFns ...func(*serviceiam.Options)) (*serviceiam.ListUserPoliciesOutput, error) {
+	_va := make([]interface{}, len(optFns))
+	for _i := range optFns {
+		_va[_i] = optFns[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, params)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *serviceiam.ListUserPoliciesOutput
+	if rf, ok := ret.Get(0).(func(context.Context, *serviceiam.ListUserPoliciesInput, ...func(*serviceiam.Options)) *serviceiam.ListUserPoliciesOutput); ok {
+		r0 = rf(ctx, params, optFns...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceiam.ListUserPoliciesOutput)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *serviceiam.ListUserPoliciesInput, ...func(*serviceiam.Options)) error); ok {
+		r1 = rf(ctx, params, optFns...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClient_ListUserPolicies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListUserPolicies'
+type MockClient_ListUserPolicies_Call struct {
+	*mock.Call
+}
+
+// ListUserPolicies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - params *serviceiam.ListUserPoliciesInput
+//   - optFns ...func(*serviceiam.Options)
+func (_e *MockClient_Expecter) ListUserPolicies(ctx interface{}, params interface{}, optFns ...interface{}) *MockClient_ListUserPolicies_Call {
+	return &MockClient_ListUserPolicies_Call{Call: _e.mock.On("ListUserPolicies",
+		append([]interface{}{ctx, params}, optFns...)...)}
+}
+
+func (_c *MockClient_ListUserPolicies_Call) Run(run func(ctx context.Context, params *serviceiam.ListUserPoliciesInput, optFns ...func(*serviceiam.Options))) *MockClient_ListUserPolicies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]func(*serviceiam.Options), len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(func(*serviceiam.Options))
+			}
+		}
+		run(args[0].(context.Context), args[1].(*serviceiam.ListUserPoliciesInput), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClient_ListUserPolicies_Call) Return(_a0 *serviceiam.ListUserPoliciesOutput, _a1 error) *MockClient_ListUserPolicies_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }

--- a/resources/providers/awslib/iam/iam.go
+++ b/resources/providers/awslib/iam/iam.go
@@ -62,8 +62,8 @@ type RolePolicyInfo struct {
 type User struct {
 	AccessKeys          []AccessKey            `json:"access_keys,omitempty"`
 	MFADevices          []AuthDevice           `json:"mfa_devices,omitempty"`
-	InlinePolicies      []PolicyDocument       `json:"inline_policies,omitempty"`
-	AttachedPolicies    []types.AttachedPolicy `json:"attached_policies,omitempty"`
+	InlinePolicies      []PolicyDocument       `json:"inline_policies"`
+	AttachedPolicies    []types.AttachedPolicy `json:"attached_policies"`
 	Name                string                 `json:"name,omitempty"`
 	LastAccess          string                 `json:"last_access,omitempty"`
 	Arn                 string                 `json:"arn,omitempty"`
@@ -113,6 +113,11 @@ type CredentialReport struct {
 	AccessKey2LastUsed    string `csv:"access_key_2_last_used_date"`
 	Cert1Active           bool   `csv:"cert_1_active"`
 	Cert2Active           bool   `csv:"cert_2_active"`
+}
+
+type PolicyDocument struct {
+	PolicyName string `json:"PolicyName,omitempty"`
+	Policy     string `json:"policy,omitempty"`
 }
 
 func NewIAMProvider(log *logp.Logger, cfg aws.Config) *Provider {

--- a/resources/providers/awslib/iam/iam.go
+++ b/resources/providers/awslib/iam/iam.go
@@ -36,13 +36,16 @@ type Client interface {
 	ListUsers(ctx context.Context, params *iamsdk.ListUsersInput, optFns ...func(*iamsdk.Options)) (*iamsdk.ListUsersOutput, error)
 	ListMFADevices(ctx context.Context, params *iamsdk.ListMFADevicesInput, optFns ...func(*iamsdk.Options)) (*iamsdk.ListMFADevicesOutput, error)
 	ListAccessKeys(ctx context.Context, params *iamsdk.ListAccessKeysInput, optFns ...func(*iamsdk.Options)) (*iamsdk.ListAccessKeysOutput, error)
+	ListAttachedRolePolicies(ctx context.Context, params *iamsdk.ListAttachedRolePoliciesInput, optFns ...func(*iamsdk.Options)) (*iamsdk.ListAttachedRolePoliciesOutput, error)
+	ListVirtualMFADevices(ctx context.Context, params *iamsdk.ListVirtualMFADevicesInput, optFns ...func(*iamsdk.Options)) (*iamsdk.ListVirtualMFADevicesOutput, error)
+	ListAttachedUserPolicies(ctx context.Context, params *iamsdk.ListAttachedUserPoliciesInput, optFns ...func(*iamsdk.Options)) (*iamsdk.ListAttachedUserPoliciesOutput, error)
+	ListUserPolicies(ctx context.Context, params *iamsdk.ListUserPoliciesInput, optFns ...func(*iamsdk.Options)) (*iamsdk.ListUserPoliciesOutput, error)
 	GetAccessKeyLastUsed(ctx context.Context, params *iamsdk.GetAccessKeyLastUsedInput, optFns ...func(*iamsdk.Options)) (*iamsdk.GetAccessKeyLastUsedOutput, error)
 	GetAccountPasswordPolicy(ctx context.Context, params *iamsdk.GetAccountPasswordPolicyInput, optFns ...func(*iamsdk.Options)) (*iamsdk.GetAccountPasswordPolicyOutput, error)
 	GetRolePolicy(ctx context.Context, params *iamsdk.GetRolePolicyInput, optFns ...func(*iamsdk.Options)) (*iamsdk.GetRolePolicyOutput, error)
-	ListAttachedRolePolicies(ctx context.Context, params *iamsdk.ListAttachedRolePoliciesInput, optFns ...func(*iamsdk.Options)) (*iamsdk.ListAttachedRolePoliciesOutput, error)
-	GenerateCredentialReport(ctx context.Context, params *iamsdk.GenerateCredentialReportInput, optFns ...func(*iamsdk.Options)) (*iamsdk.GenerateCredentialReportOutput, error)
 	GetCredentialReport(ctx context.Context, params *iamsdk.GetCredentialReportInput, optFns ...func(*iamsdk.Options)) (*iamsdk.GetCredentialReportOutput, error)
-	ListVirtualMFADevices(ctx context.Context, params *iamsdk.ListVirtualMFADevicesInput, optFns ...func(*iamsdk.Options)) (*iamsdk.ListVirtualMFADevicesOutput, error)
+	GetUserPolicy(ctx context.Context, params *iamsdk.GetUserPolicyInput, optFns ...func(*iamsdk.Options)) (*iamsdk.GetUserPolicyOutput, error)
+	GenerateCredentialReport(ctx context.Context, params *iamsdk.GenerateCredentialReportInput, optFns ...func(*iamsdk.Options)) (*iamsdk.GenerateCredentialReportOutput, error)
 }
 
 type Provider struct {
@@ -57,14 +60,16 @@ type RolePolicyInfo struct {
 
 // User Override SDK User type
 type User struct {
-	AccessKeys          []AccessKey  `json:"access_keys,omitempty"`
-	MFADevices          []AuthDevice `json:"mfa_devices,omitempty"`
-	Name                string       `json:"name,omitempty"`
-	LastAccess          string       `json:"last_access,omitempty"`
-	Arn                 string       `json:"arn,omitempty"`
-	PasswordLastChanged string       `json:"password_last_changed,omitempty"`
-	PasswordEnabled     bool         `json:"password_enabled"`
-	MfaActive           bool         `json:"mfa_active"`
+	AccessKeys          []AccessKey            `json:"access_keys,omitempty"`
+	MFADevices          []AuthDevice           `json:"mfa_devices,omitempty"`
+	InlinePolicies      []PolicyDocument       `json:"inline_policies,omitempty"`
+	AttachedPolicies    []types.AttachedPolicy `json:"attached_policies,omitempty"`
+	Name                string                 `json:"name,omitempty"`
+	LastAccess          string                 `json:"last_access,omitempty"`
+	Arn                 string                 `json:"arn,omitempty"`
+	PasswordLastChanged string                 `json:"password_last_changed,omitempty"`
+	PasswordEnabled     bool                   `json:"password_enabled"`
+	MfaActive           bool                   `json:"mfa_active"`
 }
 
 type AuthDevice struct {

--- a/resources/providers/awslib/iam/policy.go
+++ b/resources/providers/awslib/iam/policy.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iam
+
+import (
+	"context"
+	iamsdk "github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+)
+
+type PolicyDocument struct {
+	PolicyName string `json:"PolicyName,omitempty"`
+	Policy     string `json:"policy,omitempty"`
+}
+
+func (p Provider) listAttachedPolicies(ctx context.Context, identity *string) ([]types.AttachedPolicy, error) {
+	input := &iamsdk.ListAttachedUserPoliciesInput{UserName: identity}
+	var policies []types.AttachedPolicy
+	for {
+		output, err := p.client.ListAttachedUserPolicies(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		policies = append(policies, output.AttachedPolicies...)
+		if !output.IsTruncated {
+			break
+		}
+		input.Marker = output.Marker
+	}
+
+	return policies, nil
+}
+
+func (p Provider) listInlinePolicies(ctx context.Context, identity *string) ([]PolicyDocument, error) {
+	input := &iamsdk.ListUserPoliciesInput{
+		UserName: identity,
+	}
+	var policyNames []string
+	for {
+		output, err := p.client.ListUserPolicies(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		policyNames = append(policyNames, output.PolicyNames...)
+		if !output.IsTruncated {
+			break
+		}
+		input.Marker = output.Marker
+	}
+
+	var policies []PolicyDocument
+	for i := range policyNames {
+		inlinePolicy, err := p.client.GetUserPolicy(ctx, &iamsdk.GetUserPolicyInput{
+			PolicyName: &policyNames[i],
+			UserName:   identity,
+		})
+
+		if err != nil {
+			p.log.Errorf("fail to get inline policy for user: %s, policy name: %s", *identity, policyNames[i])
+			policies = append(policies, PolicyDocument{PolicyName: policyNames[i]})
+			continue
+		}
+
+		policies = append(policies, PolicyDocument{PolicyName: policyNames[i], Policy: *inlinePolicy.PolicyDocument})
+	}
+
+	return policies, nil
+}

--- a/resources/providers/awslib/iam/policy.go
+++ b/resources/providers/awslib/iam/policy.go
@@ -26,7 +26,7 @@ import (
 func (p Provider) listAttachedPolicies(ctx context.Context, identity *string) ([]types.AttachedPolicy, error) {
 	p.log.Debugf("listAttachedPolicies for user: %s", *identity)
 	input := &iamsdk.ListAttachedUserPoliciesInput{UserName: identity}
-	var policies []types.AttachedPolicy
+	policies := []types.AttachedPolicy{}
 	for {
 		output, err := p.client.ListAttachedUserPolicies(ctx, input)
 		if err != nil {
@@ -62,14 +62,14 @@ func (p Provider) listInlinePolicies(ctx context.Context, identity *string) ([]P
 		input.Marker = output.Marker
 	}
 
-	var policies []PolicyDocument
+	policies := []PolicyDocument{}
 	for i := range policyNames {
 		inlinePolicy, err := p.client.GetUserPolicy(ctx, &iamsdk.GetUserPolicyInput{
 			PolicyName: &policyNames[i],
 			UserName:   identity,
 		})
 
-		if err != nil && !p.isRootUser(*identity) {
+		if err != nil {
 			p.log.Errorf("fail to get inline policy for user: %s, policy name: %s", *identity, policyNames[i])
 			policies = append(policies, PolicyDocument{PolicyName: policyNames[i]})
 			continue

--- a/resources/providers/awslib/iam/root_account.go
+++ b/resources/providers/awslib/iam/root_account.go
@@ -103,3 +103,7 @@ func (p Provider) listRootMFADevice(ctx context.Context, userAccount *Credential
 
 	return append(devices, rootMFADevice), nil
 }
+
+func (p Provider) isRootUser(username string) bool {
+	return username == rootAccount
+}

--- a/resources/providers/awslib/iam/root_account.go
+++ b/resources/providers/awslib/iam/root_account.go
@@ -104,6 +104,6 @@ func (p Provider) listRootMFADevice(ctx context.Context, userAccount *Credential
 	return append(devices, rootMFADevice), nil
 }
 
-func (p Provider) isRootUser(username string) bool {
+func isRootUser(username string) bool {
 	return username == rootAccount
 }

--- a/resources/providers/awslib/iam/user.go
+++ b/resources/providers/awslib/iam/user.go
@@ -77,23 +77,35 @@ func (p Provider) GetUsers(ctx context.Context) ([]awslib.AwsResource, error) {
 
 		mfaDevices, err := p.getMFADevices(ctx, apiUser, userAccount)
 		if err != nil {
-			p.log.Errorf("fail to list mfa device for user: %v, error: %v", apiUser, err)
+			p.log.Errorf("fail to list mfa device for user: %s, error: %v", username, err)
 		}
 
 		pwdEnabled, err := isPasswordEnabled(userAccount)
 		if err != nil {
-			p.log.Errorf("fail to parse PasswordEnabled for user: %v, error: %v", apiUser, err)
+			p.log.Errorf("fail to parse PasswordEnabled for user: %s, error: %v", username, err)
 			pwdEnabled = false
+		}
+
+		inlinePolicies, err := p.listInlinePolicies(ctx, apiUser.UserName)
+		if err != nil {
+			p.log.Errorf("fail to list inline policies for user: %s, error: %v", username, err)
+		}
+
+		attachedPolicies, err := p.listAttachedPolicies(ctx, apiUser.UserName)
+		if err != nil {
+			p.log.Errorf("fail to list attached policies for user: %s, error: %v", username, err)
 		}
 
 		users = append(users, User{
 			AccessKeys:          keys,
 			MFADevices:          mfaDevices,
+			InlinePolicies:      inlinePolicies,
+			AttachedPolicies:    attachedPolicies,
 			Name:                username,
 			LastAccess:          userAccount.PasswordLastUsed,
 			Arn:                 arn,
-			PasswordEnabled:     pwdEnabled,
 			PasswordLastChanged: userAccount.PasswordLastChanged,
+			PasswordEnabled:     pwdEnabled,
 			MfaActive:           userAccount.MfaActive,
 		})
 	}

--- a/resources/providers/awslib/iam/user.go
+++ b/resources/providers/awslib/iam/user.go
@@ -87,12 +87,12 @@ func (p Provider) GetUsers(ctx context.Context) ([]awslib.AwsResource, error) {
 		}
 
 		inlinePolicies, err := p.listInlinePolicies(ctx, apiUser.UserName)
-		if err != nil && !p.isRootUser(username) {
+		if err != nil && !isRootUser(username) {
 			p.log.Errorf("fail to list inline policies for user: %s, error: %v", username, err)
 		}
 
 		attachedPolicies, err := p.listAttachedPolicies(ctx, apiUser.UserName)
-		if err != nil && !p.isRootUser(username) {
+		if err != nil && !isRootUser(username) {
 			p.log.Errorf("fail to list attached policies for user: %s, error: %v", username, err)
 		}
 

--- a/resources/providers/awslib/iam/user.go
+++ b/resources/providers/awslib/iam/user.go
@@ -87,12 +87,12 @@ func (p Provider) GetUsers(ctx context.Context) ([]awslib.AwsResource, error) {
 		}
 
 		inlinePolicies, err := p.listInlinePolicies(ctx, apiUser.UserName)
-		if err != nil {
+		if err != nil && !p.isRootUser(username) {
 			p.log.Errorf("fail to list inline policies for user: %s, error: %v", username, err)
 		}
 
 		attachedPolicies, err := p.listAttachedPolicies(ctx, apiUser.UserName)
-		if err != nil {
+		if err != nil && !p.isRootUser(username) {
 			p.log.Errorf("fail to list attached policies for user: %s, error: %v", username, err)
 		}
 

--- a/resources/providers/awslib/iam/user_test.go
+++ b/resources/providers/awslib/iam/user_test.go
@@ -33,10 +33,11 @@ import (
 type mocksReturnVals map[string][][]any
 
 type expectedResult struct {
-	Arn          string
-	HasUsed      bool
-	IsVirtualMFA bool
-	MfaActive    bool
+	Arn               string
+	HasUsed           bool
+	IsVirtualMFA      bool
+	MfaActive         bool
+	hasAttachedPolicy bool
 }
 
 func Test_GetUsers(t *testing.T) {
@@ -50,24 +51,23 @@ func Test_GetUsers(t *testing.T) {
 		{
 			name: "Test 1: Should not return users",
 			mocksReturnVals: mocksReturnVals{
-				"ListUsers":                {{&iamsdk.ListUsersOutput{}, nil}},
-				"ListMFADevices":           {{nil, nil}},
-				"GenerateCredentialReport": {{nil, nil}},
-				"GetCredentialReport":      {{nil, nil}},
+				"ListUsers":           {{&iamsdk.ListUsersOutput{}, nil}},
+				"GetCredentialReport": {{nil, nil}},
 			},
 			expected: []expectedResult{
 				{
-					HasUsed:      false,
-					IsVirtualMFA: false,
-					Arn:          "",
-					MfaActive:    true,
+					Arn:               "",
+					HasUsed:           false,
+					IsVirtualMFA:      false,
+					MfaActive:         true,
+					hasAttachedPolicy: false,
 				},
 			},
 			wantErr:       false,
 			expectedUsers: 0,
 		},
 		{
-			name: "Test 2: Should return two users",
+			name: "Test 2: Should return 3 users",
 			mocksReturnVals: mocksReturnVals{
 				"ListUsers": {{&iamsdk.ListUsersOutput{Users: apiUsers}, nil}},
 				"ListMFADevices": {
@@ -79,25 +79,43 @@ func Test_GetUsers(t *testing.T) {
 				"GetCredentialReport": {
 					{nil, &smithy.GenericAPIError{Code: "ReportNotPresent"}},
 					{CredentialsReportOutput, nil}},
+				"ListUserPolicies": {
+					{&iamsdk.ListUserPoliciesOutput{PolicyNames: []string{"inline-test-policy"}}, nil},
+					{&iamsdk.ListUserPoliciesOutput{PolicyNames: []string{"inline-test-policy"}}, nil},
+					{nil, errors.New("no such user - root account")},
+				},
+				"ListAttachedUserPolicies": {
+					{&iamsdk.ListAttachedUserPoliciesOutput{AttachedPolicies: []types.AttachedPolicy{{PolicyName: aws.String("policy-name-1")}}}, nil},
+					{&iamsdk.ListAttachedUserPoliciesOutput{AttachedPolicies: []types.AttachedPolicy{{PolicyName: aws.String("policy-name-2")}}}, nil},
+					{nil, errors.New("no such user - root account")},
+				},
+				"GetUserPolicy": {
+					{&iamsdk.GetUserPolicyOutput{PolicyDocument: aws.String("aws-test-policy"), PolicyName: aws.String("policy-name-1")}, nil},
+					{&iamsdk.GetUserPolicyOutput{PolicyDocument: aws.String("aws-test-policy"), PolicyName: aws.String("policy-name-2")}, nil},
+					{nil, errors.New("no such user - root account")},
+				},
 			},
 			expected: []expectedResult{
 				{
-					HasUsed:      true,
-					MfaActive:    true,
-					IsVirtualMFA: true,
-					Arn:          "arn:aws:iam::123456789012:user/user1",
+					Arn:               "arn:aws:iam::123456789012:user/user1",
+					HasUsed:           true,
+					IsVirtualMFA:      true,
+					MfaActive:         true,
+					hasAttachedPolicy: true,
 				},
 				{
-					HasUsed:      true,
-					MfaActive:    true,
-					IsVirtualMFA: false,
-					Arn:          "arn:aws:iam::123456789012:user/user2",
+					HasUsed:           true,
+					MfaActive:         true,
+					IsVirtualMFA:      false,
+					Arn:               "arn:aws:iam::123456789012:user/user2",
+					hasAttachedPolicy: true,
 				},
 				{
-					HasUsed:      true,
-					MfaActive:    false,
-					IsVirtualMFA: false,
-					Arn:          "arn:aws:iam::1234567890:root",
+					HasUsed:           true,
+					MfaActive:         false,
+					IsVirtualMFA:      false,
+					Arn:               "arn:aws:iam::1234567890:root",
+					hasAttachedPolicy: false,
 				},
 			},
 			wantErr:       false,
@@ -152,6 +170,7 @@ func Test_GetUsers(t *testing.T) {
 			assert.Equal(t, test.expected[i].Arn, user.(User).Arn)
 			assert.Equal(t, test.expected[i].HasUsed, user.(User).AccessKeys[0].HasUsed)
 			assert.Equal(t, test.expected[i].MfaActive, user.(User).MfaActive)
+			assert.Equal(t, test.expected[i].hasAttachedPolicy, len(user.(User).AttachedPolicies)+len(user.(User).InlinePolicies) > 0)
 
 			if test.expected[i].MfaActive {
 				assert.Equal(t, test.expected[i].IsVirtualMFA, user.(User).MFADevices[0].IsVirtual)

--- a/version/policy.go
+++ b/version/policy.go
@@ -17,7 +17,7 @@
 
 package version
 
-const policyVersion = "v1.2.9"
+const policyVersion = "v1.2.10"
 
 // PolicyVersion returns cloudbeat version info used for the build.
 func PolicyVersion() Version {


### PR DESCRIPTION
**What does this PR do?**
Adds attached and inline policies information of the IAM user.
Update csp policies version to `v1.2.10`.

**Related Issues**
- Related: https://github.com/elastic/csp-security-policies/pull/173

**Checklist**
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
