### PR TITLE
Add cloudbeat.yml for vulnerability management

### DIFF
--- a/deploy/vulnerability/cloudbeat-vuln-mgmt.yml
+++ b/deploy/vulnerability/cloudbeat-vuln-mgmt.yml
@@ -1,0 +1,53 @@
+cloudbeat:
+  config:
+    v1:
+      type: vuln_mgmt
+# =================================== Kibana ===================================
+setup.kibana:
+  # Kibana Host
+  host: "http://host.docker.internal:5601"
+# =============================== Elastic Cloud ================================
+
+# These settings simplify using Cloudbeat with the Elastic Cloud (https://cloud.elastic.co/).
+
+# The cloud.id setting overwrites the `output.elasticsearch.hosts` and
+# `setup.kibana.host` options.
+# You can find the `cloud.id` in the Elastic Cloud web UI.
+#cloud.id:
+
+# The cloud.auth setting overwrites the `output.elasticsearch.username` and
+# `output.elasticsearch.password` settings. The format is `<user>:<pass>`.
+#cloud.auth:
+
+# ---------------------------- Elasticsearch Output ----------------------------
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ${ES_HOST}
+
+  # Protocol - either `http` (default) or `https`.
+  #  protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  #api_key: "id:api_key"
+  username: ${ES_USERNAME}
+  password: ${ES_PASSWORD}
+
+  # Enable to allow sending output to older ES versions
+  allow_older_versions: true
+
+# ================================= Processors =================================
+processors:
+  - add_host_metadata: ~
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~
+
+# Sets log level. The default log level is info.
+# Available log levels are: error, warning, info, debug
+logging.level: debug
+# Enable debug output for selected components. To enable all selectors use ["*"]
+# Other available selectors are "beat", "publisher", "service"
+# Multiple selectors can be chained.
+#logging.selectors: ["publisher"]
+
+# Send all logging output to stderr. The default is false.
+#logging.to_stderr: false

--- a/deploy/vulnerability/cloudbeat-vuln-mgmt.yml
+++ b/deploy/vulnerability/cloudbeat-vuln-mgmt.yml
@@ -2,6 +2,7 @@ cloudbeat:
   config:
     v1:
       type: vuln_mgmt
+      deployment: aws
 # =================================== Kibana ===================================
 setup.kibana:
   # Kibana Host


### PR DESCRIPTION
### Summary of your changes
With this file part of the repository we could easily run cloudbeat and trigger the vulnerability management flavor.
For example using vscode, adding to `launch.json` the snippet:
```
{
        "name": "Launch Vulnerability Management",
        "type": "go",
        "request": "launch",
        "mode": "auto",
        "program": "${workspaceFolder}/main.go",
        "args": ["-c", "deploy/vulnerability/cloudbeat-vuln-mgmt.yml", "-e", "-d", "'*'"],
        "env": {
                "ES_HOST": "https://localhost:9200",
                "ES_USERNAME": "elastic",
                "ES_PASSWORD": "changeme",
        }
}
```


### Related Issues
- Related: https://github.com/elastic/cloudbeat/issues/833

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
