### PR TITLE
Support Trivy credentials configuration

### DIFF
--- a/flavors/vulnerability.go
+++ b/flavors/vulnerability.go
@@ -24,9 +24,10 @@ import (
 	"time"
 
 	"github.com/elastic/cloudbeat/config"
-	"github.com/elastic/cloudbeat/dataprovider"
-	_ "github.com/elastic/cloudbeat/processor" // Add vulnerability default processors.
-	"github.com/elastic/cloudbeat/transformer"
+	// "github.com/elastic/cloudbeat/dataprovider"
+	// _ "github.com/elastic/cloudbeat/processor" // Add vulnerability default processors.
+
+	// "github.com/elastic/cloudbeat/transformer"
 	vuln "github.com/elastic/cloudbeat/vulnerability"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -56,23 +57,23 @@ func NewVulnerability(_ *beat.Beat, cfg *agentconfig.C) (*vulnerability, error) 
 	log.Info("Config initiated with cycle period of ", c.Period)
 
 	// namespace will be passed as param from fleet on https://github.com/elastic/security-team/issues/2383 and it's user configurable
-	resultsIndex := config.Datastream("", config.ResultsDatastreamIndexPrefix)
+	// resultsIndex := config.Datastream("", config.ResultsDatastreamIndexPrefix)
 
-	commonDataProvider := dataprovider.NewCommonDataProvider(log, c)
-	commonData, err := commonDataProvider.FetchCommonData(ctx)
-	if err != nil {
-		cancel()
-		return nil, err
-	}
+	// commonDataProvider := dataprovider.NewCommonDataProvider(log, c)
+	// commonData, err := commonDataProvider.FetchCommonData(ctx)
+	// if err != nil {
+	// 	cancel()
+	// 	return nil, err
+	// }
 
-	t := transformer.NewTransformer(log, commonData, resultsIndex)
+	// t := transformer.NewTransformer(log, commonData, resultsIndex)
 
 	base := flavorBase{
-		ctx:         ctx,
-		cancel:      cancel,
-		config:      c,
-		transformer: t,
-		log:         log,
+		ctx:    ctx,
+		cancel: cancel,
+		config: c,
+		// transformer: t,
+		log: log,
 	}
 
 	// TODO: Due to boltDB lock, I've moved this to a global variable as single runner

--- a/flavors/vulnerability.go
+++ b/flavors/vulnerability.go
@@ -24,10 +24,6 @@ import (
 	"time"
 
 	"github.com/elastic/cloudbeat/config"
-	// "github.com/elastic/cloudbeat/dataprovider"
-	// _ "github.com/elastic/cloudbeat/processor" // Add vulnerability default processors.
-
-	// "github.com/elastic/cloudbeat/transformer"
 	vuln "github.com/elastic/cloudbeat/vulnerability"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -56,24 +52,11 @@ func NewVulnerability(_ *beat.Beat, cfg *agentconfig.C) (*vulnerability, error) 
 
 	log.Info("Config initiated with cycle period of ", c.Period)
 
-	// namespace will be passed as param from fleet on https://github.com/elastic/security-team/issues/2383 and it's user configurable
-	// resultsIndex := config.Datastream("", config.ResultsDatastreamIndexPrefix)
-
-	// commonDataProvider := dataprovider.NewCommonDataProvider(log, c)
-	// commonData, err := commonDataProvider.FetchCommonData(ctx)
-	// if err != nil {
-	// 	cancel()
-	// 	return nil, err
-	// }
-
-	// t := transformer.NewTransformer(log, commonData, resultsIndex)
-
 	base := flavorBase{
 		ctx:    ctx,
 		cancel: cancel,
 		config: c,
-		// transformer: t,
-		log: log,
+		log:    log,
 	}
 
 	// TODO: Due to boltDB lock, I've moved this to a global variable as single runner

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 require (
 	github.com/aquasecurity/trivy v0.35.0
 	github.com/aquasecurity/trivy-db v0.0.0-20221227141502-af78ecb7db4c
+	github.com/aws/aws-sdk-go-v2/config v1.18.3
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.3
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.19
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.24.4
@@ -112,7 +113,6 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.44.136 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.8 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.18.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.28 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.26 // indirect
@@ -171,6 +171,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.14.1 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
@@ -194,7 +195,7 @@ require (
 	github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/masahiro331/go-disk v0.0.0-20220919035250-c8da316f91ac // indirect
-	github.com/masahiro331/go-ebs-file v0.0.0-20221125181850-09c63351e38c // indirect
+	github.com/masahiro331/go-ebs-file v0.0.0-20230228042409-005c81d4ae43 // indirect
 	github.com/masahiro331/go-ext4-filesystem v0.0.0-20221016160854-4b40d7ee6193 // indirect
 	github.com/masahiro331/go-mvn-version v0.0.0-20210429150710-d3157d602a08 // indirect
 	github.com/masahiro331/go-vmdk-parser v0.0.0-20221124162251-5eeffd974e5a // indirect
@@ -473,6 +474,8 @@ replace (
 	github.com/google/gopacket => github.com/elastic/gopacket v1.1.20-0.20211202005954-d412fca7f83a
 
 )
+
+replace github.com/aquasecurity/trivy => github.com/jeniawhite/trivy v0.0.2
 
 // exclude github.com/elastic/elastic-agent v0.0.0-20220831162706-5f1e54f40d3e
 

--- a/go.mod
+++ b/go.mod
@@ -475,7 +475,7 @@ replace (
 
 )
 
-replace github.com/aquasecurity/trivy => github.com/jeniawhite/trivy v0.0.2
+replace github.com/aquasecurity/trivy => github.com/jeniawhite/trivy v0.0.0
 
 // exclude github.com/elastic/elastic-agent v0.0.0-20220831162706-5f1e54f40d3e
 

--- a/go.sum
+++ b/go.sum
@@ -1235,8 +1235,8 @@ github.com/jcmturner/gokrb5/v8 v8.4.2/go.mod h1:sb+Xq/fTY5yktf/VxLsE3wlfPqQjp0aW
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
 github.com/jedib0t/go-pretty v4.3.0+incompatible/go.mod h1:XemHduiw8R651AF9Pt4FwCTKeG3oo7hrHJAoznj9nag=
-github.com/jeniawhite/trivy v0.0.2 h1:cRrswcUj52eL0/V+Wn6yaFBj3sI5Gonbt+I1CqCNea4=
-github.com/jeniawhite/trivy v0.0.2/go.mod h1:qEMOtJRgTNFPI2JrnqjVxAh4fEg1yea1NJ+Kh4qLGwk=
+github.com/jeniawhite/trivy v0.0.0 h1:wmivOyOhUXtbPPBfXVCQ68iGzL+aEygyP0yrg48V53o=
+github.com/jeniawhite/trivy v0.0.0/go.mod h1:qEMOtJRgTNFPI2JrnqjVxAh4fEg1yea1NJ+Kh4qLGwk=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,6 @@ github.com/aquasecurity/table v1.8.0/go.mod h1:eqOmvjjB7AhXFgFqpJUEE/ietg7RrMSJZ
 github.com/aquasecurity/testdocker v0.0.0-20210911155206-e1e85f5a1516 h1:moQmzbpLo5dxHQCyEhqzizsDSNrNhn/7uRTCZzo4A1o=
 github.com/aquasecurity/tml v0.6.1 h1:y2ZlGSfrhnn7t4ZJ/0rotuH+v5Jgv6BDDO5jB6A9gwo=
 github.com/aquasecurity/tml v0.6.1/go.mod h1:OnYMWY5lvI9ejU7yH9LCberWaaTBW7hBFsITiIMY2yY=
-github.com/aquasecurity/trivy v0.35.0 h1:qtSn7MSLjRRmUOTI7UbGOlT3NVk/Zcv2/m19kD4EjIY=
-github.com/aquasecurity/trivy v0.35.0/go.mod h1:gwkdeoZUwAxDrwBVD6EmCDHPVo+nkMxeudy06HiWkcA=
 github.com/aquasecurity/trivy-db v0.0.0-20221227141502-af78ecb7db4c h1:CgJiXxVxgFOQ4btP97LEYqEHnx++FRpf2IJEXJV+xHs=
 github.com/aquasecurity/trivy-db v0.0.0-20221227141502-af78ecb7db4c/go.mod h1:/nULgnDeq/JMPMVwE1dmf4kWlYn++7VrM3O2naj4BHA=
 github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
@@ -1177,6 +1175,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
+github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.14.1 h1:x0BpjfZ+CYdbiz+8yZTQ+gdLO7IXvOut7Da+XJayx34=
@@ -1235,6 +1235,8 @@ github.com/jcmturner/gokrb5/v8 v8.4.2/go.mod h1:sb+Xq/fTY5yktf/VxLsE3wlfPqQjp0aW
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
 github.com/jedib0t/go-pretty v4.3.0+incompatible/go.mod h1:XemHduiw8R651AF9Pt4FwCTKeG3oo7hrHJAoznj9nag=
+github.com/jeniawhite/trivy v0.0.2 h1:cRrswcUj52eL0/V+Wn6yaFBj3sI5Gonbt+I1CqCNea4=
+github.com/jeniawhite/trivy v0.0.2/go.mod h1:qEMOtJRgTNFPI2JrnqjVxAh4fEg1yea1NJ+Kh4qLGwk=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
@@ -1384,8 +1386,8 @@ github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11 h1:YFh+sjyJ
 github.com/martini-contrib/render v0.0.0-20150707142108-ec18f8345a11/go.mod h1:Ah2dBMoxZEqk118as2T4u4fjfXarE0pPnMJaArZQZsI=
 github.com/masahiro331/go-disk v0.0.0-20220919035250-c8da316f91ac h1:QyRucnGOLHJag1eB9CtuZwZk+/LpvTSYr5mnFLLFlgA=
 github.com/masahiro331/go-disk v0.0.0-20220919035250-c8da316f91ac/go.mod h1:J7Vb0sf0JzOhT0uHTeCqO6dqP/ELVcQvQ6yQ/56ZRGw=
-github.com/masahiro331/go-ebs-file v0.0.0-20221125181850-09c63351e38c h1:sBVxQbdRxqMoczqQYPxUwe3V3msmAUj9KPuPZRpD13k=
-github.com/masahiro331/go-ebs-file v0.0.0-20221125181850-09c63351e38c/go.mod h1:5NOkqebMwu8UiOTSjwqam1Ykdr7fci52TVE2xDQnIiM=
+github.com/masahiro331/go-ebs-file v0.0.0-20230228042409-005c81d4ae43 h1:umYrurEClKuDjU29DKNNPmnWJNt4mnR0fWLOpWsDg0M=
+github.com/masahiro331/go-ebs-file v0.0.0-20230228042409-005c81d4ae43/go.mod h1:5NOkqebMwu8UiOTSjwqam1Ykdr7fci52TVE2xDQnIiM=
 github.com/masahiro331/go-ext4-filesystem v0.0.0-20221016160854-4b40d7ee6193 h1:1005OfmUUdBL4540DpkovaDrV+lkiEda7Nb/t792LEg=
 github.com/masahiro331/go-ext4-filesystem v0.0.0-20221016160854-4b40d7ee6193/go.mod h1:X08d9nmB+eg7Gj2XWAOkiG8lbMFbgGXPsDKEvkFwyF8=
 github.com/masahiro331/go-mvn-version v0.0.0-20210429150710-d3157d602a08 h1:AevUBW4cc99rAF8q8vmddIP8qd/0J5s/UyltGbp66dg=

--- a/resources/providers/awslib/ec2/provider.go
+++ b/resources/providers/awslib/ec2/provider.go
@@ -157,7 +157,6 @@ func (p *Provider) GetEbsEncryptionByDefault(ctx context.Context) ([]awslib.AwsR
 }
 
 func (p *Provider) DescribeInstances(ctx context.Context, region string) ([]types.Instance, error) {
-	// ins, err := awslib.MultiRegionFetch(ctx, p.clients, func(ctx context.Context, region string, c Client) ([]types.Instance, error) {
 	client := p.clients[region]
 	if client == nil {
 		return nil, fmt.Errorf("error in DescribeInstances no client for region %s", region)
@@ -178,12 +177,9 @@ func (p *Provider) DescribeInstances(ctx context.Context, region string) ([]type
 		input.NextToken = output.NextToken
 	}
 	return allInstances, nil
-	// })
-	// return lo.Flatten(ins), err
 }
 
 func (p *Provider) CreateSnapshots(ctx context.Context, ins types.Instance, region string) ([]types.SnapshotInfo, error) {
-	// snaps, err := awslib.MultiRegionFetch(ctx, p.clients, func(ctx context.Context, region string, c Client) ([]types.SnapshotInfo, error) {
 	client := p.clients[region]
 	if client == nil {
 		return nil, fmt.Errorf("error in CreateSnapshots no client for region %s", region)
@@ -199,14 +195,11 @@ func (p *Provider) CreateSnapshots(ctx context.Context, ins types.Instance, regi
 		return nil, err
 	}
 	return result.Snapshots, nil
-	// })
-	// return lo.Flatten(snaps), err
 }
 
 // TODO: Maybe we should bulk request snapshots?
 // This will limit us scaling the pipeline
 func (p *Provider) DescribeSnapshots(ctx context.Context, snap types.SnapshotInfo, region string) ([]types.Snapshot, error) {
-	// snaps, err := awslib.MultiRegionFetch(ctx, p.clients, func(ctx context.Context, region string, c Client) ([]types.Snapshot, error) {
 	client := p.clients[region]
 	if client == nil {
 		return nil, fmt.Errorf("error in DescribeSnapshots no client for region %s", region)
@@ -219,6 +212,4 @@ func (p *Provider) DescribeSnapshots(ctx context.Context, snap types.SnapshotInf
 		return nil, err
 	}
 	return result.Snapshots, nil
-	// })
-	// return lo.Flatten(snaps), err
 }

--- a/resources/providers/awslib/ec2/provider.go
+++ b/resources/providers/awslib/ec2/provider.go
@@ -19,6 +19,7 @@ package ec2
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/samber/lo"
@@ -155,57 +156,69 @@ func (p *Provider) GetEbsEncryptionByDefault(ctx context.Context) ([]awslib.AwsR
 	})
 }
 
-func (p *Provider) DescribeInstances(ctx context.Context) ([]types.Instance, error) {
-	ins, err := awslib.MultiRegionFetch(ctx, p.clients, func(ctx context.Context, region string, c Client) ([]types.Instance, error) {
-		input := &ec2.DescribeInstancesInput{}
-		allInstances := []types.Instance{}
-		for {
-			output, err := c.DescribeInstances(ctx, input)
-			if err != nil {
-				return nil, err
-			}
-			for _, reservation := range output.Reservations {
-				allInstances = append(allInstances, reservation.Instances...)
-			}
-			if output.NextToken == nil {
-				break
-			}
-			input.NextToken = output.NextToken
-		}
-		return allInstances, nil
-	})
-	return lo.Flatten(ins), err
-}
-
-func (p *Provider) CreateSnapshots(ctx context.Context, ins types.Instance) ([]types.SnapshotInfo, error) {
-	snaps, err := awslib.MultiRegionFetch(ctx, p.clients, func(ctx context.Context, region string, c Client) ([]types.SnapshotInfo, error) {
-		input := &ec2.CreateSnapshotsInput{
-			InstanceSpecification: &types.InstanceSpecification{
-				InstanceId: ins.InstanceId,
-			},
-			Description: aws.String("Cloudbeat Vulnerability Snapshot."),
-		}
-		result, err := c.CreateSnapshots(ctx, input)
+func (p *Provider) DescribeInstances(ctx context.Context, region string) ([]types.Instance, error) {
+	// ins, err := awslib.MultiRegionFetch(ctx, p.clients, func(ctx context.Context, region string, c Client) ([]types.Instance, error) {
+	client := p.clients[region]
+	if client == nil {
+		return nil, fmt.Errorf("error in DescribeInstances no client for region %s", region)
+	}
+	input := &ec2.DescribeInstancesInput{}
+	allInstances := []types.Instance{}
+	for {
+		output, err := client.DescribeInstances(ctx, input)
 		if err != nil {
 			return nil, err
 		}
-		return result.Snapshots, nil
-	})
-	return lo.Flatten(snaps), err
+		for _, reservation := range output.Reservations {
+			allInstances = append(allInstances, reservation.Instances...)
+		}
+		if output.NextToken == nil {
+			break
+		}
+		input.NextToken = output.NextToken
+	}
+	return allInstances, nil
+	// })
+	// return lo.Flatten(ins), err
+}
+
+func (p *Provider) CreateSnapshots(ctx context.Context, ins types.Instance, region string) ([]types.SnapshotInfo, error) {
+	// snaps, err := awslib.MultiRegionFetch(ctx, p.clients, func(ctx context.Context, region string, c Client) ([]types.SnapshotInfo, error) {
+	client := p.clients[region]
+	if client == nil {
+		return nil, fmt.Errorf("error in CreateSnapshots no client for region %s", region)
+	}
+	input := &ec2.CreateSnapshotsInput{
+		InstanceSpecification: &types.InstanceSpecification{
+			InstanceId: ins.InstanceId,
+		},
+		Description: aws.String("Cloudbeat Vulnerability Snapshot."),
+	}
+	result, err := client.CreateSnapshots(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return result.Snapshots, nil
+	// })
+	// return lo.Flatten(snaps), err
 }
 
 // TODO: Maybe we should bulk request snapshots?
 // This will limit us scaling the pipeline
-func (p *Provider) DescribeSnapshots(ctx context.Context, snap types.SnapshotInfo) ([]types.Snapshot, error) {
-	snaps, err := awslib.MultiRegionFetch(ctx, p.clients, func(ctx context.Context, region string, c Client) ([]types.Snapshot, error) {
-		input := &ec2.DescribeSnapshotsInput{
-			SnapshotIds: []string{*snap.SnapshotId},
-		}
-		result, err := c.DescribeSnapshots(ctx, input)
-		if err != nil {
-			return nil, err
-		}
-		return result.Snapshots, nil
-	})
-	return lo.Flatten(snaps), err
+func (p *Provider) DescribeSnapshots(ctx context.Context, snap types.SnapshotInfo, region string) ([]types.Snapshot, error) {
+	// snaps, err := awslib.MultiRegionFetch(ctx, p.clients, func(ctx context.Context, region string, c Client) ([]types.Snapshot, error) {
+	client := p.clients[region]
+	if client == nil {
+		return nil, fmt.Errorf("error in DescribeSnapshots no client for region %s", region)
+	}
+	input := &ec2.DescribeSnapshotsInput{
+		SnapshotIds: []string{*snap.SnapshotId},
+	}
+	result, err := client.DescribeSnapshots(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return result.Snapshots, nil
+	// })
+	// return lo.Flatten(snaps), err
 }

--- a/resources/providers/awslib/ec2/provider_test.go
+++ b/resources/providers/awslib/ec2/provider_test.go
@@ -293,7 +293,7 @@ func TestProvider_DescribeInstances(t *testing.T) {
 				clients:      tt.fields.clients,
 				awsAccountID: tt.fields.awsAccountID,
 			}
-			got, err := p.DescribeInstances(tt.args.ctx)
+			got, err := p.DescribeInstances(tt.args.ctx, "us-east-1")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Provider.DescribeInstances() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -331,7 +331,7 @@ func TestProvider_CreateSnapshots(t *testing.T) {
 				clients:      tt.fields.clients,
 				awsAccountID: tt.fields.awsAccountID,
 			}
-			got, err := p.CreateSnapshots(tt.args.ctx, tt.args.ins)
+			got, err := p.CreateSnapshots(tt.args.ctx, tt.args.ins, "us-east-1")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Provider.CreateSnapshots() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -369,7 +369,7 @@ func TestProvider_DescribeSnapshots(t *testing.T) {
 				clients:      tt.fields.clients,
 				awsAccountID: tt.fields.awsAccountID,
 			}
-			got, err := p.DescribeSnapshots(tt.args.ctx, tt.args.snap)
+			got, err := p.DescribeSnapshots(tt.args.ctx, tt.args.snap, "us-east-1")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Provider.DescribeSnapshots() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/vulnerability/fetcher.go
+++ b/vulnerability/fetcher.go
@@ -41,7 +41,7 @@ func NewVulnerabilityFetcher(log *logp.Logger, provider *ec2.Provider) Vulnerabi
 	}
 }
 
-func (f VulnerabilityFetcher) FetchInstances(ctx context.Context) error {
+func (f VulnerabilityFetcher) FetchInstances(ctx context.Context, region string) error {
 	defer close(f.ch)
 	f.log.Info("Starting VulnerabilityFetcher.FetchInstances")
 	for {
@@ -50,7 +50,7 @@ func (f VulnerabilityFetcher) FetchInstances(ctx context.Context) error {
 			f.log.Info("VulnerabilityFetcher.FetchInstances context canceled")
 			return nil
 		default:
-			ins, err := f.provider.DescribeInstances(ctx)
+			ins, err := f.provider.DescribeInstances(ctx, region)
 			if err != nil {
 				f.log.Errorf("VulnerabilityFetcher.FetchInstances DescribeInstances failed: %v", err)
 				return err

--- a/vulnerability/replicator.go
+++ b/vulnerability/replicator.go
@@ -41,7 +41,7 @@ func NewVulnerabilityReplicator(log *logp.Logger, provider *ec2.Provider) Vulner
 	}
 }
 
-func (f VulnerabilityReplicator) SnapshotInstance(ctx context.Context, insCh chan types.Instance) {
+func (f VulnerabilityReplicator) SnapshotInstance(ctx context.Context, insCh chan types.Instance, region string) {
 	f.log.Info("Starting VulnerabilityReplicator.SnapshotInstance")
 	defer close(f.ch)
 	for {
@@ -54,7 +54,7 @@ func (f VulnerabilityReplicator) SnapshotInstance(ctx context.Context, insCh cha
 				f.log.Info("VulnerabilityReplicator.SnapshotInstance channel is closed")
 				return
 			}
-			sp, err := f.provider.CreateSnapshots(ctx, data)
+			sp, err := f.provider.CreateSnapshots(ctx, data, region)
 			if err != nil {
 				f.log.Errorf("VulnerabilityReplicator.SnapshotInstance.CreateSnapshots failed: %v", err)
 				continue

--- a/vulnerability/runner.go
+++ b/vulnerability/runner.go
@@ -36,59 +36,25 @@ type VulnerabilityRunner struct {
 // initial commit created a new runner every iteration in the evaluator constructor
 func NewVulnerabilityRunner(log *logp.Logger) (VulnerabilityRunner, error) {
 	log.Debug("NewVulnerabilityRunner: New")
-	// TODO: POC REMOVE and pick only what needed
 	opts := flag.Options{
 		GlobalOptions: flag.GlobalOptions{
 			// TODO: Make configurable
 			Timeout: 1 * time.Hour,
 			Quiet:   false,
 			Debug:   true,
-			// CacheDir: "/tmp/trivy",
-			// CacheDir: "/home/ubuntu/.cache/trivy",
 		},
 		VulnerabilityOptions: flag.VulnerabilityOptions{
 			VulnType:      []string{"os", "library"},
 			IgnoreUnfixed: false,
 		},
 		ScanOptions: flag.ScanOptions{
-			// Target: fmt.Sprint("ebs:", *snap.SnapshotId),
-			// Target:         "ebs:snap-07a4a228a916368c5",
-			// Target:         "file:snap-07a4a228a916368c5",
 			SecurityChecks: []string{"vuln"},
 			RekorURL:       "https://rekor.sigstore.dev",
-			// OptFns: func(optFns ...func(*config.LoadOptions) error) []func(*config.LoadOptions) error {
-			// 	return optFns
-			// }(config.WithRegion(c.CloudConfig.AwsCred.DefaultRegion), config.WithCredentialsProvider(&CredentialProvider{
-			// 	AccessKeyID:     c.CloudConfig.AwsCred.AccessKeyID,
-			// 	SecretAccessKey: c.CloudConfig.AwsCred.SecretAccessKey})),
 		},
 		DBOptions: flag.DBOptions{
-			// DownloadDBOnly: true,
-			// SkipDBUpdate: true,
 			DBRepository: "ghcr.io/aquasecurity/trivy-db",
 		},
-		// CacheOptions: flag.CacheOptions{
-		// 	CacheBackend: "fs",
-		// 	ClearCache:   false,
-		// 	CacheTTL:     0,
-		// },
-		// CloudOptions: flag.CloudOptions{
-		// 	MaxCacheAge: 0,
-		// 	UpdateCache: false,
-		// },
-		// ReportOptions: flag.ReportOptions{
-		// 	Output:     o,
-		// 	Format:     "json",
-		// 	Severities: []db_types.Severity{0, 1, 2, 3, 4},
-		// },
 	}
-
-	// config_str := "{\"ConfigFile\":\"trivy.yaml\",\"ShowVersion\":false,\"Quiet\":false,\"Debug\":false,\"Insecure\":false,\"Timeout\":1800000000000,\"CacheDir\":\"/home/ubuntu/.cache/trivy\",\"GenerateDefaultConfig\":false,\"Region\":\"\",\"Endpoint\":\"\",\"Services\":null,\"Account\":\"\",\"ARN\":\"\",\"ClearCache\":false,\"CacheBackend\":\"fs\",\"CacheTTL\":0,\"RedisCACert\":\"\",\"RedisCert\":\"\",\"RedisKey\":\"\",\"MaxCacheAge\":0,\"UpdateCache\":false,\"Reset\":false,\"DownloadDBOnly\":false,\"SkipDBUpdate\":false,\"NoProgress\":false,\"DBRepository\":\"ghcr.io/aquasecurity/trivy-db\",\"Light\":false,\"Input\":\"\",\"ScanRemovedPkgs\":false,\"Platform\":\"\",\"ClusterContext\":\"\",\"Namespace\":\"\",\"KubeConfig\":\"\",\"Components\":null,\"LicenseFull\":false,\"IgnoredLicenses\":null,\"LicenseRiskThreshold\":0,\"LicenseCategories\":{\"forbidden\":[\"AGPL-1.0\",\"AGPL-3.0\",\"CC-BY-NC-1.0\",\"CC-BY-NC-2.0\",\"CC-BY-NC-2.5\",\"CC-BY-NC-3.0\",\"CC-BY-NC-4.0\",\"CC-BY-NC-ND-1.0\",\"CC-BY-NC-ND-2.0\",\"CC-BY-NC-ND-2.5\",\"CC-BY-NC-ND-3.0\",\"CC-BY-NC-ND-4.0\",\"CC-BY-NC-SA-1.0\",\"CC-BY-NC-SA-2.0\",\"CC-BY-NC-SA-2.5\",\"CC-BY-NC-SA-3.0\",\"CC-BY-NC-SA-4.0\",\"Commons-Clause\",\"Facebook-2-Clause\",\"Facebook-3-Clause\",\"Facebook-Examples\",\"WTFPL\"],\"notice\":[\"AFL-1.1\",\"AFL-1.2\",\"AFL-2.0\",\"AFL-2.1\",\"AFL-3.0\",\"Apache-1.0\",\"Apache-1.1\",\"Apache-2.0\",\"Artistic-1.0-cl8\",\"Artistic-1.0-Perl\",\"Artistic-1.0\",\"Artistic-2.0\",\"BSL-1.0\",\"BSD-2-Clause-FreeBSD\",\"BSD-2-Clause-NetBSD\",\"BSD-2-Clause\",\"BSD-3-Clause-Attribution\",\"BSD-3-Clause-Clear\",\"BSD-3-Clause-LBNL\",\"BSD-3-Clause\",\"BSD-4-Clause\",\"BSD-4-Clause-UC\",\"BSD-Protection\",\"CC-BY-1.0\",\"CC-BY-2.0\",\"CC-BY-2.5\",\"CC-BY-3.0\",\"CC-BY-4.0\",\"FTL\",\"ISC\",\"ImageMagick\",\"Libpng\",\"Lil-1.0\",\"Linux-OpenIB\",\"LPL-1.02\",\"LPL-1.0\",\"MS-PL\",\"MIT\",\"NCSA\",\"OpenSSL\",\"PHP-3.01\",\"PHP-3.0\",\"PIL\",\"Python-2.0\",\"Python-2.0-complete\",\"PostgreSQL\",\"SGI-B-1.0\",\"SGI-B-1.1\",\"SGI-B-2.0\",\"Unicode-DFS-2015\",\"Unicode-DFS-2016\",\"Unicode-TOU\",\"UPL-1.0\",\"W3C-19980720\",\"W3C-20150513\",\"W3C\",\"X11\",\"Xnet\",\"Zend-2.0\",\"zlib-acknowledgement\",\"Zlib\",\"ZPL-1.1\",\"ZPL-2.0\",\"ZPL-2.1\"],\"permissive\":null,\"reciprocal\":[\"APSL-1.0\",\"APSL-1.1\",\"APSL-1.2\",\"APSL-2.0\",\"CDDL-1.0\",\"CDDL-1.1\",\"CPL-1.0\",\"EPL-1.0\",\"EPL-2.0\",\"FreeImage\",\"IPL-1.0\",\"MPL-1.0\",\"MPL-1.1\",\"MPL-2.0\",\"Ruby\"],\"restricted\":[\"BCL\",\"CC-BY-ND-1.0\",\"CC-BY-ND-2.0\",\"CC-BY-ND-2.5\",\"CC-BY-ND-3.0\",\"CC-BY-ND-4.0\",\"CC-BY-SA-1.0\",\"CC-BY-SA-2.0\",\"CC-BY-SA-2.5\",\"CC-BY-SA-3.0\",\"CC-BY-SA-4.0\",\"GPL-1.0\",\"GPL-2.0\",\"GPL-2.0-with-autoconf-exception\",\"GPL-2.0-with-bison-exception\",\"GPL-2.0-with-classpath-exception\",\"GPL-2.0-with-font-exception\",\"GPL-2.0-with-GCC-exception\",\"GPL-3.0\",\"GPL-3.0-with-autoconf-exception\",\"GPL-3.0-with-GCC-exception\",\"LGPL-2.0\",\"LGPL-2.1\",\"LGPL-3.0\",\"NPL-1.0\",\"NPL-1.1\",\"OSL-1.0\",\"OSL-1.1\",\"OSL-2.0\",\"OSL-2.1\",\"OSL-3.0\",\"QPL-1.0\",\"Sleepycat\"],\"unencumbered\":[\"CC0-1.0\",\"Unlicense\",\"0BSD\"]},\"IncludeNonFailures\":false,\"HelmValues\":null,\"HelmValueFiles\":null,\"HelmFileValues\":null,\"HelmStringValues\":null,\"TerraformTFVars\":null,\"SkipPolicyUpdate\":false,\"Trace\":false,\"PolicyPaths\":null,\"DataPaths\":null,\"PolicyNamespaces\":null,\"Token\":\"\",\"TokenHeader\":\"Trivy-Token\",\"ServerAddr\":\"\",\"Listen\":\"\",\"CustomHeaders\":{},\"RepoBranch\":\"\",\"RepoCommit\":\"\",\"RepoTag\":\"\",\"Format\":\"table\",\"ReportFormat\":\"\",\"Template\":\"\",\"DependencyTree\":false,\"ListAllPkgs\":false,\"IgnoreFile\":\".trivyignore\",\"ExitCode\":0,\"IgnorePolicy\":\"\",\"Output\":{},\"Severities\":[0,1,2,3,4],\"Compliance\":\"\",\"ArtifactType\":\"\",\"SBOMFormat\":\"\",\"Target\":\"ebs:snap-1726726362\",\"SkipDirs\":null,\"SkipFiles\":null,\"OfflineScan\":false,\"SecurityChecks\":[\"vuln\"],\"FilePatterns\":null,\"Slow\":false,\"SBOMSources\":null,\"RekorURL\":\"https://rekor.sigstore.dev\",\"SecretConfigPath\":\"trivy-secret.yaml\",\"VulnType\":[\"os\",\"library\"],\"IgnoreUnfixed\":false,\"AppVersion\":\"0.35.0-48-g62b369ee\",\"DisabledAnalyzers\":null}"
-	// data := flag.Options{}
-	// json.Unmarshal([]byte(config_str), &data)
-
-	// res2B, _ := json.Marshal(data)
-	// fmt.Println("JENIA THIS OPTS: ", string(res2B))
 
 	runner, err := artifact.NewRunner(context.Background(), opts)
 	if err != nil {

--- a/vulnerability/runner.go
+++ b/vulnerability/runner.go
@@ -56,6 +56,11 @@ func NewVulnerabilityRunner(log *logp.Logger) (VulnerabilityRunner, error) {
 			// Target:         "file:snap-07a4a228a916368c5",
 			SecurityChecks: []string{"vuln"},
 			RekorURL:       "https://rekor.sigstore.dev",
+			// OptFns: func(optFns ...func(*config.LoadOptions) error) []func(*config.LoadOptions) error {
+			// 	return optFns
+			// }(config.WithRegion(c.CloudConfig.AwsCred.DefaultRegion), config.WithCredentialsProvider(&CredentialProvider{
+			// 	AccessKeyID:     c.CloudConfig.AwsCred.AccessKeyID,
+			// 	SecretAccessKey: c.CloudConfig.AwsCred.SecretAccessKey})),
 		},
 		DBOptions: flag.DBOptions{
 			// DownloadDBOnly: true,

--- a/vulnerability/scanner.go
+++ b/vulnerability/scanner.go
@@ -20,11 +20,13 @@ package vulnerability
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
+	cb_config "github.com/elastic/cloudbeat/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
 
@@ -32,18 +34,33 @@ import (
 	"github.com/aquasecurity/trivy/pkg/commands/artifact"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	trivy_types "github.com/aquasecurity/trivy/pkg/types"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	ec2_types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
+
+type CredentialProvider struct {
+	AccessKeyID     string
+	SecretAccessKey string
+}
+
+func (p *CredentialProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
+	return aws.Credentials{
+		AccessKeyID:     p.AccessKeyID,
+		SecretAccessKey: p.SecretAccessKey,
+	}, nil
+}
 
 type VulnerabilityScanner struct {
 	log *logp.Logger
 	// TODO: Change to type that includes snapshot for deletion after evaluation
 	ch     chan beat.Event
 	runner artifact.Runner
+	cfg    *cb_config.Config
 }
 
 // TODO: Take region from config or from snapshot
-func NewVulnerabilityScanner(log *logp.Logger, runner artifact.Runner) (VulnerabilityScanner, error) {
+func NewVulnerabilityScanner(log *logp.Logger, runner artifact.Runner, c *cb_config.Config) (VulnerabilityScanner, error) {
 	log.Debug("VulnerabilityScanner: New")
 	ch := make(chan beat.Event)
 
@@ -110,6 +127,7 @@ func NewVulnerabilityScanner(log *logp.Logger, runner artifact.Runner) (Vulnerab
 		log:    log,
 		ch:     ch,
 		runner: runner,
+		cfg:    c,
 	}, nil
 }
 
@@ -144,10 +162,10 @@ func (f VulnerabilityScanner) evaluate(ctx context.Context, snap ec2_types.Snaps
 	defer os.Remove(o.Name())
 
 	opts := flag.Options{
-		AWSOptions: flag.AWSOptions{
-			// TODO: Take region from config
-			Region: "eu-west-1",
-		},
+		// AWSOptions: flag.AWSOptions{
+		// 	// TODO: Take region from config
+		// 	Region: "eu-west-1",
+		// },
 		GlobalOptions: flag.GlobalOptions{
 			// TODO: Make configurable
 			Timeout: 1 * time.Hour,
@@ -160,11 +178,16 @@ func (f VulnerabilityScanner) evaluate(ctx context.Context, snap ec2_types.Snaps
 			IgnoreUnfixed: false,
 		},
 		ScanOptions: flag.ScanOptions{
-			// Target: fmt.Sprint("ebs:", *snap.SnapshotId),
+			Target: fmt.Sprint("ebs:", *snap.SnapshotId),
 			// Target:         "ebs:snap-07a4a228a916368c5",
-			Target:         "file:ebs_8g.img",
+			// Target:         "file:ebs_8g.img",
 			SecurityChecks: []string{"vuln"},
 			RekorURL:       "https://rekor.sigstore.dev",
+			OptFns: func(optFns ...func(*config.LoadOptions) error) []func(*config.LoadOptions) error {
+				return optFns
+			}(config.WithRegion(f.cfg.CloudConfig.AwsCred.DefaultRegion), config.WithCredentialsProvider(&CredentialProvider{
+				AccessKeyID:     f.cfg.CloudConfig.AwsCred.AccessKeyID,
+				SecretAccessKey: f.cfg.CloudConfig.AwsCred.SecretAccessKey})),
 		},
 		DBOptions: flag.DBOptions{
 			// SkipDBUpdate: true,

--- a/vulnerability/scanner.go
+++ b/vulnerability/scanner.go
@@ -59,69 +59,9 @@ type VulnerabilityScanner struct {
 	cfg    *cb_config.Config
 }
 
-// TODO: Take region from config or from snapshot
 func NewVulnerabilityScanner(log *logp.Logger, runner artifact.Runner, c *cb_config.Config) (VulnerabilityScanner, error) {
 	log.Debug("VulnerabilityScanner: New")
 	ch := make(chan beat.Event)
-
-	// // TODO: POC REMOVE and pick only what needed
-	// opts := flag.Options{
-	// 	AWSOptions: flag.AWSOptions{
-	// 		// TODO: Take region from config
-	// 		Region: "eu-west-1",
-	// 	},
-	// 	GlobalOptions: flag.GlobalOptions{
-	// 		// TODO: Make configurable
-	// 		Timeout: 1 * time.Hour,
-	// 		Quiet:   false,
-	// 		Debug:   true,
-	// 		// CacheDir: "/tmp/trivy",
-	// 		// CacheDir: "/home/ubuntu/.cache/trivy",
-	// 	},
-	// 	VulnerabilityOptions: flag.VulnerabilityOptions{
-	// 		VulnType:      []string{"os", "library"},
-	// 		IgnoreUnfixed: false,
-	// 	},
-	// 	ScanOptions: flag.ScanOptions{
-	// 		// Target: fmt.Sprint("ebs:", *snap.SnapshotId),
-	// 		// Target:         "ebs:snap-07a4a228a916368c5",
-	// 		// Target:         "file:snap-07a4a228a916368c5",
-	// 		SecurityChecks: []string{"vuln"},
-	// 		RekorURL:       "https://rekor.sigstore.dev",
-	// 	},
-	// 	DBOptions: flag.DBOptions{
-	// 		// DownloadDBOnly: true,
-	// 		// SkipDBUpdate: true,
-	// 		DBRepository: "ghcr.io/aquasecurity/trivy-db",
-	// 	},
-	// 	CacheOptions: flag.CacheOptions{
-	// 		CacheBackend: "fs",
-	// 		ClearCache:   false,
-	// 		CacheTTL:     0,
-	// 	},
-	// 	// CloudOptions: flag.CloudOptions{
-	// 	// 	MaxCacheAge: 0,
-	// 	// 	UpdateCache: false,
-	// 	// },
-	// 	// ReportOptions: flag.ReportOptions{
-	// 	// 	Output:     o,
-	// 	// 	Format:     "json",
-	// 	// 	Severities: []db_types.Severity{0, 1, 2, 3, 4},
-	// 	// },
-	// }
-
-	// config_str := "{\"ConfigFile\":\"trivy.yaml\",\"ShowVersion\":false,\"Quiet\":false,\"Debug\":false,\"Insecure\":false,\"Timeout\":1800000000000,\"CacheDir\":\"/home/ubuntu/.cache/trivy\",\"GenerateDefaultConfig\":false,\"Region\":\"\",\"Endpoint\":\"\",\"Services\":null,\"Account\":\"\",\"ARN\":\"\",\"ClearCache\":false,\"CacheBackend\":\"fs\",\"CacheTTL\":0,\"RedisCACert\":\"\",\"RedisCert\":\"\",\"RedisKey\":\"\",\"MaxCacheAge\":0,\"UpdateCache\":false,\"Reset\":false,\"DownloadDBOnly\":false,\"SkipDBUpdate\":false,\"NoProgress\":false,\"DBRepository\":\"ghcr.io/aquasecurity/trivy-db\",\"Light\":false,\"Input\":\"\",\"ScanRemovedPkgs\":false,\"Platform\":\"\",\"ClusterContext\":\"\",\"Namespace\":\"\",\"KubeConfig\":\"\",\"Components\":null,\"LicenseFull\":false,\"IgnoredLicenses\":null,\"LicenseRiskThreshold\":0,\"LicenseCategories\":{\"forbidden\":[\"AGPL-1.0\",\"AGPL-3.0\",\"CC-BY-NC-1.0\",\"CC-BY-NC-2.0\",\"CC-BY-NC-2.5\",\"CC-BY-NC-3.0\",\"CC-BY-NC-4.0\",\"CC-BY-NC-ND-1.0\",\"CC-BY-NC-ND-2.0\",\"CC-BY-NC-ND-2.5\",\"CC-BY-NC-ND-3.0\",\"CC-BY-NC-ND-4.0\",\"CC-BY-NC-SA-1.0\",\"CC-BY-NC-SA-2.0\",\"CC-BY-NC-SA-2.5\",\"CC-BY-NC-SA-3.0\",\"CC-BY-NC-SA-4.0\",\"Commons-Clause\",\"Facebook-2-Clause\",\"Facebook-3-Clause\",\"Facebook-Examples\",\"WTFPL\"],\"notice\":[\"AFL-1.1\",\"AFL-1.2\",\"AFL-2.0\",\"AFL-2.1\",\"AFL-3.0\",\"Apache-1.0\",\"Apache-1.1\",\"Apache-2.0\",\"Artistic-1.0-cl8\",\"Artistic-1.0-Perl\",\"Artistic-1.0\",\"Artistic-2.0\",\"BSL-1.0\",\"BSD-2-Clause-FreeBSD\",\"BSD-2-Clause-NetBSD\",\"BSD-2-Clause\",\"BSD-3-Clause-Attribution\",\"BSD-3-Clause-Clear\",\"BSD-3-Clause-LBNL\",\"BSD-3-Clause\",\"BSD-4-Clause\",\"BSD-4-Clause-UC\",\"BSD-Protection\",\"CC-BY-1.0\",\"CC-BY-2.0\",\"CC-BY-2.5\",\"CC-BY-3.0\",\"CC-BY-4.0\",\"FTL\",\"ISC\",\"ImageMagick\",\"Libpng\",\"Lil-1.0\",\"Linux-OpenIB\",\"LPL-1.02\",\"LPL-1.0\",\"MS-PL\",\"MIT\",\"NCSA\",\"OpenSSL\",\"PHP-3.01\",\"PHP-3.0\",\"PIL\",\"Python-2.0\",\"Python-2.0-complete\",\"PostgreSQL\",\"SGI-B-1.0\",\"SGI-B-1.1\",\"SGI-B-2.0\",\"Unicode-DFS-2015\",\"Unicode-DFS-2016\",\"Unicode-TOU\",\"UPL-1.0\",\"W3C-19980720\",\"W3C-20150513\",\"W3C\",\"X11\",\"Xnet\",\"Zend-2.0\",\"zlib-acknowledgement\",\"Zlib\",\"ZPL-1.1\",\"ZPL-2.0\",\"ZPL-2.1\"],\"permissive\":null,\"reciprocal\":[\"APSL-1.0\",\"APSL-1.1\",\"APSL-1.2\",\"APSL-2.0\",\"CDDL-1.0\",\"CDDL-1.1\",\"CPL-1.0\",\"EPL-1.0\",\"EPL-2.0\",\"FreeImage\",\"IPL-1.0\",\"MPL-1.0\",\"MPL-1.1\",\"MPL-2.0\",\"Ruby\"],\"restricted\":[\"BCL\",\"CC-BY-ND-1.0\",\"CC-BY-ND-2.0\",\"CC-BY-ND-2.5\",\"CC-BY-ND-3.0\",\"CC-BY-ND-4.0\",\"CC-BY-SA-1.0\",\"CC-BY-SA-2.0\",\"CC-BY-SA-2.5\",\"CC-BY-SA-3.0\",\"CC-BY-SA-4.0\",\"GPL-1.0\",\"GPL-2.0\",\"GPL-2.0-with-autoconf-exception\",\"GPL-2.0-with-bison-exception\",\"GPL-2.0-with-classpath-exception\",\"GPL-2.0-with-font-exception\",\"GPL-2.0-with-GCC-exception\",\"GPL-3.0\",\"GPL-3.0-with-autoconf-exception\",\"GPL-3.0-with-GCC-exception\",\"LGPL-2.0\",\"LGPL-2.1\",\"LGPL-3.0\",\"NPL-1.0\",\"NPL-1.1\",\"OSL-1.0\",\"OSL-1.1\",\"OSL-2.0\",\"OSL-2.1\",\"OSL-3.0\",\"QPL-1.0\",\"Sleepycat\"],\"unencumbered\":[\"CC0-1.0\",\"Unlicense\",\"0BSD\"]},\"IncludeNonFailures\":false,\"HelmValues\":null,\"HelmValueFiles\":null,\"HelmFileValues\":null,\"HelmStringValues\":null,\"TerraformTFVars\":null,\"SkipPolicyUpdate\":false,\"Trace\":false,\"PolicyPaths\":null,\"DataPaths\":null,\"PolicyNamespaces\":null,\"Token\":\"\",\"TokenHeader\":\"Trivy-Token\",\"ServerAddr\":\"\",\"Listen\":\"\",\"CustomHeaders\":{},\"RepoBranch\":\"\",\"RepoCommit\":\"\",\"RepoTag\":\"\",\"Format\":\"table\",\"ReportFormat\":\"\",\"Template\":\"\",\"DependencyTree\":false,\"ListAllPkgs\":false,\"IgnoreFile\":\".trivyignore\",\"ExitCode\":0,\"IgnorePolicy\":\"\",\"Output\":{},\"Severities\":[0,1,2,3,4],\"Compliance\":\"\",\"ArtifactType\":\"\",\"SBOMFormat\":\"\",\"Target\":\"ebs:snap-1726726362\",\"SkipDirs\":null,\"SkipFiles\":null,\"OfflineScan\":false,\"SecurityChecks\":[\"vuln\"],\"FilePatterns\":null,\"Slow\":false,\"SBOMSources\":null,\"RekorURL\":\"https://rekor.sigstore.dev\",\"SecretConfigPath\":\"trivy-secret.yaml\",\"VulnType\":[\"os\",\"library\"],\"IgnoreUnfixed\":false,\"AppVersion\":\"0.35.0-48-g62b369ee\",\"DisabledAnalyzers\":null}"
-	// data := flag.Options{}
-	// json.Unmarshal([]byte(config_str), &data)
-
-	// res2B, _ := json.Marshal(data)
-	// fmt.Println("JENIA THIS OPTS: ", string(res2B))
-
-	// runner, err := artifact.NewRunner(context.Background(), opts)
-	// if err != nil {
-	// 	log.Error("VulnerabilityScanner: NewRunner error: ", err)
-	// 	return VulnerabilityScanner{}, err
-	// }
 
 	return VulnerabilityScanner{
 		log:    log,
@@ -153,7 +93,6 @@ func (f VulnerabilityScanner) EvaluateSnapshot(ctx context.Context, snapCh chan 
 
 func (f VulnerabilityScanner) evaluate(ctx context.Context, snap ec2_types.Snapshot) {
 	f.log.Info("Starting VulnerabilityScanner.evaluate")
-	f.log.Info("JENIA SNAPS3", *snap.Description, *snap.SnapshotId, *snap.Progress, snap.State)
 	o, err := os.CreateTemp("", "")
 	if err != nil {
 		f.log.Error("VulnerabilityScanner.evaluate.TempFile error: ", err)
@@ -162,35 +101,23 @@ func (f VulnerabilityScanner) evaluate(ctx context.Context, snap ec2_types.Snaps
 	defer os.Remove(o.Name())
 
 	opts := flag.Options{
-		// AWSOptions: flag.AWSOptions{
-		// 	// TODO: Take region from config
-		// 	Region: "eu-west-1",
-		// },
 		GlobalOptions: flag.GlobalOptions{
 			// TODO: Make configurable
 			Timeout: 1 * time.Hour,
 			Quiet:   false,
 			Debug:   true,
-			// CacheDir: "/tmp/trivy",
 		},
 		VulnerabilityOptions: flag.VulnerabilityOptions{
 			VulnType:      []string{"os", "library"},
 			IgnoreUnfixed: false,
 		},
 		ScanOptions: flag.ScanOptions{
-			Target: fmt.Sprint("ebs:", *snap.SnapshotId),
-			// Target:         "ebs:snap-07a4a228a916368c5",
-			// Target:         "file:ebs_8g.img",
+			Target:         fmt.Sprint("ebs:", *snap.SnapshotId),
 			SecurityChecks: []string{"vuln"},
 			RekorURL:       "https://rekor.sigstore.dev",
-			OptFns: func(optFns ...func(*config.LoadOptions) error) []func(*config.LoadOptions) error {
-				return optFns
-			}(config.WithRegion(f.cfg.CloudConfig.AwsCred.DefaultRegion), config.WithCredentialsProvider(&CredentialProvider{
-				AccessKeyID:     f.cfg.CloudConfig.AwsCred.AccessKeyID,
-				SecretAccessKey: f.cfg.CloudConfig.AwsCred.SecretAccessKey})),
+			OptFns:         f.getOptFns(),
 		},
 		DBOptions: flag.DBOptions{
-			// SkipDBUpdate: true,
 			DBRepository: "ghcr.io/aquasecurity/trivy-db",
 		},
 		ReportOptions: flag.ReportOptions{
@@ -199,13 +126,6 @@ func (f VulnerabilityScanner) evaluate(ctx context.Context, snap ec2_types.Snaps
 			Severities: []db_types.Severity{0, 1, 2, 3, 4},
 		},
 	}
-
-	// f.log.Info("VulnerabilityScanner.evaluate.NewRunner")
-	// r, err := artifact.NewRunner(ctx, opts)
-	// if err != nil {
-	// 	f.log.Error("VulnerabilityScanner.evaluate.NewRunner error: ", err)
-	// 	return
-	// }
 
 	f.log.Info("VulnerabilityScanner.evaluate.ScanVM")
 	report, err := f.runner.ScanVM(ctx, opts)
@@ -245,11 +165,6 @@ func (f VulnerabilityScanner) evaluate(ctx context.Context, snap ec2_types.Snaps
 		return
 	}
 
-	// file, _ := json.MarshalIndent(result, "", " ")
-	// _ = os.WriteFile("JENIA_RES_NEW.json", file, 0644)
-	// evn, _ := json.Marshal(result)
-	// f.log.Info("VulnerabilityScanner.evaluate.JENIARES", string(evn))
-
 	f.ch <- beat.Event{
 		Fields: mapstr.M{"result": result},
 	}
@@ -259,4 +174,12 @@ func (f VulnerabilityScanner) evaluate(ctx context.Context, snap ec2_types.Snaps
 
 func (f VulnerabilityScanner) GetChan() chan beat.Event {
 	return f.ch
+}
+
+func (f VulnerabilityScanner) getOptFns() []func(*config.LoadOptions) error {
+	return func(optFns ...func(*config.LoadOptions) error) []func(*config.LoadOptions) error {
+		return optFns
+	}(config.WithRegion(f.cfg.CloudConfig.AwsCred.DefaultRegion), config.WithCredentialsProvider(&CredentialProvider{
+		AccessKeyID:     f.cfg.CloudConfig.AwsCred.AccessKeyID,
+		SecretAccessKey: f.cfg.CloudConfig.AwsCred.SecretAccessKey}))
 }

--- a/vulnerability/verifier.go
+++ b/vulnerability/verifier.go
@@ -43,7 +43,7 @@ func NewVulnerabilityVerifier(log *logp.Logger, provider *ec2.Provider) Vulnerab
 }
 
 // TODO: Maybe verify more than one snapshot
-func (f VulnerabilityVerifier) VerifySnapshot(ctx context.Context, snapCh chan types.SnapshotInfo) {
+func (f VulnerabilityVerifier) VerifySnapshot(ctx context.Context, snapCh chan types.SnapshotInfo, region string) {
 	f.log.Info("Starting VulnerabilityVerifier.VerifySnapshot")
 	defer close(f.ch)
 	for {
@@ -56,12 +56,12 @@ func (f VulnerabilityVerifier) VerifySnapshot(ctx context.Context, snapCh chan t
 				f.log.Info("VulnerabilityVerifier.VerifySnapshot channel is closed")
 				return
 			}
-			f.verify(ctx, data)
+			f.verify(ctx, data, region)
 		}
 	}
 }
 
-func (f VulnerabilityVerifier) verify(ctx context.Context, snap types.SnapshotInfo) {
+func (f VulnerabilityVerifier) verify(ctx context.Context, snap types.SnapshotInfo, region string) {
 	f.log.Info("Starting VulnerabilityVerifier.verify")
 	// TODO: Change this to variable
 	timer := time.After(5 * time.Minute)
@@ -75,7 +75,7 @@ func (f VulnerabilityVerifier) verify(ctx context.Context, snap types.SnapshotIn
 			return
 		// TODO: Change this to variable
 		case <-time.After(15 * time.Second):
-			sp, err := f.provider.DescribeSnapshots(ctx, snap)
+			sp, err := f.provider.DescribeSnapshots(ctx, snap, region)
 			if err != nil {
 				f.log.Errorf("VulnerabilityVerifier.verify.DescribeSnapshots failed: %v", err)
 				continue

--- a/vulnerability/worker.go
+++ b/vulnerability/worker.go
@@ -31,10 +31,9 @@ import (
 )
 
 type VulnerabilityWorker struct {
-	log      *logp.Logger
-	cfg      *config.Config
-	provider *ec2.Provider
-	// cloudIdentity *awslib.Identity
+	log        *logp.Logger
+	cfg        *config.Config
+	provider   *ec2.Provider
 	fetcher    VulnerabilityFetcher
 	replicator VulnerabilityReplicator
 	verifier   VulnerabilityVerifier
@@ -46,44 +45,26 @@ type VulnerabilityWorker struct {
 
 func NewVulnerabilityWorker(log *logp.Logger, c *config.Config, runner VulnerabilityRunner) (*VulnerabilityWorker, error) {
 	log.Debug("VulnerabilityWorker: New")
-	// ctx := context.Background()
-
-	// acp := awslib.ConfigProvider{MetadataProvider: awslib.Ec2MetadataProvider{}}
-	// awsConfig, err := acp.InitializeAWSConfig(ctx, c.CloudConfig.AwsCred)
-	// log.Info("VulnerabilityWorker: New - InitializeAWSConfig")
 	awsConfig, err := libbeat_aws.InitializeAWSConfig(c.CloudConfig.AwsCred)
 	if err != nil {
 		return nil, fmt.Errorf("VulnerabilityWorker: failed to initialize AWS credentials: %w", err)
 	}
 
-	// identityProvider := awslib.GetIdentityClient(awsConfig)
-	// identity, err := identityProvider.GetIdentity(ctx)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("VulnerabilityWorker: could not get cloud indentity: %w", err)
-	// }
-
-	// provider := ec2.NewEC2Provider(log, *identity.Account, awsConfig)
-	// log.Info("VulnerabilityWorker: New - NewEC2Provider")
 	provider := ec2.NewEC2Provider(log, "", awsConfig, &awslib.MultiRegionClientFactory[ec2.Client]{})
 
-	// log.Info("VulnerabilityWorker: New - NewVulnerabilityFetcher")
 	fetcher := NewVulnerabilityFetcher(log, provider)
-	// log.Info("VulnerabilityWorker: New - NewVulnerabilityReplicator")
 	replicator := NewVulnerabilityReplicator(log, provider)
-	// log.Info("VulnerabilityWorker: New - NewVulnerabilityVerifier")
 	verifier := NewVulnerabilityVerifier(log, provider)
-	// log.Info("VulnerabilityWorker: New - NewVulnerabilityScanner")
+
 	evaluator, err := NewVulnerabilityScanner(log, runner.GetRunner(), c)
 	if err != nil {
 		return nil, fmt.Errorf("VulnerabilityWorker: could not get init NewVulnerabilityScanner: %w", err)
 	}
 
-	// log.Info("VulnerabilityWorker: New - NewVulnerabilityWorker")
 	return &VulnerabilityWorker{
-		log:      log,
-		cfg:      c,
-		provider: provider,
-		// cloudIdentity: identity,
+		log:        log,
+		cfg:        c,
+		provider:   provider,
 		fetcher:    fetcher,
 		replicator: replicator,
 		verifier:   verifier,
@@ -93,13 +74,6 @@ func NewVulnerabilityWorker(log *logp.Logger, c *config.Config, runner Vulnerabi
 		region:     awsConfig.Region,
 	}, nil
 }
-
-// // TODO: Maybe verify more than one snapshot
-// func (f *VulnerabilityWorker) Run(ctx context.Context) error {
-// 	f.log.Info("Starting VulnerabilityWorker.Run")
-// 	go f.work(ctx)
-// 	return nil
-// }
 
 func (f *VulnerabilityWorker) Run(ctx context.Context) {
 	// TODO: Handle deletion of snapshots

--- a/vulnerability/worker.go
+++ b/vulnerability/worker.go
@@ -41,6 +41,7 @@ type VulnerabilityWorker struct {
 	evaluator  VulnerabilityScanner
 	runner     VulnerabilityRunner
 	wg         sync.WaitGroup
+	region     string
 }
 
 func NewVulnerabilityWorker(log *logp.Logger, c *config.Config, runner VulnerabilityRunner) (*VulnerabilityWorker, error) {
@@ -72,7 +73,7 @@ func NewVulnerabilityWorker(log *logp.Logger, c *config.Config, runner Vulnerabi
 	// log.Info("VulnerabilityWorker: New - NewVulnerabilityVerifier")
 	verifier := NewVulnerabilityVerifier(log, provider)
 	// log.Info("VulnerabilityWorker: New - NewVulnerabilityScanner")
-	evaluator, err := NewVulnerabilityScanner(log, runner.GetRunner())
+	evaluator, err := NewVulnerabilityScanner(log, runner.GetRunner(), c)
 	if err != nil {
 		return nil, fmt.Errorf("VulnerabilityWorker: could not get init NewVulnerabilityScanner: %w", err)
 	}
@@ -89,6 +90,7 @@ func NewVulnerabilityWorker(log *logp.Logger, c *config.Config, runner Vulnerabi
 		evaluator:  evaluator,
 		runner:     runner,
 		wg:         sync.WaitGroup{},
+		region:     awsConfig.Region,
 	}, nil
 }
 
@@ -111,7 +113,7 @@ func (f *VulnerabilityWorker) Run(ctx context.Context) {
 			f.wg.Add(1)
 			go func() {
 				defer f.wg.Done()
-				err := f.fetcher.FetchInstances(ctx)
+				err := f.fetcher.FetchInstances(ctx, f.region)
 				if err != nil {
 					f.log.Error("VulnerabilityWorker.work FetchInstances failed: %v", err)
 					return
@@ -121,13 +123,13 @@ func (f *VulnerabilityWorker) Run(ctx context.Context) {
 			f.wg.Add(1)
 			go func() {
 				defer f.wg.Done()
-				f.replicator.SnapshotInstance(ctx, f.fetcher.GetChan())
+				f.replicator.SnapshotInstance(ctx, f.fetcher.GetChan(), f.region)
 				f.log.Info("VulnerabilityWorker.work SnapshotInstance finished")
 			}()
 			f.wg.Add(1)
 			go func() {
 				defer f.wg.Done()
-				f.verifier.VerifySnapshot(ctx, f.replicator.GetChan())
+				f.verifier.VerifySnapshot(ctx, f.replicator.GetChan(), f.region)
 				f.log.Info("VulnerabilityWorker.work VerifySnapshot finished")
 			}()
 			f.wg.Add(1)


### PR DESCRIPTION
### Summary of your changes
Adding the ability to configure the AWS config that `Trivy` uses in order to scan EBS snapshots.
Currently, this is a temporary solution and is based on a forked `Trivy` using the following commits:
- https://github.com/masahiro331/go-ebs-file/pull/2
- https://github.com/jeniawhite/trivy/commit/77c59c27eda01973cfb9fe86e16bc3b19b4fa70b

### Related Issues
- Related: https://github.com/elastic/cloudbeat/issues/727

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
