### PR TITLE
Rename deployment to type as in integration

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -50,7 +50,7 @@ func NewBeater(b *beat.Beat, cfg *agentconfig.C) (beat.Beater, error) {
 	if err != nil {
 		return nil, fmt.Errorf("NewBeater: could not parse configuration %v, skipping with error: %w", cfg.FlattenedKeys(), err)
 	}
-	switch c.Deployment {
+	switch c.Type {
 	case config.VulnerabilityType:
 		return flavors.NewVulnerability(b, cfg)
 	default:

--- a/config/config.go
+++ b/config/config.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	DefaultNamespace             = "default"
-	VulnerabilityType            = "cloudbeat/vuln_mgmt_aws"
+	VulnerabilityType            = "vuln_mgmt"
 	ResultsDatastreamIndexPrefix = "logs-cloud_security_posture.findings"
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ type Fetcher struct {
 
 type Config struct {
 	Benchmark   string                  `config:"config.v1.benchmark"`
-	Deployment  string                  `config:"config.v1.deployment"`
+	Type        string                  `config:"config.v1.type"`
 	CloudConfig CloudConfig             `config:"config.v1"`
 	Fetchers    []*config.C             `config:"fetchers"`
 	KubeConfig  string                  `config:"kube_config"`

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,7 @@ type Fetcher struct {
 type Config struct {
 	Benchmark   string                  `config:"config.v1.benchmark"`
 	Type        string                  `config:"config.v1.type"`
+	Deployment  string                  `config:"config.v1.deployment"`
 	CloudConfig CloudConfig             `config:"config.v1"`
 	Fetchers    []*config.C             `config:"fetchers"`
 	KubeConfig  string                  `config:"kube_config"`


### PR DESCRIPTION
### Summary of your changes
Same as the integration works. We expect the `v1.config.type` to contain `cspm | kspm | vuln_mgmt`.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
