### PR TITLE
Add permissions to cloudformation to list account aliases

### DIFF
--- a/deploy/cloudformation/elastic-agent-ec2.yml
+++ b/deploy/cloudformation/elastic-agent-ec2.yml
@@ -68,6 +68,10 @@ Resources:
             - ebs:ListChangedBlocks
             - ebs:GetSnapshotBlock
             Resource: "*"
+          - Effect: Allow
+            Action:
+              - iam:ListAccountAliases
+            Resource: "*"
 
   # Instance profile to attach to EC2 instance
   ElasticAgentInstanceProfile:


### PR DESCRIPTION
### Summary of your changes
Add permissions to cloudformation to list account aliases, part of the aws data we're sending with findings.


### Related Issues
- Related: https://github.com/elastic/security-team/issues/6339

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
