### PR TITLE
Update build timeout in eks-ci workflow

### DIFF
--- a/.github/workflows/eks-ci.yml
+++ b/.github/workflows/eks-ci.yml
@@ -53,7 +53,7 @@ jobs:
   Build:
     name: Build
     runs-on: ubuntu-20.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
### Summary of your changes

According to the latest runs ([run-1](https://github.com/elastic/cloudbeat/actions/runs/4502240659/jobs/7923779699), [run-2](https://github.com/elastic/cloudbeat/actions/runs/4498747448/jobs/7915746694)) the build job in eks-ci flow is not finished and interrupted due timeout event.
This PR updates Build job timeout-minutes value.
