### PR TITLE
pre-merge agent tests failure

### DIFF
--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Run Tests
         id: run_tests
         run: |
-          just run-tests ${{ matrix.test-target }}     
+          just run-tests ${{ matrix.test-target }}
 
       - name: Upload Test Results
         if: always()

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -101,15 +101,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-target: [file_system_rules, k8s_object_rules, process_scheduler_rules, process_api_server_rules, process_controller_manager_rules, process_etcd_rules, process_kubelet_rules]
-        values_file: [tests/deploy/values/ci.yml]
-        range: ['0..4']
+        # test-target: [file_system_rules, k8s_object_rules, process_scheduler_rules, process_api_server_rules, process_controller_manager_rules, process_etcd_rules, process_kubelet_rules]
+        # values_file: [tests/deploy/values/ci.yml]
+        # range: ['0..4']
         include:
           - test-target: pre_merge_agent
             range: ''
             values_file: tests/deploy/values/ci-sa-agent.yml
-          - test-target: pre_merge
-            range: ''
+          # - test-target: pre_merge
+          #   range: ''
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -141,6 +141,12 @@ jobs:
         id: run_tests
         run: |
           just run-tests ${{ matrix.test-target }}
+      
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: failure()
+        with:
+          limit-access-to-actor: true      
 
       - name: Upload Test Results
         if: always()

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -101,15 +101,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # test-target: [file_system_rules, k8s_object_rules, process_scheduler_rules, process_api_server_rules, process_controller_manager_rules, process_etcd_rules, process_kubelet_rules]
-        # values_file: [tests/deploy/values/ci.yml]
-        # range: ['0..4']
+        test-target: [file_system_rules, k8s_object_rules, process_scheduler_rules, process_api_server_rules, process_controller_manager_rules, process_etcd_rules, process_kubelet_rules]
+        values_file: [tests/deploy/values/ci.yml]
+        range: ['0..4']
         include:
           - test-target: pre_merge_agent
             range: ''
             values_file: tests/deploy/values/ci-sa-agent.yml
-          # - test-target: pre_merge
-          #   range: ''
+          - test-target: pre_merge
+            range: ''
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -140,13 +140,7 @@ jobs:
       - name: Run Tests
         id: run_tests
         run: |
-          just run-tests ${{ matrix.test-target }}
-      
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: failure()
-        with:
-          limit-access-to-actor: true      
+          just run-tests ${{ matrix.test-target }}     
 
       - name: Upload Test Results
         if: always()

--- a/tests/commonlib/elastic_wrapper.py
+++ b/tests/commonlib/elastic_wrapper.py
@@ -85,7 +85,7 @@ class ElasticWrapper:
             "bool": {
                 "filter": [
                     {"term": term},
-                    {"range": {"@timestamp": {"gte": "now-30s"}}},
+                    {"range": {"@timestamp": {"gte": "now-5m"}}},
                 ],
             },
         }

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import time
 import pytest
 from commonlib.io_utils import get_k8s_yaml_objects
-# from commonlib.kubernetes import ApiException
+from commonlib.kubernetes import ApiException
 from loguru import logger
 
 DEPLOY_YML_DICT = {
@@ -60,22 +60,22 @@ def fixture_start_stop_cloudbeat(k8s, api_client, cloudbeat_agent):
     time.sleep(10)
     logger.info(f"'{cloudbeat_agent.name}' pod started")
     yield k8s, api_client, cloudbeat_agent
-    # k8s_yaml_list = get_k8s_yaml_objects(file_path=file_path)
-    # k8s.delete_from_yaml(yaml_objects_list=k8s_yaml_list)  # stop agent
-    #
-    # lease_resources = [
-    #     {"name": "cloudbeat-cluster-leader", "namespace": cloudbeat_agent.namespace},
-    #     {
-    #         "name": "elastic-agent-cluster-leader",
-    #         "namespace": cloudbeat_agent.namespace,
-    #     },
-    # ]
-    # # Delete lease resources
-    # for resource in lease_resources:
-    #     try:
-    #         k8s.delete_resources(resource_type="Lease", **resource)
-    #     except ApiException:
-    #         continue
+    k8s_yaml_list = get_k8s_yaml_objects(file_path=file_path)
+    k8s.delete_from_yaml(yaml_objects_list=k8s_yaml_list)  # stop agent
+
+    lease_resources = [
+        {"name": "cloudbeat-cluster-leader", "namespace": cloudbeat_agent.namespace},
+        {
+            "name": "elastic-agent-cluster-leader",
+            "namespace": cloudbeat_agent.namespace,
+        },
+    ]
+    # Delete lease resources
+    for resource in lease_resources:
+        try:
+            k8s.delete_resources(resource_type="Lease", **resource)
+        except ApiException:
+            continue
 
 
 @pytest.fixture(name="fixture_data")

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -56,7 +56,7 @@ def fixture_start_stop_cloudbeat(k8s, api_client, cloudbeat_agent):
     # some of them are runinng in multi cluster environment
     # the k8s.wait_for_resoruce waits for only the first pod it founds
     # see more details https://github.com/elastic/cloudbeat/pull/422
-    time.sleep(10)
+    time.sleep(20)
     logger.info(f"'{cloudbeat_agent.name}' pod started")
     yield k8s, api_client, cloudbeat_agent
     k8s_yaml_list = get_k8s_yaml_objects(file_path=file_path)

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -10,7 +10,6 @@ from loguru import logger
 
 DEPLOY_YML_DICT = {
     "cloudbeat_vanilla": "../../deploy/cloudbeat-pytest.yml",
-    "cloudbeat_vanilla_aws": "../../deploy/cloudbeat-pytest.yml",
     "elastic-agent_vanilla": "../../deploy/sa-agent-pytest.yml",
     "cloudbeat_eks": "../../deploy/cloudbeat-eks-pytest.yaml",
 }

--- a/tests/integration/tests/conftest.py
+++ b/tests/integration/tests/conftest.py
@@ -5,11 +5,12 @@ from pathlib import Path
 import time
 import pytest
 from commonlib.io_utils import get_k8s_yaml_objects
-from commonlib.kubernetes import ApiException
+# from commonlib.kubernetes import ApiException
 from loguru import logger
 
 DEPLOY_YML_DICT = {
     "cloudbeat_vanilla": "../../deploy/cloudbeat-pytest.yml",
+    "cloudbeat_vanilla_aws": "../../deploy/cloudbeat-pytest.yml",
     "elastic-agent_vanilla": "../../deploy/sa-agent-pytest.yml",
     "cloudbeat_eks": "../../deploy/cloudbeat-eks-pytest.yaml",
 }
@@ -59,22 +60,22 @@ def fixture_start_stop_cloudbeat(k8s, api_client, cloudbeat_agent):
     time.sleep(10)
     logger.info(f"'{cloudbeat_agent.name}' pod started")
     yield k8s, api_client, cloudbeat_agent
-    k8s_yaml_list = get_k8s_yaml_objects(file_path=file_path)
-    k8s.delete_from_yaml(yaml_objects_list=k8s_yaml_list)  # stop agent
-
-    lease_resources = [
-        {"name": "cloudbeat-cluster-leader", "namespace": cloudbeat_agent.namespace},
-        {
-            "name": "elastic-agent-cluster-leader",
-            "namespace": cloudbeat_agent.namespace,
-        },
-    ]
-    # Delete lease resources
-    for resource in lease_resources:
-        try:
-            k8s.delete_resources(resource_type="Lease", **resource)
-        except ApiException:
-            continue
+    # k8s_yaml_list = get_k8s_yaml_objects(file_path=file_path)
+    # k8s.delete_from_yaml(yaml_objects_list=k8s_yaml_list)  # stop agent
+    #
+    # lease_resources = [
+    #     {"name": "cloudbeat-cluster-leader", "namespace": cloudbeat_agent.namespace},
+    #     {
+    #         "name": "elastic-agent-cluster-leader",
+    #         "namespace": cloudbeat_agent.namespace,
+    #     },
+    # ]
+    # # Delete lease resources
+    # for resource in lease_resources:
+    #     try:
+    #         k8s.delete_resources(resource_type="Lease", **resource)
+    #     except ApiException:
+    #         continue
 
 
 @pytest.fixture(name="fixture_data")


### PR DESCRIPTION
Pre-merge agent test suite is failed on retrieving findings (k8s object findings are not exist).
This PR increases agent's startup timeout and updates query of data to be retrieved.