### PR TITLE
Modify ES query timeout in agent integration test

### DIFF
--- a/tests/commonlib/elastic_wrapper.py
+++ b/tests/commonlib/elastic_wrapper.py
@@ -15,6 +15,7 @@ class ElasticWrapper:
         self.es_client = Elasticsearch(
             hosts=elastic_params.url,
             basic_auth=elastic_params.basic_auth,
+            request_timeout=30,
         )
 
     def get_index_data(

--- a/tests/integration/tests/test_standalone_agent_integration.py
+++ b/tests/integration/tests/test_standalone_agent_integration.py
@@ -11,7 +11,7 @@ from commonlib.io_utils import FsClient
 from loguru import logger
 
 testdata = ["file", "process", "k8s_object"]
-CONFIG_TIMEOUT = 60
+CONFIG_TIMEOUT = 90
 
 
 @pytest.mark.pre_merge_agent

--- a/tests/integration/tests/test_standalone_agent_integration.py
+++ b/tests/integration/tests/test_standalone_agent_integration.py
@@ -11,7 +11,7 @@ from commonlib.io_utils import FsClient
 from loguru import logger
 
 testdata = ["file", "process", "k8s_object"]
-CONFIG_TIMEOUT = 90
+CONFIG_TIMEOUT = 60
 
 
 @pytest.mark.pre_merge_agent


### PR DESCRIPTION
### Summary of your changes
Agent integration tests are failing for a long time - pre and post-merge.
This error is returning when tests are failing:
```
/usr/local/lib/python3.9/site-packages/elasticsearch/_sync/client/_base.py:321: elasticsearch.ApiError: ApiError(503, 'search_phase_execution_exception', None)
```
The above indicates that it might be related to us querying es before it's ready, in this pr I extend the timeout to see if it helps.

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
