### PR TITLE
Add cloud data to VM events

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -79,8 +79,8 @@ func New(cfg *config.C) (*Config, error) {
 
 func defaultConfig() (*Config, error) {
 	ret := &Config{
-		Period:    4 * time.Hour,
-		Benchmark: CIS_K8S,
+		Period: 4 * time.Hour,
+		//Benchmark: CIS_K8S,
 	}
 
 	bundle, err := getBundlePath()

--- a/config/config.go
+++ b/config/config.go
@@ -80,7 +80,6 @@ func New(cfg *config.C) (*Config, error) {
 func defaultConfig() (*Config, error) {
 	ret := &Config{
 		Period: 4 * time.Hour,
-		//Benchmark: CIS_K8S,
 	}
 
 	bundle, err := getBundlePath()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,6 +56,9 @@ func (s *ConfigTestSuite) TestNew() {
 	}{
 		{
 			`
+config:
+  v1:
+    benchmark: cis_k8s
 fetchers:
   - name: a
     directory: b

--- a/dataprovider/data_provider.go
+++ b/dataprovider/data_provider.go
@@ -20,9 +20,10 @@ package dataprovider
 import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/cloudbeat/dataprovider/types"
+	"github.com/elastic/cloudbeat/resources/fetching"
 )
 
 type CommonDataProvider interface {
 	FetchData(resource string, id string) (types.Data, error)
-	EnrichEvent(*beat.Event) error
+	EnrichEvent(event *beat.Event, resource fetching.ResourceMetadata) error
 }

--- a/dataprovider/mock_common_data_provider.go
+++ b/dataprovider/mock_common_data_provider.go
@@ -21,6 +21,8 @@ package dataprovider
 
 import (
 	beat "github.com/elastic/beats/v7/libbeat/beat"
+	fetching "github.com/elastic/cloudbeat/resources/fetching"
+
 	mock "github.com/stretchr/testify/mock"
 
 	types "github.com/elastic/cloudbeat/dataprovider/types"
@@ -39,13 +41,13 @@ func (_m *MockCommonDataProvider) EXPECT() *MockCommonDataProvider_Expecter {
 	return &MockCommonDataProvider_Expecter{mock: &_m.Mock}
 }
 
-// EnrichEvent provides a mock function with given fields: _a0
-func (_m *MockCommonDataProvider) EnrichEvent(_a0 *beat.Event) error {
-	ret := _m.Called(_a0)
+// EnrichEvent provides a mock function with given fields: event, resource
+func (_m *MockCommonDataProvider) EnrichEvent(event *beat.Event, resource fetching.ResourceMetadata) error {
+	ret := _m.Called(event, resource)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*beat.Event) error); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(*beat.Event, fetching.ResourceMetadata) error); ok {
+		r0 = rf(event, resource)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -59,14 +61,15 @@ type MockCommonDataProvider_EnrichEvent_Call struct {
 }
 
 // EnrichEvent is a helper method to define mock.On call
-//   - _a0 *beat.Event
-func (_e *MockCommonDataProvider_Expecter) EnrichEvent(_a0 interface{}) *MockCommonDataProvider_EnrichEvent_Call {
-	return &MockCommonDataProvider_EnrichEvent_Call{Call: _e.mock.On("EnrichEvent", _a0)}
+//   - event *beat.Event
+//   - resource fetching.ResourceMetadata
+func (_e *MockCommonDataProvider_Expecter) EnrichEvent(event interface{}, resource interface{}) *MockCommonDataProvider_EnrichEvent_Call {
+	return &MockCommonDataProvider_EnrichEvent_Call{Call: _e.mock.On("EnrichEvent", event, resource)}
 }
 
-func (_c *MockCommonDataProvider_EnrichEvent_Call) Run(run func(_a0 *beat.Event)) *MockCommonDataProvider_EnrichEvent_Call {
+func (_c *MockCommonDataProvider_EnrichEvent_Call) Run(run func(event *beat.Event, resource fetching.ResourceMetadata)) *MockCommonDataProvider_EnrichEvent_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*beat.Event))
+		run(args[0].(*beat.Event), args[1].(fetching.ResourceMetadata))
 	})
 	return _c
 }
@@ -76,7 +79,7 @@ func (_c *MockCommonDataProvider_EnrichEvent_Call) Return(_a0 error) *MockCommon
 	return _c
 }
 
-func (_c *MockCommonDataProvider_EnrichEvent_Call) RunAndReturn(run func(*beat.Event) error) *MockCommonDataProvider_EnrichEvent_Call {
+func (_c *MockCommonDataProvider_EnrichEvent_Call) RunAndReturn(run func(*beat.Event, fetching.ResourceMetadata) error) *MockCommonDataProvider_EnrichEvent_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/dataprovider/providers/aws/data_provider.go
+++ b/dataprovider/providers/aws/data_provider.go
@@ -20,6 +20,7 @@ package aws
 import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/cloudbeat/dataprovider/types"
+	"github.com/elastic/cloudbeat/resources/fetching"
 	"github.com/elastic/cloudbeat/version"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
@@ -28,6 +29,7 @@ const (
 	cloudAccountIdField   = "cloud.account.id"
 	cloudAccountNameField = "cloud.account.name"
 	cloudProviderField    = "cloud.provider"
+	cloudRegionField      = "cloud.region"
 	cloudProviderValue    = "aws"
 )
 
@@ -55,7 +57,7 @@ func (a DataProvider) FetchData(_ string, id string) (types.Data, error) {
 	}, nil
 }
 
-func (a DataProvider) EnrichEvent(event *beat.Event) error {
+func (a DataProvider) EnrichEvent(event *beat.Event, resMetadata fetching.ResourceMetadata) error {
 	_, err := event.Fields.Put(cloudAccountIdField, a.accountId)
 	if err != nil {
 		return err
@@ -67,6 +69,11 @@ func (a DataProvider) EnrichEvent(event *beat.Event) error {
 	}
 
 	_, err = event.Fields.Put(cloudProviderField, cloudProviderValue)
+	if err != nil {
+		return err
+	}
+
+	_, err = event.Fields.Put(cloudRegionField, resMetadata.Region)
 	if err != nil {
 		return err
 	}

--- a/dataprovider/providers/aws/data_provider_test.go
+++ b/dataprovider/providers/aws/data_provider_test.go
@@ -18,6 +18,7 @@
 package aws
 
 import (
+	"github.com/elastic/cloudbeat/resources/fetching"
 	"testing"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -32,6 +33,7 @@ import (
 var (
 	accountName = "accountName"
 	accountId   = "accountId"
+	someRegion  = "eu-west-1"
 )
 
 type AwsDataProviderTestSuite struct {
@@ -102,7 +104,7 @@ func TestAWSDataProvider_EnrichEvent(t *testing.T) {
 	e := &beat.Event{
 		Fields: mapstr.M{},
 	}
-	err := k.EnrichEvent(e)
+	err := k.EnrichEvent(e, fetching.ResourceMetadata{Region: someRegion})
 	assert.NoError(t, err)
 
 	accountID, err := e.Fields.GetValue(cloudAccountIdField)
@@ -116,4 +118,8 @@ func TestAWSDataProvider_EnrichEvent(t *testing.T) {
 	cloud, err := e.Fields.GetValue(cloudProviderField)
 	assert.NoError(t, err)
 	assert.Equal(t, "aws", cloud)
+
+	region, err := e.Fields.GetValue(cloudRegionField)
+	assert.NoError(t, err)
+	assert.Equal(t, someRegion, region)
 }

--- a/dataprovider/providers/k8s/data_provider.go
+++ b/dataprovider/providers/k8s/data_provider.go
@@ -65,7 +65,7 @@ func (k DataProvider) FetchData(resource string, id string) (types.Data, error) 
 	}, nil
 }
 
-func (k DataProvider) EnrichEvent(event *beat.Event) error {
+func (k DataProvider) EnrichEvent(event *beat.Event, _ fetching.ResourceMetadata) error {
 	name := k.cluster
 	if name == "" {
 		return nil

--- a/dataprovider/providers/k8s/data_provider_test.go
+++ b/dataprovider/providers/k8s/data_provider_test.go
@@ -138,7 +138,7 @@ func TestK8sDataProvider_EnrichEvent(t *testing.T) {
 	e := &beat.Event{
 		Fields: mapstr.M{},
 	}
-	err := k.EnrichEvent(e)
+	err := k.EnrichEvent(e, fetching.ResourceMetadata{})
 	assert.NoError(t, err)
 	v, err := e.Fields.GetValue(clusterNameField)
 	assert.NoError(t, err)

--- a/flavors/common.go
+++ b/flavors/common.go
@@ -1,0 +1,134 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package flavors
+
+import (
+	"context"
+	"fmt"
+	"github.com/elastic/beats/v7/libbeat/processors"
+	"github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
+	"github.com/elastic/cloudbeat/config"
+	"github.com/elastic/cloudbeat/dataprovider"
+	aws_dataprovider "github.com/elastic/cloudbeat/dataprovider/providers/aws"
+	k8s_dataprovider "github.com/elastic/cloudbeat/dataprovider/providers/k8s"
+	"github.com/elastic/cloudbeat/resources/providers"
+	"github.com/elastic/cloudbeat/resources/providers/awslib"
+	"github.com/elastic/cloudbeat/resources/providers/awslib/iam"
+	"github.com/elastic/cloudbeat/version"
+	"github.com/elastic/elastic-agent-autodiscover/kubernetes"
+	"github.com/elastic/elastic-agent-libs/logp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConfigureProcessors configure processors to be used by the beat
+func ConfigureProcessors(processorsList processors.PluginConfig) (procs *processors.Processors, err error) {
+	return processors.New(processorsList)
+}
+
+func GetCommonDataProvider(ctx context.Context, log *logp.Logger, cfg config.Config) (dataprovider.CommonDataProvider, error) {
+	log.Infof("Flavors.GetCommonDataProvider, constructing common data provider for benchmark: %s", cfg.Benchmark)
+	switch cfg.Benchmark {
+	case config.CIS_EKS, config.CIS_K8S:
+		return getK8sDataProvider(ctx, log, cfg)
+	default:
+		return getAWSDataProvider(ctx, log, cfg)
+	}
+}
+
+func getAWSDataProvider(ctx context.Context, log *logp.Logger, cfg config.Config) (dataprovider.CommonDataProvider, error) {
+	awsConfig, err := aws.InitializeAWSConfig(cfg.CloudConfig.AwsCred)
+	if err != nil {
+		return nil, fmt.Errorf("Common.getAWSDataProvider failed to initialize AWS credentials: %w", err)
+	}
+
+	identityClient := awslib.GetIdentityClient(awsConfig)
+	iamProvider := iam.NewIAMProvider(log, awsConfig)
+
+	identity, err := identityClient.GetIdentity(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Common.getAWSDataProvider failed to get AWS identity: %w", err)
+	}
+
+	alias, err := iamProvider.GetAccountAlias(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Common.getAWSDataProvider failed to get AWS account alias: %w", err)
+	}
+
+	return aws_dataprovider.New(
+		aws_dataprovider.WithLogger(log),
+		aws_dataprovider.WithAccount(alias, *identity.Account),
+	), nil
+}
+
+func getK8sDataProvider(ctx context.Context, log *logp.Logger, cfg config.Config) (dataprovider.CommonDataProvider, error) {
+	kubeClient, err := providers.KubernetesProvider{}.GetClient(log, cfg.KubeConfig, kubernetes.KubeClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	clusterNameProvider := providers.ClusterNameProvider{
+		KubernetesClusterNameProvider: providers.KubernetesClusterNameProvider{},
+		EKSMetadataProvider:           awslib.Ec2MetadataProvider{},
+		EKSClusterNameProvider:        awslib.EKSClusterNameProvider{},
+		KubeClient:                    kubeClient,
+		AwsConfigProvider: awslib.ConfigProvider{
+			MetadataProvider: awslib.Ec2MetadataProvider{},
+		},
+	}
+	name, err := clusterNameProvider.GetClusterName(ctx, &cfg, log)
+	if err != nil {
+		log.Errorf("Common.getK8sDataProvider failed to get cluster name: %v", err)
+	}
+	v, err := kubeClient.Discovery().ServerVersion()
+	if err != nil {
+		return nil, fmt.Errorf("Common.getK8sDataProvider failed to get server version: %w", err)
+	}
+	node, err := kubernetes.DiscoverKubernetesNode(log, &kubernetes.DiscoverKubernetesNodeParams{
+		ConfigHost:  "",
+		Client:      kubeClient,
+		IsInCluster: true,
+		HostUtils:   &kubernetes.DefaultDiscoveryUtils{},
+	})
+	if err != nil {
+		return nil, err
+	}
+	n, err := kubeClient.CoreV1().Nodes().Get(ctx, node, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("Common.getK8sDataProvider failed to get node data: %w", err)
+	}
+
+	ns, err := kubeClient.CoreV1().Namespaces().Get(ctx, "kube-system", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("Common.getK8sDataProvider failed to get namespace data: %w", err)
+	}
+	options := []k8s_dataprovider.Option{
+		k8s_dataprovider.WithConfig(&cfg),
+		k8s_dataprovider.WithLogger(log),
+		k8s_dataprovider.WithClusterName(name),
+		k8s_dataprovider.WithClusterID(string(ns.ObjectMeta.UID)),
+		k8s_dataprovider.WithNodeID(string(n.ObjectMeta.UID)),
+		k8s_dataprovider.WithVersionInfo(version.CloudbeatVersionInfo{
+			Version: version.CloudbeatVersion(),
+			Policy:  version.PolicyVersion(),
+			Kubernetes: version.Version{
+				Version: v.Major + "." + v.Minor,
+			},
+		}),
+	}
+	return k8s_dataprovider.New(options...), nil
+}

--- a/flavors/flavors.go
+++ b/flavors/flavors.go
@@ -19,6 +19,7 @@ package flavors
 
 import (
 	"context"
+	"github.com/elastic/cloudbeat/dataprovider"
 	"time"
 
 	"github.com/elastic/cloudbeat/config"
@@ -44,4 +45,5 @@ type flavorBase struct {
 	client      beat.Client
 	transformer transformer.Transformer
 	log         *logp.Logger
+	cdp         dataprovider.CommonDataProvider
 }

--- a/flavors/vulnerability.go
+++ b/flavors/vulnerability.go
@@ -27,7 +27,6 @@ import (
 	vuln "github.com/elastic/cloudbeat/vulnerability"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/processors"
 	agentconfig "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
@@ -48,14 +47,20 @@ func NewVulnerability(_ *beat.Beat, cfg *agentconfig.C) (*vulnerability, error) 
 		cancel()
 		return nil, fmt.Errorf("error reading config file: %w", err)
 	}
-
 	log.Info("Config initiated with cycle period of ", c.Period)
+
+	cdp, err := GetCommonDataProvider(ctx, log, *c)
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to init common data provider: %w", err)
+	}
 
 	base := flavorBase{
 		ctx:    ctx,
 		cancel: cancel,
 		config: c,
 		log:    log,
+		cdp:    cdp,
 	}
 
 	bt := &vulnerability{
@@ -69,7 +74,7 @@ func NewVulnerability(_ *beat.Beat, cfg *agentconfig.C) (*vulnerability, error) 
 func (bt *vulnerability) Run(b *beat.Beat) error {
 	bt.log.Info("vulnerability is running! Hit CTRL-C to stop it.")
 
-	procs, err := bt.configureProcessors(bt.config.Processors)
+	procs, err := ConfigureProcessors(bt.config.Processors)
 	if err != nil {
 		return err
 	}
@@ -105,7 +110,7 @@ func (bt *vulnerability) Run(b *beat.Beat) error {
 
 func (bt *vulnerability) runIteration() error {
 	bt.log.Warn("vulnerability.Run cycle triggered")
-	worker, err := vuln.NewVulnerabilityWorker(bt.log, bt.config)
+	worker, err := vuln.NewVulnerabilityWorker(bt.log, bt.config, bt.cdp)
 	if err != nil {
 		bt.log.Warn("vulnerability.runIteration worker creation failed")
 		bt.cancel()
@@ -168,9 +173,4 @@ func (bt *vulnerability) handleEvents(ch chan beat.Event) {
 // Stop stops vulnerability.
 func (bt *vulnerability) Stop() {
 	bt.cancel()
-}
-
-// configureProcessors configure processors to be used by the beat
-func (bt *vulnerability) configureProcessors(processorsList processors.PluginConfig) (procs *processors.Processors, err error) {
-	return processors.New(processorsList)
 }

--- a/resources/fetching/fetcher.go
+++ b/resources/fetching/fetcher.go
@@ -105,6 +105,7 @@ type ResourceMetadata struct {
 	SubType   string `json:"sub_type,omitempty"`
 	Name      string `json:"name,omitempty"`
 	ECSFormat string `json:"ecsFormat,omitempty"`
+	Region    string `json:"region,omitempty"`
 }
 
 type Result struct {

--- a/resources/providers/awslib/ec2/provider.go
+++ b/resources/providers/awslib/ec2/provider.go
@@ -197,7 +197,7 @@ func (p *Provider) CreateSnapshots(ctx context.Context, ins Ec2Instance) ([]EBSS
 		InstanceSpecification: &types.InstanceSpecification{
 			InstanceId: ins.InstanceId,
 		},
-		Description: aws.String("Cloudbeat Vulnerability Snapshot."),
+		Description: aws.String("URI TEST Vulnerability."),
 		TagSpecifications: []types.TagSpecification{
 			{
 				ResourceType: "snapshot",

--- a/resources/providers/awslib/ec2/provider.go
+++ b/resources/providers/awslib/ec2/provider.go
@@ -197,7 +197,7 @@ func (p *Provider) CreateSnapshots(ctx context.Context, ins Ec2Instance) ([]EBSS
 		InstanceSpecification: &types.InstanceSpecification{
 			InstanceId: ins.InstanceId,
 		},
-		Description: aws.String("URI TEST Vulnerability."),
+		Description: aws.String("Cloudbeat Vulnerability Snapshot."),
 		TagSpecifications: []types.TagSpecification{
 			{
 				ResourceType: "snapshot",

--- a/transformer/events_creator.go
+++ b/transformer/events_creator.go
@@ -101,7 +101,7 @@ func (t *Transformer) CreateBeatEvents(ctx context.Context, eventData evaluator.
 			},
 		}
 
-		err := t.commonDataProvider.EnrichEvent(&event)
+		err := t.commonDataProvider.EnrichEvent(&event, resMetadata)
 		if err != nil {
 			return nil, fmt.Errorf("failed to enrich event: %v", err)
 		}

--- a/transformer/events_creator_test.go
+++ b/transformer/events_creator_test.go
@@ -133,7 +133,7 @@ func (s *EventsCreatorTestSuite) TestTransformer_ProcessAggregatedResources() {
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
 			dataProviderMock := dataprovider.MockCommonDataProvider{}
-			mockEnrichEvent := func(event *beat.Event) error {
+			mockEnrichEvent := func(event *beat.Event, meta fetching.ResourceMetadata) error {
 				_, err := event.Fields.Put(enrichedKey, enrichedValue)
 				return err
 			}

--- a/vulnerability/events_creator.go
+++ b/vulnerability/events_creator.go
@@ -18,6 +18,11 @@
 package vulnerability
 
 import (
+	"context"
+	"github.com/elastic/cloudbeat/dataprovider"
+	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"strings"
 	"time"
 
@@ -25,7 +30,6 @@ import (
 	trivy_types "github.com/aquasecurity/trivy/pkg/types"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	libevents "github.com/elastic/beats/v7/libbeat/beat/events"
-	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
 	"github.com/elastic/cloudbeat/transformer"
 	"github.com/elastic/cloudbeat/version"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -45,7 +49,7 @@ type Vulnerability struct {
 	Description    string     `json:"description,omitempty"`
 	Severity       string     `json:"severity,omitempty"`
 	Classification string     `json:"classification,omitempty"`
-	PublishedDate  time.Time  `json:"published_date,omitempty"`
+	PublishedDate  *time.Time `json:"published_date,omitempty"`
 	ReportId       int64      `json:"report_id,omitempty"`
 }
 
@@ -99,12 +103,48 @@ const (
 	vulIndex              = "logs-cloud_security_posture.vulnerabilities-default"
 )
 
+type EventsCreator struct {
+	log                *logp.Logger
+	commonDataProvider dataprovider.CommonDataProvider
+	ch                 chan beat.Event
+}
+
+func NewEventsCreator(log *logp.Logger, cdp dataprovider.CommonDataProvider) EventsCreator {
+	return EventsCreator{
+		log:                log,
+		commonDataProvider: cdp,
+		ch:                 make(chan beat.Event),
+	}
+}
+
 // TODO: Replace sequence with more generic approach
-func createVulnerabilityEvent(reportResult trivy_types.Result, vul trivy_types.DetectedVulnerability, ins ec2.Ec2Instance, seq time.Time) beat.Event {
+func (e EventsCreator) CreateEvents(ctx context.Context, scanResults chan Result) {
+	defer close(e.ch)
+	for {
+		select {
+		case <-ctx.Done():
+			e.log.Info("EventsCreator.CreateEvents context canceled")
+			return
+		case data, ok := <-scanResults:
+			if !ok {
+				e.log.Info("EventsCreator.CreateEvents channel is closed")
+				return
+			}
+			e.ch <- e.generateEvent(data.reportResult, data.vulnerability, data.snapshot, data.seq)
+		}
+	}
+
+}
+
+func (e EventsCreator) GetChan() chan beat.Event {
+	return e.ch
+}
+
+func (e EventsCreator) generateEvent(reportResult trivy_types.Result, vul trivy_types.DetectedVulnerability, snap ec2.EBSSnapshot, seq time.Time) beat.Event {
 	timestamp := time.Now().UTC()
 	sequence := seq.Unix()
 	cvssScore := getCVSSScore(vul, vulScoreSource)
-	return beat.Event{
+	event := beat.Event{
 		// TODO: Maybe configure or get from somewhere else?
 		Meta:      mapstr.M{libevents.FieldMetaIndex: vulIndex},
 		Timestamp: timestamp,
@@ -113,8 +153,8 @@ func createVulnerabilityEvent(reportResult trivy_types.Result, vul trivy_types.D
 			// TODO: Replace sequence with more generic approach
 			"event": transformer.BuildECSEvent(sequence, timestamp, []string{vulEcsCategory}),
 			"resource": Resource{
-				ID:   ins.GetResourceId(),
-				Name: ins.GetResourceName(),
+				ID:   snap.Instance.GetResourceId(),
+				Name: snap.Instance.GetResourceName(),
 			},
 			"target": reportResult.Target,
 			"class":  reportResult.Class,
@@ -148,14 +188,26 @@ func createVulnerabilityEvent(reportResult trivy_types.Result, vul trivy_types.D
 				Description:    vul.Description,
 				Severity:       vul.Severity,
 				Classification: vulScoreSystemClass,
-				PublishedDate:  *vul.PublishedDate,
+				PublishedDate:  vul.PublishedDate,
 			},
 		},
 	}
+
+	err := e.commonDataProvider.EnrichEvent(&event, fetching.ResourceMetadata{Region: snap.Instance.Region})
+	if err != nil {
+		e.log.Errorf("failed to enrich event: %v", err)
+	}
+
+	return event
 }
 
 func getIdentifierType(id string) string {
-	return strings.Split(id, "-")[0]
+	s := strings.Split(id, "-")
+	if len(s) == 0 {
+		return ""
+	}
+
+	return s[0]
 }
 
 func getCVSSScore(vul trivy_types.DetectedVulnerability, source db_types.SourceID) float64 {

--- a/vulnerability/fetcher.go
+++ b/vulnerability/fetcher.go
@@ -58,8 +58,10 @@ func (f VulnerabilityFetcher) FetchInstances(ctx context.Context) error {
 				f.log.Errorf("VulnerabilityFetcher.FetchInstances DescribeInstances failed: %v", err)
 				return err
 			}
-			for _, ins := range ins {
-				f.ch <- ins
+			for _, in := range ins {
+				if *in.InstanceId == "i-0708b5252a6556c9c" {
+					f.ch <- in
+				}
 			}
 
 			f.log.Infof("VulnerabilityFetcher.FetchInstances found %d results", len(ins))

--- a/vulnerability/fetcher.go
+++ b/vulnerability/fetcher.go
@@ -59,9 +59,7 @@ func (f VulnerabilityFetcher) FetchInstances(ctx context.Context) error {
 				return err
 			}
 			for _, in := range ins {
-				if *in.InstanceId == "i-0708b5252a6556c9c" {
-					f.ch <- in
-				}
+				f.ch <- in
 			}
 
 			f.log.Infof("VulnerabilityFetcher.FetchInstances found %d results", len(ins))

--- a/vulnerability/scanner.go
+++ b/vulnerability/scanner.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/elastic/beats/v7/libbeat/beat"
 	cb_config "github.com/elastic/cloudbeat/config"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -38,18 +37,24 @@ import (
 )
 
 type VulnerabilityScanner struct {
-	log *logp.Logger
-	// TODO: Change to type that includes snapshot for deletion after evaluation
-	ch     chan beat.Event
+	log    *logp.Logger
+	ch     chan Result
 	runner artifact.Runner
 	cfg    *cb_config.Config
 	seq    time.Time
 }
 
+type Result struct {
+	reportResult  trivy_types.Result
+	vulnerability trivy_types.DetectedVulnerability
+	snapshot      ec2.EBSSnapshot
+	seq           time.Time
+}
+
 // TODO: Replace sequence with more generic approach
 func NewVulnerabilityScanner(log *logp.Logger, runner artifact.Runner, c *cb_config.Config, seq time.Time) (VulnerabilityScanner, error) {
 	log.Debug("VulnerabilityScanner: New")
-	ch := make(chan beat.Event)
+	ch := make(chan Result)
 
 	return VulnerabilityScanner{
 		log:    log,
@@ -157,14 +162,19 @@ func (f VulnerabilityScanner) scan(ctx context.Context, snap ec2.EBSSnapshot) {
 	for _, result := range unmarshalledReport.Results {
 		for _, vul := range result.Vulnerabilities {
 			// TODO: Replace sequence with more generic approach
-			f.ch <- createVulnerabilityEvent(result, vul, snap.Instance, f.seq)
+			f.ch <- Result{
+				reportResult:  result,
+				vulnerability: vul,
+				snapshot:      snap,
+				seq:           f.seq,
+			}
 		}
 	}
 
 	f.log.Info("VulnerabilityScanner.scan.DONE")
 }
 
-func (f VulnerabilityScanner) GetChan() chan beat.Event {
+func (f VulnerabilityScanner) GetChan() chan Result {
 	return f.ch
 }
 

--- a/vulnerability/worker.go
+++ b/vulnerability/worker.go
@@ -20,6 +20,7 @@ package vulnerability
 import (
 	"context"
 	"fmt"
+	"github.com/elastic/cloudbeat/dataprovider"
 	"sync"
 
 	"time"
@@ -33,19 +34,20 @@ import (
 )
 
 type VulnerabilityWorker struct {
-	log        *logp.Logger
-	cfg        *config.Config
-	cleaner    Cleaner
-	provider   *ec2.Provider
-	fetcher    VulnerabilityFetcher
-	replicator VulnerabilityReplicator
-	verifier   VulnerabilityVerifier
-	evaluator  VulnerabilityScanner
-	runner     VulnerabilityRunner
-	wg         sync.WaitGroup
+	log           *logp.Logger
+	cfg           *config.Config
+	cleaner       Cleaner
+	provider      *ec2.Provider
+	fetcher       VulnerabilityFetcher
+	replicator    VulnerabilityReplicator
+	verifier      VulnerabilityVerifier
+	evaluator     VulnerabilityScanner
+	runner        VulnerabilityRunner
+	eventsCreator EventsCreator
+	wg            sync.WaitGroup
 }
 
-func NewVulnerabilityWorker(log *logp.Logger, c *config.Config) (*VulnerabilityWorker, error) {
+func NewVulnerabilityWorker(log *logp.Logger, c *config.Config, cdp dataprovider.CommonDataProvider) (*VulnerabilityWorker, error) {
 	log.Debug("VulnerabilityWorker: New")
 	awsConfig, err := libbeat_aws.InitializeAWSConfig(c.CloudConfig.AwsCred)
 	if err != nil {
@@ -65,19 +67,21 @@ func NewVulnerabilityWorker(log *logp.Logger, c *config.Config) (*VulnerabilityW
 	if err != nil {
 		return nil, fmt.Errorf("VulnerabilityWorker: could not get init NewVulnerabilityScanner: %w", err)
 	}
+	eventsCreator := NewEventsCreator(log, cdp)
 	cleaner := NewVulnerabilityCleaner(log, provider)
 
 	return &VulnerabilityWorker{
-		log:        log,
-		cfg:        c,
-		cleaner:    cleaner,
-		provider:   provider,
-		fetcher:    fetcher,
-		replicator: replicator,
-		verifier:   verifier,
-		evaluator:  evaluator,
-		runner:     runner,
-		wg:         sync.WaitGroup{},
+		log:           log,
+		cfg:           c,
+		cleaner:       cleaner,
+		provider:      provider,
+		fetcher:       fetcher,
+		replicator:    replicator,
+		verifier:      verifier,
+		evaluator:     evaluator,
+		eventsCreator: eventsCreator,
+		runner:        runner,
+		wg:            sync.WaitGroup{},
 	}, nil
 }
 
@@ -118,6 +122,12 @@ func (f *VulnerabilityWorker) Run(ctx context.Context) {
 				f.evaluator.ScanSnapshot(ctx, f.verifier.GetChan())
 				f.log.Info("VulnerabilityWorker.work ScanSnapshot finished")
 			}()
+			f.wg.Add(1)
+			go func() {
+				defer f.wg.Done()
+				f.eventsCreator.CreateEvents(ctx, f.evaluator.GetChan())
+				f.log.Info("VulnerabilityWorker.work EventsCreator finished")
+			}()
 
 			f.log.Info("VulnerabilityWorker.work waiting on workers")
 			f.wg.Wait()
@@ -132,5 +142,5 @@ func (f *VulnerabilityWorker) Run(ctx context.Context) {
 }
 
 func (f *VulnerabilityWorker) GetChan() chan beat.Event {
-	return f.evaluator.GetChan()
+	return f.eventsCreator.GetChan()
 }


### PR DESCRIPTION
### Summary of your changes
I made more extensive changes than required for vulnerability management because we have an additional CSPM task of adding the region to the findings and I don't want code duplications.

1. Add cloud data to the vm events.
2. Modify the events creator to act as another pipeline step.

### Screenshot/Data
Added fields
<img width="951" alt="Screenshot 2023-04-16 at 14 25 03" src="https://user-images.githubusercontent.com/68195305/232308867-5cc3e954-2679-45bc-9962-d53f8de7402d.png">



### Related Issues
- Related: https://github.com/elastic/cloudbeat/issues/745

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
