### PR TITLE
global mage call in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ release-manager-release: release
 
 release: export PATH:=$(dir $(BIN_MAGE)):$(PATH)
 release: $(MAGE) $(PYTHON) build/dependencies.csv
-	$(MAGE) package
+	mage package
 
 build/dependencies.csv: $(PYTHON) go.mod
 ifdef SNAPSHOT


### PR DESCRIPTION
### Summary of your changes
This fix is done in order to fix the [publish workflow](https://internal-ci.elastic.co/blue/organizations/jenkins/cloudbeat%2Fcloudbeat-mbp/detail/main/363/pipeline) temporarily

