### PR TITLE
Launcher logging adds beater name

### DIFF
--- a/beater/cloudbeat.go
+++ b/beater/cloudbeat.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	name             = "Cloudbeat"
+	beaterName       = "Cloudbeat"
 	flushInterval    = 10 * time.Second
 	eventsThreshold  = 75
 	resourceChBuffer = 10000
@@ -68,7 +68,7 @@ func New(b *beat.Beat, cfg *agentconfig.C) (beat.Beater, error) {
 	reloader := launcher.NewListener(log)
 	validator := &validator{}
 
-	s, err := launcher.New(log, name, reloader, validator, NewCloudbeat, cfg)
+	s, err := launcher.New(log, beaterName, reloader, validator, NewCloudbeat, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/beater/cloudbeat.go
+++ b/beater/cloudbeat.go
@@ -68,7 +68,7 @@ func New(b *beat.Beat, cfg *agentconfig.C) (beat.Beater, error) {
 	reloader := launcher.NewListener(log)
 	validator := &validator{}
 
-	s, err := launcher.New(log name, reloader, validator, NewCloudbeat, cfg)
+	s, err := launcher.New(log, name, reloader, validator, NewCloudbeat, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/beater/cloudbeat.go
+++ b/beater/cloudbeat.go
@@ -43,6 +43,7 @@ import (
 )
 
 const (
+	name             = "Cloudbeat"
 	flushInterval    = 10 * time.Second
 	eventsThreshold  = 75
 	resourceChBuffer = 10000
@@ -67,7 +68,7 @@ func New(b *beat.Beat, cfg *agentconfig.C) (beat.Beater, error) {
 	reloader := launcher.NewListener(log)
 	validator := &validator{}
 
-	s, err := launcher.New(log, reloader, validator, NewCloudbeat, cfg)
+	s, err := launcher.New(log name, reloader, validator, NewCloudbeat, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +181,7 @@ func (bt *cloudbeat) Run(b *beat.Beat) error {
 	for {
 		select {
 		case <-bt.ctx.Done():
-			bt.log.Warn("cloudbeat context is done")
+			bt.log.Warn("Cloudbeat context is done")
 			return nil
 
 		// Flush events to ES after a pre-defined interval, meant to clean residuals after a cycle is finished.

--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -38,6 +38,8 @@ import (
 	"go.uber.org/goleak"
 )
 
+var dummyBeaterName = "Dummybeat"
+
 type beaterMock struct {
 	cfg  *config.C
 	done chan struct{}
@@ -319,7 +321,7 @@ func (s *LauncherTestSuite) TestWaitForUpdates() {
 	for _, tcase := range testcases {
 		s.Run(tcase.name, func() {
 			mocks := s.InitMocks()
-			sut, err := New(s.log, mocks.reloader, nil, beaterMockCreator, config.NewConfig())
+			sut, err := New(s.log, dummyBeaterName, mocks.reloader, nil, beaterMockCreator, config.NewConfig())
 			s.NoError(err)
 
 			go func(ic incomingConfigs) {
@@ -348,7 +350,7 @@ func (s *LauncherTestSuite) TestErrorWaitForUpdates() {
 	})
 
 	mocks := s.InitMocks()
-	sut, err := New(s.log, mocks.reloader, nil, errorReloadBeaterCreator(), config.NewConfig())
+	sut, err := New(s.log, dummyBeaterName, mocks.reloader, nil, errorReloadBeaterCreator(), config.NewConfig())
 	s.NoError(err)
 
 	go func() {
@@ -441,7 +443,7 @@ func (s *LauncherTestSuite) TestLauncherValidator() {
 	for _, tcase := range testcases {
 		s.Run(tcase.name, func() {
 			mocks := s.InitMocks()
-			sut, err := New(s.log, mocks.reloader, mocks.validator, beaterMockCreator, config.NewConfig())
+			sut, err := New(s.log, dummyBeaterName, mocks.reloader, mocks.validator, beaterMockCreator, config.NewConfig())
 			s.NoError(err)
 
 			mocks.reloader.ch = make(chan *config.C, len(tcase.configs))
@@ -466,7 +468,7 @@ func (s *LauncherTestSuite) TestLauncherValidator() {
 // TestLauncherErrorBeater should not call sut.Stop as the launcher should stop without callling it
 func (s *LauncherTestSuite) TestLauncherErrorBeater() {
 	mocks := s.InitMocks()
-	sut, err := New(s.log, mocks.reloader, nil, errorBeaterMockCreator, config.NewConfig())
+	sut, err := New(s.log, dummyBeaterName, mocks.reloader, nil, errorBeaterMockCreator, config.NewConfig())
 	s.NoError(err)
 	err = sut.run()
 	s.Error(err)
@@ -475,7 +477,7 @@ func (s *LauncherTestSuite) TestLauncherErrorBeater() {
 // TestLauncherPanicBeater should not call sut.Stop as the launcher should stop without callling it
 func (s *LauncherTestSuite) TestLauncherPanicBeater() {
 	mocks := s.InitMocks()
-	sut, err := New(s.log, mocks.reloader, nil, panicBeaterMockCreator, config.NewConfig())
+	sut, err := New(s.log, dummyBeaterName, mocks.reloader, nil, panicBeaterMockCreator, config.NewConfig())
 	s.NoError(err)
 	err = sut.run()
 	s.Error(err)
@@ -484,7 +486,7 @@ func (s *LauncherTestSuite) TestLauncherPanicBeater() {
 
 func (s *LauncherTestSuite) TestLauncherUpdateAndStop() {
 	mocks := s.InitMocks()
-	sut, err := New(s.log, mocks.reloader, nil, beaterMockCreator, config.NewConfig())
+	sut, err := New(s.log, dummyBeaterName, mocks.reloader, nil, beaterMockCreator, config.NewConfig())
 	s.NoError(err)
 	go func() {
 		mocks.reloader.ch <- config.NewConfig()
@@ -496,7 +498,7 @@ func (s *LauncherTestSuite) TestLauncherUpdateAndStop() {
 
 func (s *LauncherTestSuite) TestLauncherStopTwicePanics() {
 	mocks := s.InitMocks()
-	sut, err := New(s.log, mocks.reloader, nil, beaterMockCreator, config.NewConfig())
+	sut, err := New(s.log, dummyBeaterName, mocks.reloader, nil, beaterMockCreator, config.NewConfig())
 	s.NoError(err)
 	go func() {
 		mocks.reloader.ch <- config.NewConfig()
@@ -513,7 +515,7 @@ func (s *LauncherTestSuite) TestLauncherStopTwicePanics() {
 // TestLauncherErrorBeaterCreation should not call sut.Stop as the launcher should stop without callling it
 func (s *LauncherTestSuite) TestLauncherErrorBeaterCreation() {
 	mocks := s.InitMocks()
-	sut, err := New(s.log, mocks.reloader, nil, errorBeaterCreator, config.NewConfig())
+	sut, err := New(s.log, dummyBeaterName, mocks.reloader, nil, errorBeaterCreator, config.NewConfig())
 	s.NoError(err)
 	err = sut.run()
 	s.Error(err)

--- a/uniqueness/leaderelection.go
+++ b/uniqueness/leaderelection.go
@@ -88,10 +88,10 @@ func (m *LeaderelectionManager) Run(ctx context.Context) error {
 
 	go m.leader.Run(newCtx)
 	m.wg.Add(1)
-	m.log.Infof("started leader election")
+	m.log.Infof("Started leader election")
 
 	time.Sleep(FirstLeaderDeadline)
-	m.log.Infof("stop waiting after %s for a leader to be elected", FirstLeaderDeadline)
+	m.log.Debugf("Stop waiting after %s for a leader to be elected", FirstLeaderDeadline)
 
 	return nil
 }
@@ -104,7 +104,7 @@ func (m *LeaderelectionManager) Stop() {
 		return
 	}
 
-	m.log.Warnf("cancelFunc is not set")
+	m.log.Warn("Leader election manager is not initialized")
 }
 
 func (m *LeaderelectionManager) buildConfig(ctx context.Context) (le.LeaderElectionConfig, error) {
@@ -138,29 +138,29 @@ func (m *LeaderelectionManager) buildConfig(ctx context.Context) (le.LeaderElect
 		RetryPeriod:     RetryPeriod,
 		Callbacks: le.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
-				m.log.Infof("leader election lock GAINED, id: %v", id)
+				m.log.Infof("Leader election lock GAINED, id: %v", id)
 			},
 			OnStoppedLeading: func() {
 				// OnStoppedLeading gets called even if cloudbeat wasn't the leader, for example, if the context is canceled due to reconfiguration from fleet.
 				// We re-run the manager to keep following leader status except for context cancellation events.
-				m.log.Infof("leader election lock LOST, id: %v", id)
+				m.log.Infof("Leader election lock LOST, id: %v", id)
 				defer m.wg.Done()
 
 				select {
 				case <-ctx.Done():
-					m.log.Info("Context is canceled - should not re-run leader election")
+					m.log.Info("Leader election is canceled")
 					return
 				default:
 					go m.leader.Run(ctx)
 					m.wg.Add(1)
-					m.log.Infof("re-running leader elector")
+					m.log.Infof("Re-running leader elector")
 				}
 			},
 			OnNewLeader: func(identity string) {
 				if identity == id {
-					m.log.Infof("leader election lock has been acquired by this pod, id: %v", identity)
+					m.log.Infof("Leader election lock has been acquired by this pod, id: %v", identity)
 				} else {
-					m.log.Infof("leader election lock has been acquired by another pod, id: %v", identity)
+					m.log.Infof("Leader election lock has been acquired by another pod, id: %v", identity)
 				}
 			},
 		},
@@ -180,7 +180,7 @@ func (m *LeaderelectionManager) currentPodID() (string, error) {
 func (m *LeaderelectionManager) lastPart(s string) (string, error) {
 	parts := strings.Split(s, "-")
 	if len(parts) == 0 {
-		m.log.Warnf("failed to find id for pod_name: %s", s)
+		m.log.Warnf("Failed to find id for pod_name: %s", s)
 		return m.generateUUID()
 	}
 


### PR DESCRIPTION
### Summary of your changes
The launcher commonly referred to Cloudbeat on logs as "The Beater, " the interface that Cloudbeat implements.
Those lines of logs are confusing and make no sense to an outside reader.
This PR replaces all occurrences with "Cloudbeat".

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for exmaple).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
