### PR TITLE
feat: update cluster name provider when running cis_aws benchmark

### DIFF
--- a/dataprovider/k8s_data_provider.go
+++ b/dataprovider/k8s_data_provider.go
@@ -20,6 +20,7 @@ package dataprovider
 import (
 	"context"
 	"fmt"
+
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/cloudbeat/config"
 	"github.com/elastic/cloudbeat/resources/fetchers"
@@ -170,6 +171,9 @@ func (c commonK8sData) GetVersionInfo() version.CloudbeatVersionInfo {
 }
 
 func (c commonK8sData) EnrichEvent(event beat.Event) error {
+	if c.clusterName == "" {
+		return nil
+	}
 	_, err := event.Fields.Put(clusterNameField, c.clusterName)
 	return err
 }

--- a/resources/providers/cluster_provider.go
+++ b/resources/providers/cluster_provider.go
@@ -56,6 +56,8 @@ func (provider ClusterNameProvider) GetClusterName(ctx context.Context, cfg *con
 		}
 		instanceId := metadata.InstanceID
 		return provider.EKSClusterNameProvider.GetClusterName(ctx, *awsConfig, instanceId)
+	case config.CIS_AWS:
+		return "", nil
 	default:
 		panic(fmt.Sprintf("cluster name provider encountered an unknown cluster type: %s, please implement the relevant cluster name provider", cfg.Benchmark))
 	}

--- a/resources/providers/cluster_provider_test.go
+++ b/resources/providers/cluster_provider_test.go
@@ -73,6 +73,14 @@ func (s *ClusterProviderTestSuite) TestGetClusterName() {
 			"eks-cluster",
 			"eks-cluster",
 		},
+		{
+			config.Config{
+				Benchmark: config.CIS_AWS,
+			},
+			"",
+			"",
+			"",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Summary of your changes
When running `cis_aws` benchmark the `ClusterNameProvider` will panic with an error that this benchmark does not support yet.
We assume that in most cases `cis_aws` benchmark will be running on a standalone instance (ec2) and not as part of a cluster. 
This is problematic panic when running this locally as well (@jeniawhite)

The first solution is to just return an empty string as anyway the [transformer](https://github.com/elastic/cloudbeat/blob/main/transformer/events_creator.go#L98) will not add the `orchestrator.cluster.name` field in case of an empty string.

