### PR TITLE
Add license override for spdx/tools-golang

### DIFF
--- a/scripts/make/generate_notice.py
+++ b/scripts/make/generate_notice.py
@@ -28,6 +28,7 @@ notice_overrides = [
     {"name": "github.com/build-security/beats/v7", "licenceType": "Elastic"},
     {"name": "github.com/elastic/csp-security-policies", "licenceType": "Elastic"},
     {"name": "github.com/golang/glog", "licenceType": "Apache-2.0"},
+    {"name": "github.com/spdx/tools-golang", "licenceFile": "LICENSE.code", "licenceType": "Apache-2.0"},
 ]
 
 # Additional third-party, non-source code dependencies, to add to the CSV output.


### PR DESCRIPTION
### Summary of your changes
Cloudbeat has a dependency, https://github.com/spdx/tools-golang, with a license file named LICENSE.docs which is not supported by go-license-detector.
In order to support this, I add an override for this repository as suggested https://github.com/elastic/go-licence-detector/pull/21#discussion_r1142966373.
### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
