### PR TITLE
Remove compilation of magefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ GENPACKAGE=$(GOOSBUILD)/genpackage
 GOIMPORTS=$(GOOSBUILD)/goimports
 GOLICENSER=$(GOOSBUILD)/go-licenser
 GOLINT=$(GOOSBUILD)/golint
-MAGE=$(GOOSBUILD)/mage
 REVIEWDOG=$(GOOSBUILD)/reviewdog
 STATICCHECK=$(GOOSBUILD)/staticcheck
 ELASTICPACKAGE=$(GOOSBUILD)/elastic-package
@@ -63,20 +62,20 @@ deactivate-hermit:
 .DEFAULT_GOAL := cloudbeat
 
 .PHONY: cloudbeat
-cloudbeat: $(MAGE)
-	@$(MAGE) build
+cloudbeat:
+	mage build
 
 .PHONY: test
 test:
 	$(GO) test $(GOTESTFLAGS) ./...
 
 .PHONY:
-clean: $(MAGE)
-	@$(MAGE) clean
+clean: 
+	mage clean
 
 .PHONY: PackageAgent
-PackageAgent: $(MAGE)
-	SNAPSHOT=TRUE PLATFORMS=linux/$(shell $(GO) env GOARCH) TYPES=tar.gz $(MAGE) -v $@
+PackageAgent:
+	SNAPSHOT=TRUE PLATFORMS=linux/$(shell $(GO) env GOARCH) TYPES=tar.gz mage -v $@
 
 # elastic_agent_docker_image builds the Cloud Elastic Agent image
 # with the local APM Server binary injected. The image will be based
@@ -104,8 +103,8 @@ check-approvals: $(APPROVALS)
 	@$(APPROVALS)
 
 .PHONY: check
-check: $(MAGE) check-fmt check-headers
-	@$(MAGE) check
+check: check-fmt check-headers
+	mage check
 
 .PHONY: bench
 bench:
@@ -115,12 +114,12 @@ bench:
 # Rules for updating config files, etc.
 ##############################################################################
 
-#update: go-generate add-headers build-package notice $(MAGE)
-update: go-generate add-headers $(MAGE)
+#update: go-generate add-headers build-package notice mage
+update: go-generate add-headers
 	@go mod download all # make sure go.sum is complete
 
 config:
-	@$(MAGE) config
+	mage config
 
 .PHONY: go-generate
 go-generate:
@@ -209,16 +208,6 @@ autopep8: $(PYTHON_BIN)
 # Rules for creating and installing build tools.
 ##############################################################################
 
-BIN_MAGE=$(GOOSBUILD)/bin/mage
-
-# BIN_MAGE is the standard "mage" binary.
-$(BIN_MAGE): go.mod
-	$(GO) build -o $@ github.com/magefile/mage
-
-# MAGE is the compiled magefile.
-$(MAGE): magefile.go $(BIN_MAGE)
-	$(BIN_MAGE) -compile=$@
-
 $(GOLINT): go.mod
 	$(GO) build -o $@ golang.org/x/lint/golint
 
@@ -239,8 +228,8 @@ $(ELASTICPACKAGE): utils/go.mod
 
 $(PYTHON): $(PYTHON_BIN)
 $(PYTHON_BIN): $(PYTHON_BIN)/activate
-$(PYTHON_BIN)/activate: $(MAGE)
-	@$(MAGE) pythonEnv
+$(PYTHON_BIN)/activate:
+	mage pythonEnv
 	@touch $@
 
 .PHONY: $(APPROVALS)
@@ -262,8 +251,7 @@ release-manager-release: release
 
 .PHONY: release
 
-release: export PATH:=$(dir $(BIN_MAGE)):$(PATH)
-release: $(MAGE) $(PYTHON) build/dependencies.csv
+release: $(PYTHON) build/dependencies.csv
 	mage package
 
 build/dependencies.csv: $(PYTHON) go.mod


### PR DESCRIPTION
### Summary of your changes
Since we have added hermit, we no longer need to use a compiled version of our magefile.
instead, since `mage` command is always available, calling `mage` will use the installed version on the machine.
This change is trying to resolve the `make release` command that has had problems lately and blocks us from publishing cloudbeat artifacts.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
