### PR TITLE
magefile: BuildOpaBundle: Always cleanup

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -23,7 +23,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"log"
 	"os"
 	"os/exec"
@@ -376,8 +375,7 @@ func BuildOpaBundle() (err error) {
 	}
 
 	if err = sh.Run("bin/opa", "build", "-b", cspPoliciesPkgDir+"/bundle", "-e", cspPoliciesPkgDir+"/bundle/compliance"); err != nil {
-		deleteDirErr := sh.Run("rm", "-rf", cspPoliciesPkgDir)
-		return errors.Wrap(err, deleteDirErr.Error())
+		return err
 	}
 
 	return nil

--- a/magefile.go
+++ b/magefile.go
@@ -338,10 +338,17 @@ func PythonEnv() error {
 	return err
 }
 
-func BuildOpaBundle() error {
+func BuildOpaBundle() (err error) {
 	owner := "elastic"
 	r := "csp-security-policies"
 	cspPoliciesPkgDir := "/tmp/" + r
+
+	defer func() {
+		rmErr := os.RemoveAll(cspPoliciesPkgDir)
+		if rmErr != nil && err == nil {
+			err = rmErr
+		}
+	}()
 
 	repo, err := git.PlainClone(cspPoliciesPkgDir, false, &git.CloneOptions{
 		URL: fmt.Sprintf("https://github.com/%s/%s.git", owner, r),
@@ -373,5 +380,5 @@ func BuildOpaBundle() error {
 		return errors.Wrap(err, deleteDirErr.Error())
 	}
 
-	return sh.Run("rm", "-rf", cspPoliciesPkgDir)
+	return nil
 }


### PR DESCRIPTION
### Summary of your changes

Always cleanup the /tmp directory when `BuildOpaBundle` is run.
This improves behaviour in the case where a build is cancelled mid-build (e.g. with Ctrl-C). Before the change, the directory would remain in /tmp and on the next build cloning it would fail, leading to a confusing error.