### PR TITLE
refactor: align providers to be multi regional

### DIFF
--- a/resources/fetchers/monitoring_factory_test.go
+++ b/resources/fetchers/monitoring_factory_test.go
@@ -93,11 +93,9 @@ func TestMonitoringFactory_Create(t *testing.T) {
 
 	mockSecurityhubService := &securityhub.MockService{}
 	mockSecurityhubService.On("Describe").Return(securityhub.SecurityHub{}, nil)
-	mockCrossRegionSecurityHubFetcher := &awslib.MockCrossRegionFetcher[securityhub.Service]{}
-	mockCrossRegionSecurityHubFetcher.On("GetMultiRegionsClientMap").Return(map[string]securityhub.Service{
-		"eu-east-1": mockSecurityhubService,
-	})
-	mockCrossRegionSecurityHubFactory := &awslib.MockCrossRegionFactory[securityhub.Service]{}
+	mockCrossRegionSecurityHubFetcher := &awslib.MockCrossRegionFetcher[securityhub.Client]{}
+	mockCrossRegionSecurityHubFetcher.On("GetMultiRegionsClientMap").Return(nil)
+	mockCrossRegionSecurityHubFactory := &awslib.MockCrossRegionFactory[securityhub.Client]{}
 	mockCrossRegionSecurityHubFactory.On(
 		"NewMultiRegionClients",
 		mock.Anything,

--- a/resources/fetchers/monitoring_fetcher.go
+++ b/resources/fetchers/monitoring_fetcher.go
@@ -35,7 +35,7 @@ type MonitoringFetcher struct {
 	cfg           MonitoringFetcherConfig
 	resourceCh    chan fetching.ResourceInfo
 	cloudIdentity *awslib.Identity
-	securityhubs  map[string]securityhub.Service
+	securityhub   securityhub.Service
 }
 
 type MonitoringFetcherConfig struct {
@@ -63,9 +63,7 @@ func (m MonitoringFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMe
 			CycleMetadata: cMetadata,
 		}
 	}
-	hubs, err := awslib.MultiRegionFetch(ctx, m.securityhubs, func(ctx context.Context, client securityhub.Service) (securityhub.SecurityHub, error) {
-		return client.Describe(ctx)
-	})
+	hubs, err := m.securityhub.Describe(ctx)
 	if err != nil {
 		m.log.Errorf("failed to describe security hub: %v", err)
 		return nil

--- a/resources/fetchers/monitoring_fetcher_test.go
+++ b/resources/fetchers/monitoring_fetcher_test.go
@@ -64,7 +64,7 @@ func TestMonitoringFetcher_Fetch(t *testing.T) {
 			securityhub: clientMocks{
 				"Describe": [2]mocks{
 					{mock.Anything},
-					{securityhub.SecurityHub{}, nil},
+					{[]securityhub.SecurityHub{{}}, nil},
 				},
 			},
 			expectedResources: 2,
@@ -80,7 +80,7 @@ func TestMonitoringFetcher_Fetch(t *testing.T) {
 			securityhub: clientMocks{
 				"Describe": [2]mocks{
 					{mock.Anything},
-					{securityhub.SecurityHub{}, fmt.Errorf("failed to run provider")},
+					{[]securityhub.SecurityHub{{}}, fmt.Errorf("failed to run provider")},
 				},
 			},
 		},
@@ -95,7 +95,7 @@ func TestMonitoringFetcher_Fetch(t *testing.T) {
 			securityhub: clientMocks{
 				"Describe": [2]mocks{
 					{mock.Anything},
-					{securityhub.SecurityHub{}, nil},
+					{[]securityhub.SecurityHub{{}}, nil},
 				},
 			},
 			expectedResources: 1,
@@ -116,11 +116,9 @@ func TestMonitoringFetcher_Fetch(t *testing.T) {
 				hub.On(name, call[0]...).Return(call[1]...)
 			}
 			m := MonitoringFetcher{
-				log:      logp.NewLogger("TestMonitoringFetcher_Fetch"),
-				provider: monitoring,
-				securityhubs: map[string]securityhub.Service{
-					"eu-west-1": hub,
-				},
+				log:           logp.NewLogger("TestMonitoringFetcher_Fetch"),
+				provider:      monitoring,
+				securityhub:   hub,
 				cfg:           MonitoringFetcherConfig{},
 				resourceCh:    ch,
 				cloudIdentity: &awslib.Identity{Account: aws.String("account")},

--- a/resources/fetchers/network_factory_test.go
+++ b/resources/fetchers/network_factory_test.go
@@ -47,12 +47,10 @@ func TestNetworkFactory_Create(t *testing.T) {
 	mockEc2Compute := &ec2.MockElasticCompute{}
 	mockEc2Compute.On("DescribeNetworkAcl", mock.Anything).Return(nil, nil)
 	mockEc2Compute.On("DescribeSecurityGroups", mock.Anything).Return(nil, nil)
-	ec2Mock := &awslib.MockCrossRegionFetcher[ec2.ElasticCompute]{}
-	ec2Mock.On("GetMultiRegionsClientMap").Return(map[string]ec2.ElasticCompute{
-		"eu-east-1": mockEc2Compute,
-	})
+	ec2Mock := &awslib.MockCrossRegionFetcher[ec2.Client]{}
+	ec2Mock.On("GetMultiRegionsClientMap").Return(nil)
 
-	mockCrossRegion := &awslib.MockCrossRegionFactory[ec2.ElasticCompute]{}
+	mockCrossRegion := &awslib.MockCrossRegionFactory[ec2.Client]{}
 	mockCrossRegion.On(
 		"NewMultiRegionClients",
 		mock.Anything,

--- a/resources/fetchers/network_fetcher.go
+++ b/resources/fetchers/network_fetcher.go
@@ -20,8 +20,6 @@ package fetchers
 import (
 	"context"
 
-	"github.com/samber/lo"
-
 	"github.com/elastic/cloudbeat/resources/fetching"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
@@ -30,7 +28,7 @@ import (
 
 type NetworkFetcher struct {
 	log           *logp.Logger
-	ec2Clients    map[string]ec2.ElasticCompute
+	ec2Client     ec2.ElasticCompute
 	cfg           ACLFetcherConfig
 	resourceCh    chan fetching.ResourceInfo
 	cloudIdentity *awslib.Identity
@@ -48,11 +46,12 @@ type NetworkResource struct {
 // Fetch collects network resource such as network acl and security groups
 func (f NetworkFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
 	f.log.Debug("Starting NetworkFetcher.Fetch")
-	resources, _ := awslib.MultiRegionFetch(ctx, f.ec2Clients, func(ctx context.Context, client ec2.ElasticCompute) ([]awslib.AwsResource, error) {
-		return f.aggregateResources(ctx, client)
-	})
+	resources, err := f.aggregateResources(ctx, f.ec2Client)
+	if err != nil {
+		return err
+	}
 
-	for _, resource := range lo.Flatten(resources) {
+	for _, resource := range resources {
 		f.resourceCh <- fetching.ResourceInfo{
 			Resource: NetworkResource{
 				AwsResource: resource,
@@ -107,7 +106,7 @@ func (f NetworkFetcher) aggregateResources(ctx context.Context, client ec2.Elast
 	}
 
 	if ebsEncryption != nil {
-		resources = append(resources, ebsEncryption)
+		resources = append(resources, ebsEncryption...)
 	}
 
 	return resources, nil

--- a/resources/fetchers/network_fetcher_test.go
+++ b/resources/fetchers/network_fetcher_test.go
@@ -115,7 +115,9 @@ func TestNetworkFetcher_Fetch(t *testing.T) {
 					ec2.VpcInfo{},
 					ec2.VpcInfo{},
 				}, nil)
-				m.On("GetEbsEncryptionByDefault", mock.Anything).Return(&ec2.EBSEncryption{}, nil)
+				m.On("GetEbsEncryptionByDefault", mock.Anything).Return([]awslib.AwsResource{
+					ec2.EBSEncryption{},
+				}, nil)
 				return &m
 			},
 			wantErr:           false,
@@ -128,10 +130,8 @@ func TestNetworkFetcher_Fetch(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 			defer cancel()
 			f := NetworkFetcher{
-				log: logp.NewLogger(tt.name),
-				ec2Clients: map[string]ec2.ElasticCompute{
-					"eu-west-1": tt.networkProvider(),
-				},
+				log:           logp.NewLogger(tt.name),
+				ec2Client:     tt.networkProvider(),
 				cfg:           ACLFetcherConfig{},
 				resourceCh:    ch,
 				cloudIdentity: &awslib.Identity{Account: &tt.name},

--- a/resources/fetchers/rds_factory_test.go
+++ b/resources/fetchers/rds_factory_test.go
@@ -18,10 +18,11 @@
 package fetchers
 
 import (
+	"testing"
+
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/rds"
 	"github.com/stretchr/testify/mock"
-	"testing"
 
 	agentConfig "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -48,7 +49,7 @@ func TestRdsFactoryTestSuite(t *testing.T) {
 func (s *RdsFactoryTestSuite) SetupTest() {}
 
 func (s *RdsFactoryTestSuite) TestCreateFetcher() {
-	var tests = []struct {
+	tests := []struct {
 		config string
 	}{
 		{
@@ -61,10 +62,10 @@ secret_access_key: secret
 	}
 
 	for _, test := range tests {
-		mockCrossRegionFetcher := &awslib.MockCrossRegionFetcher[rds.Rds]{}
+		mockCrossRegionFetcher := &awslib.MockCrossRegionFetcher[rds.Client]{}
 		mockCrossRegionFetcher.On("GetMultiRegionsClientMap").Return(nil)
 
-		mockCrossRegionFactory := &awslib.MockCrossRegionFactory[rds.Rds]{}
+		mockCrossRegionFactory := &awslib.MockCrossRegionFactory[rds.Client]{}
 		mockCrossRegionFactory.On(
 			"NewMultiRegionClients",
 			mock.Anything,

--- a/resources/providers/awslib/ec2/mock_elastic_compute.go
+++ b/resources/providers/awslib/ec2/mock_elastic_compute.go
@@ -179,15 +179,15 @@ func (_c *MockElasticCompute_DescribeVPCs_Call) Return(_a0 []awslib.AwsResource,
 }
 
 // GetEbsEncryptionByDefault provides a mock function with given fields: ctx
-func (_m *MockElasticCompute) GetEbsEncryptionByDefault(ctx context.Context) (*EBSEncryption, error) {
+func (_m *MockElasticCompute) GetEbsEncryptionByDefault(ctx context.Context) ([]awslib.AwsResource, error) {
 	ret := _m.Called(ctx)
 
-	var r0 *EBSEncryption
-	if rf, ok := ret.Get(0).(func(context.Context) *EBSEncryption); ok {
+	var r0 []awslib.AwsResource
+	if rf, ok := ret.Get(0).(func(context.Context) []awslib.AwsResource); ok {
 		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*EBSEncryption)
+			r0 = ret.Get(0).([]awslib.AwsResource)
 		}
 	}
 
@@ -219,7 +219,7 @@ func (_c *MockElasticCompute_GetEbsEncryptionByDefault_Call) Run(run func(ctx co
 	return _c
 }
 
-func (_c *MockElasticCompute_GetEbsEncryptionByDefault_Call) Return(_a0 *EBSEncryption, _a1 error) *MockElasticCompute_GetEbsEncryptionByDefault_Call {
+func (_c *MockElasticCompute_GetEbsEncryptionByDefault_Call) Return(_a0 []awslib.AwsResource, _a1 error) *MockElasticCompute_GetEbsEncryptionByDefault_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }

--- a/resources/providers/awslib/multi_region.go
+++ b/resources/providers/awslib/multi_region.go
@@ -73,7 +73,7 @@ func (w *MultiRegionClientFactory[T]) NewMultiRegionClients(client DescribeCloud
 }
 
 // MultiRegionFetch retrieves resources from multiple regions concurrently using the provided fetcher function.
-func MultiRegionFetch[T any, K any](ctx context.Context, set map[string]T, fetcher func(ctx context.Context, client T) (K, error)) ([]K, error) {
+func MultiRegionFetch[T any, K any](ctx context.Context, set map[string]T, fetcher func(ctx context.Context, region string, client T) (K, error)) ([]K, error) {
 	var err error
 	var wg sync.WaitGroup
 	var mux sync.Mutex
@@ -87,7 +87,7 @@ func MultiRegionFetch[T any, K any](ctx context.Context, set map[string]T, fetch
 		wg.Add(1)
 		go func(client T, region string) {
 			defer wg.Done()
-			results, fetchErr := fetcher(ctx, client)
+			results, fetchErr := fetcher(ctx, region, client)
 			if fetchErr != nil {
 				err = fmt.Errorf("fail to retrieve aws resources for region: %s, error: %v, ", region, fetchErr)
 			}

--- a/resources/providers/awslib/multi_region_test.go
+++ b/resources/providers/awslib/multi_region_test.go
@@ -109,7 +109,7 @@ func TestMultiRegionFetch(t *testing.T) {
 	type testCase[T any] struct {
 		name    string
 		clients map[string]testClient
-		fetcher func(context.Context, T) ([]AwsResource, error)
+		fetcher func(context.Context, string, T) ([]AwsResource, error)
 		want    []AwsResource
 		wantErr bool
 	}
@@ -117,7 +117,7 @@ func TestMultiRegionFetch(t *testing.T) {
 		{
 			name:    "Fetch resources from multiple regions",
 			clients: map[string]testClient{euRegion: &dummyTester{euRegion}, usRegion: &dummyTester{usRegion}},
-			fetcher: func(ctx context.Context, c testClient) ([]AwsResource, error) {
+			fetcher: func(ctx context.Context, region string, c testClient) ([]AwsResource, error) {
 				return c.DummyFunc()
 			},
 			want:    []AwsResource{testAwsResource{resRegion: usRegion}, testAwsResource{resRegion: euRegion}},
@@ -126,7 +126,7 @@ func TestMultiRegionFetch(t *testing.T) {
 		{
 			name:    "Error from a single region",
 			clients: map[string]testClient{afRegion: &dummyTester{afRegion}, usRegion: &dummyTester{usRegion}},
-			fetcher: func(ctx context.Context, c testClient) ([]AwsResource, error) {
+			fetcher: func(ctx context.Context, region string, c testClient) ([]AwsResource, error) {
 				return c.DummyFunc()
 			},
 			want:    []AwsResource{testAwsResource{resRegion: usRegion}},
@@ -135,7 +135,7 @@ func TestMultiRegionFetch(t *testing.T) {
 		{
 			name:    "Error from all regions",
 			clients: map[string]testClient{afRegion: &dummyTester{afRegion}, usRegion: &dummyTester{usRegion}},
-			fetcher: func(ctx context.Context, c testClient) ([]AwsResource, error) {
+			fetcher: func(ctx context.Context, region string, c testClient) ([]AwsResource, error) {
 				return nil, errors.New("service unavailable")
 			},
 			want:    nil,

--- a/resources/providers/awslib/rds/rds.go
+++ b/resources/providers/awslib/rds/rds.go
@@ -19,6 +19,7 @@ package rds
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -36,8 +37,8 @@ type Rds interface {
 }
 
 type Provider struct {
-	log    *logp.Logger
-	client Client
+	log     *logp.Logger
+	clients map[string]Client
 }
 
 type Client interface {

--- a/resources/providers/awslib/securityhub/mock_service.go
+++ b/resources/providers/awslib/securityhub/mock_service.go
@@ -39,14 +39,16 @@ func (_m *MockService) EXPECT() *MockService_Expecter {
 }
 
 // Describe provides a mock function with given fields: ctx
-func (_m *MockService) Describe(ctx context.Context) (SecurityHub, error) {
+func (_m *MockService) Describe(ctx context.Context) ([]SecurityHub, error) {
 	ret := _m.Called(ctx)
 
-	var r0 SecurityHub
-	if rf, ok := ret.Get(0).(func(context.Context) SecurityHub); ok {
+	var r0 []SecurityHub
+	if rf, ok := ret.Get(0).(func(context.Context) []SecurityHub); ok {
 		r0 = rf(ctx)
 	} else {
-		r0 = ret.Get(0).(SecurityHub)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]SecurityHub)
+		}
 	}
 
 	var r1 error
@@ -77,7 +79,7 @@ func (_c *MockService_Describe_Call) Run(run func(ctx context.Context)) *MockSer
 	return _c
 }
 
-func (_c *MockService_Describe_Call) Return(_a0 SecurityHub, _a1 error) *MockService_Describe_Call {
+func (_c *MockService_Describe_Call) Return(_a0 []SecurityHub, _a1 error) *MockService_Describe_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }

--- a/resources/providers/awslib/securityhub/securityhub.go
+++ b/resources/providers/awslib/securityhub/securityhub.go
@@ -27,7 +27,7 @@ import (
 
 type (
 	Service interface {
-		Describe(ctx context.Context) (SecurityHub, error)
+		Describe(ctx context.Context) ([]SecurityHub, error)
 	}
 
 	SecurityHub struct {


### PR DESCRIPTION
### Summary of your changes
refactor securityhub, ec2 and rds providers to be multi-regional like the other aws providers we have



### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
