### PR TITLE
CloudFormation template runs arm64

### DIFF
--- a/deploy/cloudformation/elastic-agent-ec2.yml
+++ b/deploy/cloudformation/elastic-agent-ec2.yml
@@ -5,17 +5,17 @@ Description: Creates an EC2 instance with permissions to run elastic-agent
 Parameters:
   LatestAmiId:
     Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
-    Default: '/aws/service/canonical/ubuntu/server/jammy/stable/current/amd64/hvm/ebs-gp2/ami-id'
+    Default: '/aws/service/canonical/ubuntu/server/jammy/stable/current/arm64/hvm/ebs-gp2/ami-id'
   KeyName:
     Type: AWS::EC2::KeyPair::KeyName
     Description: SSH Keypair to login to the instance
   InstanceType:
     Type: String
-    Default: t2.micro
+    Default: a1.xlarge
     AllowedValues:
-    - t2.micro
-    - t2.small
-    - t2.medium
+    - a1.xlarge
+    - a1.2xlarge
+    - a1.4xlarge
     Description: The type of EC2 instance to create
   EnrollmentToken:
     Type: String
@@ -55,48 +55,22 @@ Resources:
           - sts:AssumeRole
       Path: /
       Policies:
-      - PolicyName: snapshot-permissions
+      - PolicyName: vuln-mgmt-permissions
         PolicyDocument:
           Version: 2012-10-17
           Statement:
           - Effect: Allow
             Action:
-            - ec2:CreateSnapshot
-            Resource: "*"
-          - Effect: Allow
-            Action:
+            - ec2:DescribeImages
+            - ec2:DescribeTags
+            - ec2:DescribeSnapshots
+            - ec2:CreateSnapshots
             - ec2:CreateTags
             Resource: "*"
           - Effect: Allow
             Action:
-            - ec2:DescribeSnapshots
-            Resource: "*"
-          - Effect: Allow
-            Action:
-            - ec2:DescribeInstances
-            Resource: "*"
-          - Effect: Allow
-            Action:
-            - ec2:DescribeImages
-            Resource: "*"
-          - Effect: Allow
-            Action:
-            - ec2:DescribeTags
-            Resource: "*"
-          - Effect: Allow
-            Action:
-            - ec2:DescribeSnapshots
-            Resource: "*"
-          - Effect: Allow
-            Action:
             - ebs:ListSnapshotBlocks
-            Resource: "*"
-          - Effect: Allow
-            Action:
             - ebs:ListChangedBlocks
-            Resource: "*"
-          - Effect: Allow
-            Action:
             - ebs:GetSnapshotBlock
             Resource: "*"
 

--- a/deploy/cloudformation/elastic-agent-ec2.yml
+++ b/deploy/cloudformation/elastic-agent-ec2.yml
@@ -61,6 +61,7 @@ Resources:
           Statement:
           - Effect: Allow
             Action:
+            - ec2:DescribeInstances
             - ec2:DescribeImages
             - ec2:DescribeTags
             - ec2:DescribeSnapshots

--- a/tests/integration/tests/test_standalone_agent_integration.py
+++ b/tests/integration/tests/test_standalone_agent_integration.py
@@ -11,7 +11,7 @@ from commonlib.io_utils import FsClient
 from loguru import logger
 
 testdata = ["file", "process", "k8s_object"]
-CONFIG_TIMEOUT = 60
+CONFIG_TIMEOUT = 120
 
 
 @pytest.mark.pre_merge_agent

--- a/tests/integration/tests/test_standalone_agent_integration.py
+++ b/tests/integration/tests/test_standalone_agent_integration.py
@@ -11,7 +11,7 @@ from commonlib.io_utils import FsClient
 from loguru import logger
 
 testdata = ["file", "process", "k8s_object"]
-CONFIG_TIMEOUT = 120
+CONFIG_TIMEOUT = 60
 
 
 @pytest.mark.pre_merge_agent

--- a/vulnerability/scanner.go
+++ b/vulnerability/scanner.go
@@ -36,21 +36,8 @@ import (
 	"github.com/aquasecurity/trivy/pkg/commands/artifact"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	trivy_types "github.com/aquasecurity/trivy/pkg/types"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 )
-
-type CredentialProvider struct {
-	AccessKeyID     string
-	SecretAccessKey string
-}
-
-func (p *CredentialProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
-	return aws.Credentials{
-		AccessKeyID:     p.AccessKeyID,
-		SecretAccessKey: p.SecretAccessKey,
-	}, nil
-}
 
 type VulnerabilityScanner struct {
 	log *logp.Logger
@@ -184,7 +171,5 @@ func (f VulnerabilityScanner) GetChan() chan beat.Event {
 func (f VulnerabilityScanner) getOptFns(region string) []func(*config.LoadOptions) error {
 	return func(optFns ...func(*config.LoadOptions) error) []func(*config.LoadOptions) error {
 		return optFns
-	}(config.WithRegion(region), config.WithCredentialsProvider(&CredentialProvider{
-		AccessKeyID:     f.cfg.CloudConfig.AwsCred.AccessKeyID,
-		SecretAccessKey: f.cfg.CloudConfig.AwsCred.SecretAccessKey}))
+	}(config.WithRegion(region))
 }


### PR DESCRIPTION
### Summary of your changes

Modifying the CloudFormation stack for vulnerability management to run on arm64 instead of amd64.
The credentials provider changes are made in order to let the flow work OOTB for elastic-agent that run on EC2 (prod).
As both beats and trivy can read the credentials from the disk.

Resolves https://github.com/elastic/cloudbeat/issues/604

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
