### PR TITLE
Add fallback logic to vulnerability events creation

### DIFF
--- a/deploy/cloudformation/elastic-agent-ec2.yml
+++ b/deploy/cloudformation/elastic-agent-ec2.yml
@@ -60,6 +60,7 @@ Resources:
             - ec2:DescribeSnapshots
             - ec2:CreateSnapshots
             - ec2:CreateTags
+            - ec2:DeleteSnapshot
             Resource: "*"
           - Effect: Allow
             Action:

--- a/vulnerability/events_creator.go
+++ b/vulnerability/events_creator.go
@@ -251,12 +251,10 @@ func getCVSSVector(vul trivy_types.DetectedVulnerability) string {
 
 func (e EventsCreator) getCVSSScore(vul trivy_types.DetectedVulnerability) float64 {
 	var zeroVal float64
-	v := getCVSSValue(vul, func(cvss db_types.CVSS) float64 { return cvss.V3Score }, zeroVal)
-	if v == zeroVal {
-		return getCVSSValue(vul, func(cvss db_types.CVSS) float64 { return cvss.V2Score }, zeroVal)
+	if v := getCVSSValue(vul, func(cvss db_types.CVSS) float64 { return cvss.V3Score }, zeroVal); v != zeroVal {
+		return v
 	}
-
-	return v
+	return getCVSSValue(vul, func(cvss db_types.CVSS) float64 { return cvss.V2Score }, zeroVal)
 }
 
 // https://github.com/elastic/cloudbeat/pull/848#discussion_r1165239774

--- a/vulnerability/events_creator.go
+++ b/vulnerability/events_creator.go
@@ -19,7 +19,8 @@ package vulnerability
 
 import (
 	"context"
-	db_types "github.com/aquasecurity/trivy-db/pkg/types"
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+	trivyVul "github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 	"github.com/elastic/cloudbeat/dataprovider"
 	"github.com/elastic/cloudbeat/resources/fetching"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
@@ -27,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	trivy_types "github.com/aquasecurity/trivy/pkg/types"
+	trivyTypes "github.com/aquasecurity/trivy/pkg/types"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	libevents "github.com/elastic/beats/v7/libbeat/beat/events"
 	"github.com/elastic/cloudbeat/transformer"
@@ -36,21 +37,21 @@ import (
 )
 
 type Vulnerability struct {
-	Cvss           VendorCVSS `json:"cvss,omitempty"`
-	DataSource     DataSource `json:"data_source,omitempty"`
-	Scanner        Scanner    `json:"scanner,omitempty"`
-	Score          Score      `json:"score,omitempty"`
-	Package        Package    `json:"package,omitempty"`
-	Cwe            []string   `json:"cwe,omitempty"`
-	ID             string     `json:"id,omitempty"`
-	Title          string     `json:"title,omitempty"`
-	Enumeration    string     `json:"enumeration,omitempty"`
-	Reference      string     `json:"reference,omitempty"`
-	Description    string     `json:"description,omitempty"`
-	Severity       string     `json:"severity,omitempty"`
-	Classification string     `json:"classification,omitempty"`
-	PublishedDate  *time.Time `json:"published_date,omitempty"`
-	ReportId       int64      `json:"report_id,omitempty"`
+	Cvss           VendorCVSS  `json:"cvss,omitempty"`
+	DataSource     *DataSource `json:"data_source,omitempty"`
+	Scanner        Scanner     `json:"scanner,omitempty"`
+	Score          Score       `json:"score,omitempty"`
+	Package        Package     `json:"package,omitempty"`
+	Cwe            []string    `json:"cwe,omitempty"`
+	ID             string      `json:"id,omitempty"`
+	Title          string      `json:"title,omitempty"`
+	Enumeration    string      `json:"enumeration,omitempty"`
+	Reference      string      `json:"reference,omitempty"`
+	Description    string      `json:"description,omitempty"`
+	Severity       string      `json:"severity,omitempty"`
+	Classification string      `json:"classification,omitempty"`
+	PublishedDate  *time.Time  `json:"published_date,omitempty"`
+	ReportId       int64       `json:"report_id,omitempty"`
 }
 
 type CVSS struct {
@@ -60,12 +61,12 @@ type CVSS struct {
 	V3Score  float64 `json:"V3Score,omitempty"`
 }
 
-type VendorCVSS map[db_types.SourceID]CVSS
+type VendorCVSS map[dbTypes.SourceID]CVSS
 
 type DataSource struct {
-	ID   db_types.SourceID `json:",omitempty"`
-	Name string            `json:",omitempty"`
-	URL  string            `json:",omitempty"`
+	ID   dbTypes.SourceID `json:",omitempty"`
+	Name string           `json:",omitempty"`
+	URL  string           `json:",omitempty"`
 }
 
 type Package struct {
@@ -93,17 +94,9 @@ const (
 	vulScannerVersion   = "v0.35.0"
 	vulScannerVendor    = "Trivy"
 	vulScoreSystemClass = "CVSS"
-	nvdSource           = "nvd"
-	ghsaSource          = "ghsa"
-	redhatSource        = "redhat"
 	vectorHeader        = "CVSS:"
 	vulEcsCategory      = "vulnerability"
 	vulIndex            = "logs-cloud_security_posture.vulnerabilities-default"
-)
-
-var (
-	// sources order is crucial as it defines the priority
-	sources = []db_types.SourceID{nvdSource, redhatSource, ghsaSource}
 )
 
 type EventsCreator struct {
@@ -143,7 +136,7 @@ func (e EventsCreator) GetChan() chan beat.Event {
 	return e.ch
 }
 
-func (e EventsCreator) generateEvent(reportResult trivy_types.Result, vul trivy_types.DetectedVulnerability, snap ec2.EBSSnapshot, seq time.Time) beat.Event {
+func (e EventsCreator) generateEvent(reportResult trivyTypes.Result, vul trivyTypes.DetectedVulnerability, snap ec2.EBSSnapshot, seq time.Time) beat.Event {
 	timestamp := time.Now().UTC()
 	sequence := seq.Unix()
 	event := beat.Event{
@@ -211,8 +204,8 @@ func getIdentifierType(id string) string {
 	return s[0]
 }
 
-func (e EventsCreator) getCVSSVersion(vul trivy_types.DetectedVulnerability) string {
-	v := getCVSSVector(vul)
+func (e EventsCreator) getCVSSVersion(vul trivyTypes.DetectedVulnerability) string {
+	v := e.getCVSSVector(vul)
 	if v == "" {
 		e.log.Warnf("No CVSS vector found for vulnerability: %s", vul.VulnerabilityID)
 		return ""
@@ -231,35 +224,48 @@ func (e EventsCreator) getCVSSVersion(vul trivy_types.DetectedVulnerability) str
 	return ""
 }
 
-func getCVSSValue[T comparable](vul trivy_types.DetectedVulnerability, value func(cvss db_types.CVSS) T, zeroVal T) T {
-	for _, source := range sources {
-		if cvss, ok := vul.CVSS[source]; ok && value(cvss) != zeroVal {
-			return value(cvss)
-		}
+func (e EventsCreator) getCVSSVector(vul trivyTypes.DetectedVulnerability) string {
+	var zeroVal string
+	if v := getCVSSValue(vul, func(cvss dbTypes.CVSS) string { return cvss.V3Vector }, zeroVal); v != zeroVal {
+		return v
+	}
+
+	e.log.Debugf("No CVSS v3 vector found for vulnerability: %s, fallback to v2", vul.VulnerabilityID)
+	return getCVSSValue(vul, func(cvss dbTypes.CVSS) string { return cvss.V2Vector }, zeroVal)
+}
+
+func (e EventsCreator) getCVSSScore(vul trivyTypes.DetectedVulnerability) float64 {
+	var zeroVal float64
+	if v := getCVSSValue(vul, func(cvss dbTypes.CVSS) float64 { return cvss.V3Score }, zeroVal); v != zeroVal {
+		return v
+	}
+
+	e.log.Debugf("No CVSS v3 score found for vulnerability: %s, fallback to v2", vul.VulnerabilityID)
+	return getCVSSValue(vul, func(cvss dbTypes.CVSS) float64 { return cvss.V2Score }, zeroVal)
+}
+
+func getCVSSValue[T comparable](vul trivyTypes.DetectedVulnerability, value func(cvss dbTypes.CVSS) T, zeroVal T) T {
+	// Detect the data source
+	var source dbTypes.SourceID
+	if vul.DataSource != nil {
+		source = vul.DataSource.ID
+	}
+
+	if cvss, ok := vul.CVSS[source]; ok {
+		return value(cvss)
+	}
+
+	// Try NVD as a fallback if it exists
+	if cvss, ok := vul.CVSS[trivyVul.NVD]; ok {
+		return value(cvss)
 	}
 
 	return zeroVal
 }
 
-func getCVSSVector(vul trivy_types.DetectedVulnerability) string {
-	var zeroVal string
-	if v := getCVSSValue(vul, func(cvss db_types.CVSS) string { return cvss.V3Vector }, zeroVal); v != zeroVal {
-		return v
-	}
-	return getCVSSValue(vul, func(cvss db_types.CVSS) string { return cvss.V2Vector }, zeroVal)
-}
-
-func (e EventsCreator) getCVSSScore(vul trivy_types.DetectedVulnerability) float64 {
-	var zeroVal float64
-	if v := getCVSSValue(vul, func(cvss db_types.CVSS) float64 { return cvss.V3Score }, zeroVal); v != zeroVal {
-		return v
-	}
-	return getCVSSValue(vul, func(cvss db_types.CVSS) float64 { return cvss.V2Score }, zeroVal)
-}
-
 // https://github.com/elastic/cloudbeat/pull/848#discussion_r1165239774
-func getCVSS(vul trivy_types.DetectedVulnerability) VendorCVSS {
-	c := make(map[db_types.SourceID]CVSS)
+func getCVSS(vul trivyTypes.DetectedVulnerability) VendorCVSS {
+	c := make(map[dbTypes.SourceID]CVSS)
 	if len(vul.CVSS) == 0 {
 		return c
 	}
@@ -277,8 +283,12 @@ func getCVSS(vul trivy_types.DetectedVulnerability) VendorCVSS {
 }
 
 // https://github.com/elastic/cloudbeat/pull/848#discussion_r1165239774
-func getDataSource(vul trivy_types.DetectedVulnerability) DataSource {
-	return DataSource{
+func getDataSource(vul trivyTypes.DetectedVulnerability) *DataSource {
+	if vul.DataSource == nil {
+		return nil
+	}
+
+	return &DataSource{
 		ID:   vul.DataSource.ID,
 		Name: vul.DataSource.Name,
 		URL:  vul.DataSource.URL,

--- a/vulnerability/events_creator.go
+++ b/vulnerability/events_creator.go
@@ -19,6 +19,7 @@ package vulnerability
 
 import (
 	"context"
+	"github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/elastic/cloudbeat/dataprovider"
 	"github.com/elastic/cloudbeat/resources/fetching"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
@@ -26,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	db_types "github.com/aquasecurity/trivy-db/pkg/types"
 	trivy_types "github.com/aquasecurity/trivy/pkg/types"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	libevents "github.com/elastic/beats/v7/libbeat/beat/events"
@@ -60,15 +60,12 @@ type CVSS struct {
 	V3Score  float64 `json:"V3Score,omitempty"`
 }
 
-// SourceID represents data source such as NVD.
-type SourceID string
-
-type VendorCVSS map[SourceID]CVSS
+type VendorCVSS map[types.SourceID]CVSS
 
 type DataSource struct {
-	ID   SourceID `json:",omitempty"`
-	Name string   `json:",omitempty"`
-	URL  string   `json:",omitempty"`
+	ID   types.SourceID `json:",omitempty"`
+	Name string         `json:",omitempty"`
+	URL  string         `json:",omitempty"`
 }
 
 type Package struct {
@@ -83,7 +80,6 @@ type Scanner struct {
 }
 
 type Score struct {
-	Impact  float64 `json:"impact,omitempty"`
 	Base    float64 `json:"base,omitempty"`
 	Version string  `json:"version,omitempty"`
 }
@@ -94,13 +90,20 @@ type Resource struct {
 }
 
 const (
-	vulScannerVersion     = "v0.35.0"
-	vulScannerVendor      = "Trivy"
-	vulScoreSystemClass   = "CVSS"
-	vulScoreSource        = "nvd"
-	vulScoreSourceVersion = "3.0"
-	vulEcsCategory        = "vulnerability"
-	vulIndex              = "logs-cloud_security_posture.vulnerabilities-default"
+	vulScannerVersion   = "v0.35.0"
+	vulScannerVendor    = "Trivy"
+	vulScoreSystemClass = "CVSS"
+	nvdSource           = "nvd"
+	ghsaSource          = "ghsa"
+	redhatSource        = "redhat"
+	vectorHeader        = "CVSS:"
+	vulEcsCategory      = "vulnerability"
+	vulIndex            = "logs-cloud_security_posture.vulnerabilities-default"
+)
+
+var (
+	// sources order is crucial as it defines the priority
+	sources = []types.SourceID{nvdSource, redhatSource, ghsaSource}
 )
 
 type EventsCreator struct {
@@ -143,7 +146,6 @@ func (e EventsCreator) GetChan() chan beat.Event {
 func (e EventsCreator) generateEvent(reportResult trivy_types.Result, vul trivy_types.DetectedVulnerability, snap ec2.EBSSnapshot, seq time.Time) beat.Event {
 	timestamp := time.Now().UTC()
 	sequence := seq.Unix()
-	cvssScore := getCVSSScore(vul, vulScoreSource)
 	event := beat.Event{
 		// TODO: Maybe configure or get from somewhere else?
 		Meta:      mapstr.M{libevents.FieldMetaIndex: vulIndex},
@@ -171,9 +173,8 @@ func (e EventsCreator) generateEvent(reportResult trivy_types.Result, vul trivy_
 					Vendor:  vulScannerVendor,
 				},
 				Score: Score{
-					Impact:  cvssScore,
-					Base:    cvssScore,
-					Version: vulScoreSourceVersion,
+					Base:    e.getCVSSScore(vul),
+					Version: e.getCVSSVersion(vul),
 				},
 				Package: Package{
 					FixedVersion: vul.FixedVersion,
@@ -210,23 +211,63 @@ func getIdentifierType(id string) string {
 	return s[0]
 }
 
-func getCVSSScore(vul trivy_types.DetectedVulnerability, source db_types.SourceID) float64 {
-	if cvss, ok := vul.CVSS[source]; ok {
-		return cvss.V3Score
+func (e EventsCreator) getCVSSVersion(vul trivy_types.DetectedVulnerability) string {
+	v := getCVSSVector(vul)
+	if v == "" {
+		e.log.Warnf("No CVSS vector found for vulnerability: %s", vul.VulnerabilityID)
+		return ""
 	}
 
+	parts := strings.Split(v, "/")
+	for _, part := range parts {
+		if strings.HasPrefix(part, vectorHeader) {
+			// Extract the number after "CVSS:"
+			version := strings.TrimPrefix(part, vectorHeader)
+			return version
+		}
+	}
+
+	e.log.Warnf("no CVSS version found in vector: %s", v)
+	return ""
+}
+
+func getCVSSVector(vul trivy_types.DetectedVulnerability) string {
+	for _, source := range sources {
+		if cvss, ok := vul.CVSS[source]; ok {
+			switch {
+			case cvss.V3Vector != "":
+				return cvss.V3Vector
+			case cvss.V2Vector != "":
+				return cvss.V2Vector
+			}
+		}
+	}
+	return ""
+}
+
+func (e EventsCreator) getCVSSScore(vul trivy_types.DetectedVulnerability) float64 {
+	for _, source := range sources {
+		if cvss, ok := vul.CVSS[source]; ok {
+			switch {
+			case cvss.V3Score != 0:
+				return cvss.V3Score
+			case cvss.V2Score != 0:
+				return cvss.V2Score
+			}
+		}
+	}
 	return 0
 }
 
 // https://github.com/elastic/cloudbeat/pull/848#discussion_r1165239774
 func getCVSS(vul trivy_types.DetectedVulnerability) VendorCVSS {
-	c := make(map[SourceID]CVSS)
+	c := make(map[types.SourceID]CVSS)
 	if len(vul.CVSS) == 0 {
 		return c
 	}
 
 	for k, v := range vul.CVSS {
-		c[SourceID(k)] = CVSS{
+		c[k] = CVSS{
 			V2Vector: v.V2Vector,
 			V3Vector: v.V3Vector,
 			V2Score:  v.V2Score,
@@ -240,7 +281,7 @@ func getCVSS(vul trivy_types.DetectedVulnerability) VendorCVSS {
 // https://github.com/elastic/cloudbeat/pull/848#discussion_r1165239774
 func getDataSource(vul trivy_types.DetectedVulnerability) DataSource {
 	return DataSource{
-		ID:   SourceID(vul.DataSource.ID),
+		ID:   vul.DataSource.ID,
 		Name: vul.DataSource.Name,
 		URL:  vul.DataSource.URL,
 	}

--- a/vulnerability/events_creator.go
+++ b/vulnerability/events_creator.go
@@ -231,32 +231,32 @@ func (e EventsCreator) getCVSSVersion(vul trivy_types.DetectedVulnerability) str
 	return ""
 }
 
-func getCVSSVector(vul trivy_types.DetectedVulnerability) string {
+func getCVSSValue[T comparable](vul trivy_types.DetectedVulnerability, value func(cvss types.CVSS) T, zeroVal T) T {
 	for _, source := range sources {
-		if cvss, ok := vul.CVSS[source]; ok {
-			switch {
-			case cvss.V3Vector != "":
-				return cvss.V3Vector
-			case cvss.V2Vector != "":
-				return cvss.V2Vector
-			}
+		if cvss, ok := vul.CVSS[source]; ok && value(cvss) != zeroVal {
+			return value(cvss)
 		}
 	}
-	return ""
+
+	return zeroVal
+}
+
+func getCVSSVector(vul trivy_types.DetectedVulnerability) string {
+	var zeroVal string
+	if v := getCVSSValue(vul, func(cvss types.CVSS) string { return cvss.V3Vector }, zeroVal); v != zeroVal {
+		return v
+	}
+	return getCVSSValue(vul, func(cvss types.CVSS) string { return cvss.V2Vector }, zeroVal)
 }
 
 func (e EventsCreator) getCVSSScore(vul trivy_types.DetectedVulnerability) float64 {
-	for _, source := range sources {
-		if cvss, ok := vul.CVSS[source]; ok {
-			switch {
-			case cvss.V3Score != 0:
-				return cvss.V3Score
-			case cvss.V2Score != 0:
-				return cvss.V2Score
-			}
-		}
+	var zeroVal float64
+	v := getCVSSValue(vul, func(cvss types.CVSS) float64 { return cvss.V3Score }, zeroVal)
+	if v == zeroVal {
+		return getCVSSValue(vul, func(cvss types.CVSS) float64 { return cvss.V2Score }, zeroVal)
 	}
-	return 0
+
+	return v
 }
 
 // https://github.com/elastic/cloudbeat/pull/848#discussion_r1165239774

--- a/vulnerability/events_creator.go
+++ b/vulnerability/events_creator.go
@@ -19,7 +19,7 @@ package vulnerability
 
 import (
 	"context"
-	"github.com/aquasecurity/trivy-db/pkg/types"
+	db_types "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/elastic/cloudbeat/dataprovider"
 	"github.com/elastic/cloudbeat/resources/fetching"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
@@ -60,12 +60,12 @@ type CVSS struct {
 	V3Score  float64 `json:"V3Score,omitempty"`
 }
 
-type VendorCVSS map[types.SourceID]CVSS
+type VendorCVSS map[db_types.SourceID]CVSS
 
 type DataSource struct {
-	ID   types.SourceID `json:",omitempty"`
-	Name string         `json:",omitempty"`
-	URL  string         `json:",omitempty"`
+	ID   db_types.SourceID `json:",omitempty"`
+	Name string            `json:",omitempty"`
+	URL  string            `json:",omitempty"`
 }
 
 type Package struct {
@@ -103,7 +103,7 @@ const (
 
 var (
 	// sources order is crucial as it defines the priority
-	sources = []types.SourceID{nvdSource, redhatSource, ghsaSource}
+	sources = []db_types.SourceID{nvdSource, redhatSource, ghsaSource}
 )
 
 type EventsCreator struct {
@@ -231,7 +231,7 @@ func (e EventsCreator) getCVSSVersion(vul trivy_types.DetectedVulnerability) str
 	return ""
 }
 
-func getCVSSValue[T comparable](vul trivy_types.DetectedVulnerability, value func(cvss types.CVSS) T, zeroVal T) T {
+func getCVSSValue[T comparable](vul trivy_types.DetectedVulnerability, value func(cvss db_types.CVSS) T, zeroVal T) T {
 	for _, source := range sources {
 		if cvss, ok := vul.CVSS[source]; ok && value(cvss) != zeroVal {
 			return value(cvss)
@@ -243,17 +243,17 @@ func getCVSSValue[T comparable](vul trivy_types.DetectedVulnerability, value fun
 
 func getCVSSVector(vul trivy_types.DetectedVulnerability) string {
 	var zeroVal string
-	if v := getCVSSValue(vul, func(cvss types.CVSS) string { return cvss.V3Vector }, zeroVal); v != zeroVal {
+	if v := getCVSSValue(vul, func(cvss db_types.CVSS) string { return cvss.V3Vector }, zeroVal); v != zeroVal {
 		return v
 	}
-	return getCVSSValue(vul, func(cvss types.CVSS) string { return cvss.V2Vector }, zeroVal)
+	return getCVSSValue(vul, func(cvss db_types.CVSS) string { return cvss.V2Vector }, zeroVal)
 }
 
 func (e EventsCreator) getCVSSScore(vul trivy_types.DetectedVulnerability) float64 {
 	var zeroVal float64
-	v := getCVSSValue(vul, func(cvss types.CVSS) float64 { return cvss.V3Score }, zeroVal)
+	v := getCVSSValue(vul, func(cvss db_types.CVSS) float64 { return cvss.V3Score }, zeroVal)
 	if v == zeroVal {
-		return getCVSSValue(vul, func(cvss types.CVSS) float64 { return cvss.V2Score }, zeroVal)
+		return getCVSSValue(vul, func(cvss db_types.CVSS) float64 { return cvss.V2Score }, zeroVal)
 	}
 
 	return v
@@ -261,7 +261,7 @@ func (e EventsCreator) getCVSSScore(vul trivy_types.DetectedVulnerability) float
 
 // https://github.com/elastic/cloudbeat/pull/848#discussion_r1165239774
 func getCVSS(vul trivy_types.DetectedVulnerability) VendorCVSS {
-	c := make(map[types.SourceID]CVSS)
+	c := make(map[db_types.SourceID]CVSS)
 	if len(vul.CVSS) == 0 {
 		return c
 	}


### PR DESCRIPTION
### Summary of your changes
Improve score and version picking by adding a fallback logic in case Trivy vul does not have `nvd` attributes.


<details>
  <summary>Finding example</summary>

  ```json
{
  "_index": ".ds-logs-cloud_security_posture.vulnerabilities-default-2023.04.18-000001",
  "_id": "3zJLnYcBY-LT9Xmo-d6A",
  "_version": 1,
  "_score": 0,
  "_source": {
    "agent": {
      "name": "Uris-MacBook-Pro.local",
      "id": "048fc243-cb89-4eb8-bc92-34904f4ae5c7",
      "type": "cloudbeat",
      "ephemeral_id": "88fdd2b2-1496-400b-9947-7883e4008469",
      "version": "8.8.0"
    },
    "resource": {
      "name": "cspm-bc4",
      "id": "0708b5252a6556c9c"
    },
    "vulnerability": {
      "severity": "MEDIUM",
      "package": {
        "fixed_version": "1.5.16, 1.6.12",
        "name": "github.com/containerd/containerd",
        "version": "v1.5.13"
      },
      "description": "containerd is an open source container runtime. A bug was found in containerd's CRI implementation where a user can exhaust memory on the host. In the CRI stream server, a goroutine is launched to handle terminal resize events if a TTY is requested. If the user's process fails to launch due to, for example, a faulty command, the goroutine will be stuck waiting to send without a receiver, resulting in a memory leak. Kubernetes and crictl can both be configured to use containerd's CRI implementation and the stream server is used for handling container IO. This bug has been fixed in containerd 1.6.12 and 1.5.16. Users should update to these versions to resolve the issue. Users unable to upgrade should ensure that only trusted images and commands are used and that only trusted users have permissions to execute commands in running containers.",
      "title": "containerd is an open source container runtime. A bug was found in con ...",
      "classification": "CVSS",
      "data_source": {
        "ID": "glad",
        "URL": "https://gitlab.com/gitlab-org/advisories-community",
        "Name": "GitLab Advisory Database Community"
      },
      "reference": "https://avd.aquasec.com/nvd/cve-2022-23471",
      "cwe": [
        "CWE-400"
      ],
      "score": {
        "version": "3.1",
        "base": 6.5
      },
      "report_id": 1681970145,
      "scanner": {
        "vendor": "Trivy",
        "version": "v0.35.0"
      },
      "id": "CVE-2022-23471",
      "enumeration": "CVE",
      "published_date": "2022-12-07T23:15:00Z",
      "cvss": {
        "nvd": {
          "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
          "V3Score": 6.5
        },
        "ghsa": {
          "V3Vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:N/A:H",
          "V3Score": 5.7
        }
      }
    },
    "type": "gobinary",
    "target": "home/ec2-user/elastic-agent-8.7.0-linux-x86_64/data/elastic-agent-568a22/components/osquerybeat",
    "cloud": {
      "provider": "aws",
      "region": "eu-west-1",
      "account": {
        "name": "elastic-security-cloud-security-dev",
        "id": "704479110758"
      }
    },
    "@timestamp": "2023-04-20T06:13:30.536Z",
    "cloudbeat": {
      "commit_sha": "a376dfabc16137ff1a10dc70ed4f15c31281cb1f",
      "commit_time": "2023-04-19T08:46:43Z",
      "version": "8.8.0"
    },
    "ecs": {
      "version": "8.6.0"
    },
    "host": {
      "hostname": "Uris-MacBook-Pro.local",
      "os": {
        "build": "22D68",
        "kernel": "22.3.0",
        "name": "macOS",
        "family": "darwin",
        "type": "macos",
        "version": "13.2.1",
        "platform": "darwin"
      },
      "ip": [
        "fe80::6426:75ff:fec4:a8f7",
        "fe80::6426:75ff:fec4:a8f8",
        "fe80::6426:75ff:fec4:a8f6",
        "fe80::f02f:4bff:fe14:b86e",
        "fe80::1c4c:652a:3f83:8478",
        "192.168.1.109",
        "fe80::28cd:15ff:fe5a:cba5",
        "fe80::28cd:15ff:fe5a:cba5",
        "fe80::a666:aa6e:a9b4:2a2",
        "fe80::be00:a1a2:7995:4c3",
        "fe80::ce81:b1c:bd2c:69e",
        "192.168.64.1",
        "fe80::f02f:4bff:fe41:e564",
        "fd76:7369:3190:11a4:1c6d:17da:ead0:7ba6"
      ],
      "name": "Uris-MacBook-Pro.local",
      "id": "C3547051-1F5D-5F3D-B337-834FC73BB4F1",
      "mac": [
        "2A-CD-15-5A-CB-A5",
        "36-08-2B-9E-7B-80",
        "36-08-2B-9E-7B-84",
        "36-08-2B-9E-7B-88",
        "66-26-75-C4-A8-D6",
        "66-26-75-C4-A8-D7",
        "66-26-75-C4-A8-D8",
        "66-26-75-C4-A8-F6",
        "66-26-75-C4-A8-F7",
        "66-26-75-C4-A8-F8",
        "82-85-1E-53-15-85",
        "B0-4F-13-F0-47-AC",
        "F0-2F-4B-14-B8-6E",
        "F2-2F-4B-14-B8-6E",
        "F2-2F-4B-41-E5-64"
      ],
      "architecture": "arm64"
    },
    "event": {
      "agent_id_status": "auth_metadata_missing",
      "sequence": 1681970145,
      "ingested": "2023-04-20T06:13:34Z",
      "created": "2023-04-20T06:13:30.536431Z",
      "kind": "state",
      "id": "e9be5428-61ba-4991-b8e8-d99b768318d6",
      "type": [
        "info"
      ],
      "category": [
        "vulnerability"
      ],
      "outcome": "success"
    },
    "class": "lang-pkgs"
  },
  "fields": {
    "vulnerability.package.version": [
      "v1.5.13"
    ],
    "event.category": [
      "vulnerability"
    ],
    "vulnerability.cvss.nvd.V3Vector": [
      "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
    ],
    "vulnerability.cvss.ghsa.V3Vector": [
      "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:N/A:H"
    ],
    "host.os.name.text": [
      "macOS"
    ],
    "host.hostname": [
      "Uris-MacBook-Pro.local"
    ],
    "vulnerability.scanner.vendor": [
      "Trivy"
    ],
    "type": [
      "gobinary"
    ],
    "host.mac": [
      "2A-CD-15-5A-CB-A5",
      "36-08-2B-9E-7B-80",
      "36-08-2B-9E-7B-84",
      "36-08-2B-9E-7B-88",
      "66-26-75-C4-A8-D6",
      "66-26-75-C4-A8-D7",
      "66-26-75-C4-A8-D8",
      "66-26-75-C4-A8-F6",
      "66-26-75-C4-A8-F7",
      "66-26-75-C4-A8-F8",
      "82-85-1E-53-15-85",
      "B0-4F-13-F0-47-AC",
      "F0-2F-4B-14-B8-6E",
      "F2-2F-4B-14-B8-6E",
      "F2-2F-4B-41-E5-64"
    ],
    "vulnerability.data_source.ID": [
      "glad"
    ],
    "host.os.version": [
      "13.2.1"
    ],
    "host.os.name": [
      "macOS"
    ],
    "vulnerability.data_source.URL": [
      "https://gitlab.com/gitlab-org/advisories-community"
    ],
    "agent.name": [
      "Uris-MacBook-Pro.local"
    ],
    "host.name": [
      "Uris-MacBook-Pro.local"
    ],
    "event.agent_id_status": [
      "auth_metadata_missing"
    ],
    "event.kind": [
      "state"
    ],
    "event.outcome": [
      "success"
    ],
    "host.os.type": [
      "macos"
    ],
    "cloud.region": [
      "eu-west-1"
    ],
    "vulnerability.title": [
      "containerd is an open source container runtime. A bug was found in con ..."
    ],
    "data_stream.type": [
      "logs"
    ],
    "host.architecture": [
      "arm64"
    ],
    "cloud.provider": [
      "aws"
    ],
    "cloudbeat.version": [
      "8.8.0"
    ],
    "agent.id": [
      "048fc243-cb89-4eb8-bc92-34904f4ae5c7"
    ],
    "ecs.version": [
      "8.6.0"
    ],
    "event.created": [
      "2023-04-20T06:13:30.536Z"
    ],
    "agent.version": [
      "8.8.0"
    ],
    "vulnerability.reference": [
      "https://avd.aquasec.com/nvd/cve-2022-23471"
    ],
    "host.os.family": [
      "darwin"
    ],
    "vulnerability.cvss.nvd.V3Score": [
      6.5
    ],
    "cloudbeat.commit_sha": [
      "a376dfabc16137ff1a10dc70ed4f15c31281cb1f"
    ],
    "vulnerability.enumeration": [
      "CVE"
    ],
    "vulnerability.package.fixed_version": [
      "1.5.16, 1.6.12"
    ],
    "vulnerability.published_date": [
      "2022-12-07T23:15:00Z"
    ],
    "resource.name": [
      "cspm-bc4"
    ],
    "vulnerability.package.name": [
      "github.com/containerd/containerd"
    ],
    "host.os.build": [
      "22D68"
    ],
    "event.sequence": [
      1681970145
    ],
    "host.ip": [
      "fe80::6426:75ff:fec4:a8f7",
      "fe80::6426:75ff:fec4:a8f8",
      "fe80::6426:75ff:fec4:a8f6",
      "fe80::f02f:4bff:fe14:b86e",
      "fe80::1c4c:652a:3f83:8478",
      "192.168.1.109",
      "fe80::28cd:15ff:fe5a:cba5",
      "fe80::28cd:15ff:fe5a:cba5",
      "fe80::a666:aa6e:a9b4:2a2",
      "fe80::be00:a1a2:7995:4c3",
      "fe80::ce81:b1c:bd2c:69e",
      "192.168.64.1",
      "fe80::f02f:4bff:fe41:e564",
      "fd76:7369:3190:11a4:1c6d:17da:ead0:7ba6"
    ],
    "agent.type": [
      "cloudbeat"
    ],
    "vulnerability.id": [
      "CVE-2022-23471"
    ],
    "host.os.kernel": [
      "22.3.0"
    ],
    "vulnerability.score.version": [
      "3.1"
    ],
    "vulnerability.score.base": [
      6.5
    ],
    "host.id": [
      "C3547051-1F5D-5F3D-B337-834FC73BB4F1"
    ],
    "class": [
      "lang-pkgs"
    ],
    "vulnerability.report_id": [
      "1.681970145E9"
    ],
    "cloud.account.name": [
      "elastic-security-cloud-security-dev"
    ],
    "vulnerability.classification": [
      "CVSS"
    ],
    "data_stream.namespace": [
      "default"
    ],
    "vulnerability.cwe": [
      "CWE-400"
    ],
    "vulnerability.scanner.version": [
      "v0.35.0"
    ],
    "resource.id": [
      "0708b5252a6556c9c"
    ],
    "target": [
      "home/ec2-user/elastic-agent-8.7.0-linux-x86_64/data/elastic-agent-568a22/components/osquerybeat"
    ],
    "event.ingested": [
      "2023-04-20T06:13:34.000Z"
    ],
    "@timestamp": [
      "2023-04-20T06:13:30.536Z"
    ],
    "vulnerability.severity": [
      "MEDIUM"
    ],
    "cloud.account.id": [
      "704479110758"
    ],
    "host.os.platform": [
      "darwin"
    ],
    "data_stream.dataset": [
      "cloud_security_posture.vulnerabilities"
    ],
    "event.type": [
      "info"
    ],
    "agent.ephemeral_id": [
      "88fdd2b2-1496-400b-9947-7883e4008469"
    ],
    "vulnerability.data_source.Name": [
      "GitLab Advisory Database Community"
    ],
    "vulnerability.cvss.ghsa.V3Score": [
      5.7
    ],
    "vulnerability.description": [
      "containerd is an open source container runtime. A bug was found in containerd's CRI implementation where a user can exhaust memory on the host. In the CRI stream server, a goroutine is launched to handle terminal resize events if a TTY is requested. If the user's process fails to launch due to, for example, a faulty command, the goroutine will be stuck waiting to send without a receiver, resulting in a memory leak. Kubernetes and crictl can both be configured to use containerd's CRI implementation and the stream server is used for handling container IO. This bug has been fixed in containerd 1.6.12 and 1.5.16. Users should update to these versions to resolve the issue. Users unable to upgrade should ensure that only trusted images and commands are used and that only trusted users have permissions to execute commands in running containers."
    ],
    "vulnerability.description.text": [
      "containerd is an open source container runtime. A bug was found in containerd's CRI implementation where a user can exhaust memory on the host. In the CRI stream server, a goroutine is launched to handle terminal resize events if a TTY is requested. If the user's process fails to launch due to, for example, a faulty command, the goroutine will be stuck waiting to send without a receiver, resulting in a memory leak. Kubernetes and crictl can both be configured to use containerd's CRI implementation and the stream server is used for handling container IO. This bug has been fixed in containerd 1.6.12 and 1.5.16. Users should update to these versions to resolve the issue. Users unable to upgrade should ensure that only trusted images and commands are used and that only trusted users have permissions to execute commands in running containers."
    ],
    "cloudbeat.commit_time": [
      "2023-04-19T08:46:43.000Z"
    ],
    "event.id": [
      "e9be5428-61ba-4991-b8e8-d99b768318d6"
    ]
  }
}
  ```
</details>

### Related Issues
- Related: https://github.com/elastic/security-team/issues/6340

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)