### PR TITLE
Reduce time in Cloudbeat CI

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -49,12 +49,8 @@ jobs:
 
       - name: Unit-Test Cloudbeat
         run: |
-          GOOS=linux go test -v -coverpkg=./... -coverprofile=cover.out.tmp ./...
+          GOOS=linux go test -v -race -coverpkg=./... -coverprofile=cover.out.tmp ./...
           cat cover.out.tmp | grep -v "mock_.*.go" > cover.out # remove mock files from coverage report
-
-      - name: Unit-Test with Race Detector
-        run: |
-          GOOS=linux go test -v -race ./...
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Summary of your changes
After multiple attemps to run the `unit-test.yml` in the CI, it seems that it the racing validation step causes a timeout.
Instead of increasing the step timeout, and by that increasing the general time that the CI runs, we would like to merge to steps in the CI:
- The race validation check
- Coverage and unit test step

By merging these two into one step we hope to get the same result in less CI time.