### PR TITLE
Vulnerability pull available CVSS data sources

### DIFF
--- a/vulnerability/events_creator.go
+++ b/vulnerability/events_creator.go
@@ -19,14 +19,15 @@ package vulnerability
 
 import (
 	"context"
+	"strings"
+	"time"
+
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	trivyVul "github.com/aquasecurity/trivy-db/pkg/vulnsrc/vulnerability"
 	"github.com/elastic/cloudbeat/dataprovider"
 	"github.com/elastic/cloudbeat/resources/fetching"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
 	"github.com/elastic/elastic-agent-libs/logp"
-	"strings"
-	"time"
 
 	trivyTypes "github.com/aquasecurity/trivy/pkg/types"
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -34,6 +35,7 @@ import (
 	"github.com/elastic/cloudbeat/transformer"
 	"github.com/elastic/cloudbeat/version"
 	"github.com/elastic/elastic-agent-libs/mapstr"
+	maps "golang.org/x/exp/maps"
 )
 
 type Vulnerability struct {
@@ -245,14 +247,31 @@ func (e EventsCreator) getCVSSScore(vul trivyTypes.DetectedVulnerability) float6
 }
 
 func getCVSSValue[T comparable](vul trivyTypes.DetectedVulnerability, value func(cvss dbTypes.CVSS) T, zeroVal T) T {
+	// Get all the sources
+	sources := maps.Keys(vul.CVSS)
+	if len(sources) == 0 {
+		return zeroVal
+	}
+
 	// Detect the data source
 	var source dbTypes.SourceID
 	if vul.DataSource != nil {
 		source = vul.DataSource.ID
 	}
 
+	// Attempt to pull detected data source
 	if cvss, ok := vul.CVSS[source]; ok {
 		return value(cvss)
+	}
+
+	// Attempt to pull any other data source besides NVD
+	for _, s := range sources {
+		if s == trivyVul.NVD {
+			continue
+		}
+		if cvss, ok := vul.CVSS[s]; ok {
+			return value(cvss)
+		}
 	}
 
 	// Try NVD as a fallback if it exists

--- a/vulnerability/events_creator.go
+++ b/vulnerability/events_creator.go
@@ -264,19 +264,16 @@ func getCVSSValue[T comparable](vul trivyTypes.DetectedVulnerability, value func
 		return value(cvss)
 	}
 
-	// Attempt to pull any other data source besides NVD
-	for _, s := range sources {
-		if s == trivyVul.NVD {
-			continue
-		}
-		if cvss, ok := vul.CVSS[s]; ok {
-			return value(cvss)
-		}
-	}
-
 	// Try NVD as a fallback if it exists
 	if cvss, ok := vul.CVSS[trivyVul.NVD]; ok {
 		return value(cvss)
+	}
+
+	// Attempt to pull any other data source
+	for _, s := range sources {
+		if cvss, ok := vul.CVSS[s]; ok {
+			return value(cvss)
+		}
 	}
 
 	return zeroVal


### PR DESCRIPTION
### Summary of your changes
We have a dynamic code that looks at Trivy's reported data_source and takes its CVSS information.
This is done in order to calculate the `score.version` and `score.base` values.
In some cases, Trivy reports a source that is non-existent in the CVSS array and that array doesn't have an NVD source.
This creates weird behavior in the FE.
![image](https://user-images.githubusercontent.com/12246907/233477643-c6ceabec-7641-4cbe-b967-281aed50e7f8.png)
![image](https://user-images.githubusercontent.com/12246907/233477681-56262c54-0922-4fab-a790-ff3bcb4ba367.png)
I've implemented a priority mechanism that attempts to pull the reported source, if non existent it will attempt to pull any other source besides NVD, and if there aren't anything resorts to NVD or empty fields if the CVSS is empty.

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
