### PR TITLE
Fetch AWS iam server-certificates

### DIFF
--- a/resources/fetchers/iam_factory.go
+++ b/resources/fetchers/iam_factory.go
@@ -20,6 +20,7 @@ package fetchers
 import (
 	"context"
 	"fmt"
+
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 

--- a/resources/fetchers/iam_fetcher.go
+++ b/resources/fetchers/iam_fetcher.go
@@ -20,6 +20,7 @@ package fetchers
 import (
 	"context"
 	"fmt"
+
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/iam"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -76,6 +77,13 @@ func (f IAMFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata)
 		f.log.Errorf("Unable to fetch AWS Support Policy, error: %v", err)
 	} else {
 		iamResources = append(iamResources, supportPolicy)
+	}
+
+	serverCertificates, err := f.iamProvider.ListServerCertificates(ctx)
+	if err != nil {
+		f.log.Errorf("Unable to fetch IAM server certificates, error: %v", err)
+	} else {
+		iamResources = append(iamResources, serverCertificates)
 	}
 
 	for _, iamResource := range iamResources {

--- a/resources/fetchers/iam_fetcher_test.go
+++ b/resources/fetchers/iam_fetcher_test.go
@@ -19,6 +19,9 @@ package fetchers
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/elastic/cloudbeat/resources/fetching"
@@ -28,7 +31,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type IamFetcherTestSuite struct {
@@ -105,6 +107,14 @@ func (s *IamFetcherTestSuite) TestIamFetcher_Fetch() {
 		},
 	}
 
+	certificates := iam.ServerCertificatesInfo{
+		Certificates: []types.ServerCertificateMetadata{
+			{
+				Expiration: &time.Time{},
+			},
+		},
+	}
+
 	var tests = []struct {
 		name               string
 		mocksReturnVals    mocksReturnVals
@@ -112,70 +122,88 @@ func (s *IamFetcherTestSuite) TestIamFetcher_Fetch() {
 		numExpectedResults int
 	}{
 		{
-			name: "Should get password policy, an IAM user and an IAM policy",
-			mocksReturnVals: mocksReturnVals{
-				"GetPasswordPolicy": {pwdPolicy, nil},
-				"GetUsers":          {[]awslib.AwsResource{iamUser}, nil},
-				"GetPolicies":       {[]awslib.AwsResource{iamPolicy}, nil},
-				"GetSupportPolicy":  {iamPolicy, nil},
-			},
-			account:            testAccount,
-			numExpectedResults: 4,
-		},
-		{
-			name: "Receives only an IAM user due to errors in other fetchers",
-			mocksReturnVals: mocksReturnVals{
-				"GetPasswordPolicy": {nil, errors.New("Fail to fetch pwd policy")},
-				"GetUsers":          {[]awslib.AwsResource{iamUser}, nil},
-				"GetPolicies":       {nil, errors.New("Fail to fetch iam policies")},
-				"GetSupportPolicy":  {nil, errors.New("Fail to fetch iam support policy")},
-			},
-			account:            testAccount,
-			numExpectedResults: 1,
-		},
-		{
-			name: "Should get only a password policy resource due errors in other fetchers",
-			mocksReturnVals: mocksReturnVals{
-				"GetPasswordPolicy": {pwdPolicy, nil},
-				"GetUsers":          {nil, errors.New("Fail to fetch iam users")},
-				"GetPolicies":       {nil, errors.New("Fail to fetch iam policies")},
-				"GetSupportPolicy":  {nil, errors.New("Fail to fetch iam support policy")},
-			},
-			account:            testAccount,
-			numExpectedResults: 1,
-		},
-		{
-			name: "Should get only IAM policies due to errors in other fetchers",
-			mocksReturnVals: mocksReturnVals{
-				"GetPasswordPolicy": {nil, errors.New("Fail to fetch pwd policy")},
-				"GetUsers":          {nil, errors.New("Fail to fetch iam users")},
-				"GetPolicies":       {[]awslib.AwsResource{iamPolicy, iamPolicy}, nil},
-				"GetSupportPolicy":  {nil, errors.New("Fail to fetch iam support policy")},
-			},
-			account:            testAccount,
-			numExpectedResults: 2, // note: intentionally including two policies
-		},
-		{
-			name: "Should get only IAM support policy due to errors in other fetchers",
-			mocksReturnVals: mocksReturnVals{
-				"GetPasswordPolicy": {nil, errors.New("Fail to fetch pwd policy")},
-				"GetUsers":          {nil, errors.New("Fail to fetch iam users")},
-				"GetPolicies":       {nil, errors.New("Fail to fetch iam policies")},
-				"GetSupportPolicy":  {iamPolicy, nil},
-			},
-			account:            testAccount,
-			numExpectedResults: 1,
-		},
-		{
 			name: "Should not get any IAM resources",
 			mocksReturnVals: mocksReturnVals{
-				"GetPasswordPolicy": {nil, errors.New("Fail to fetch pwd policy")},
-				"GetUsers":          {nil, errors.New("Fail to fetch iam users")},
-				"GetPolicies":       {nil, errors.New("Fail to fetch iam policies")},
-				"GetSupportPolicy":  {nil, errors.New("Fail to fetch iam support policy")},
+				"GetPasswordPolicy":      {nil, errors.New("Fail to fetch iam pwd policy")},
+				"GetUsers":               {nil, errors.New("Fail to fetch iam users")},
+				"GetPolicies":            {nil, errors.New("Fail to fetch iam policies")},
+				"GetSupportPolicy":       {nil, errors.New("Fail to fetch iam support policy")},
+				"ListServerCertificates": {nil, errors.New("Fail to fetch iam certificates")},
 			},
 			account:            testAccount,
 			numExpectedResults: 0,
+		},
+		{
+			name: "Should get all AWS resources",
+			mocksReturnVals: mocksReturnVals{
+				"GetPasswordPolicy":      {pwdPolicy, nil},
+				"GetUsers":               {[]awslib.AwsResource{iamUser}, nil},
+				"GetPolicies":            {[]awslib.AwsResource{iamPolicy}, nil},
+				"GetSupportPolicy":       {iamPolicy, nil},
+				"ListServerCertificates": {&certificates, nil},
+			},
+			account:            testAccount,
+			numExpectedResults: 5,
+		},
+		{
+			name: "Should only get iam pwd policy",
+			mocksReturnVals: mocksReturnVals{
+				"GetPasswordPolicy":      {pwdPolicy, nil},
+				"GetUsers":               {nil, errors.New("Fail to fetch iam users")},
+				"GetPolicies":            {nil, errors.New("Fail to fetch iam policies")},
+				"GetSupportPolicy":       {nil, errors.New("Fail to fetch iam support policy")},
+				"ListServerCertificates": {nil, errors.New("Fail to fetch iam certificates")},
+			},
+			account:            testAccount,
+			numExpectedResults: 1,
+		},
+		{
+			name: "Should only get iam users",
+			mocksReturnVals: mocksReturnVals{
+				"GetPasswordPolicy":      {nil, errors.New("Fail to fetch iam pwd policy")},
+				"GetUsers":               {[]awslib.AwsResource{iamUser}, nil},
+				"GetPolicies":            {nil, errors.New("Fail to fetch iam policies")},
+				"GetSupportPolicy":       {nil, errors.New("Fail to fetch iam support policy")},
+				"ListServerCertificates": {nil, errors.New("Fail to fetch iam certificates")},
+			},
+			account:            testAccount,
+			numExpectedResults: 1,
+		},
+		{
+			name: "Should only get iam policies",
+			mocksReturnVals: mocksReturnVals{
+				"GetPasswordPolicy":      {nil, errors.New("Fail to fetch iam pwd policy")},
+				"GetUsers":               {nil, errors.New("Fail to fetch iam users")},
+				"GetPolicies":            {[]awslib.AwsResource{iamPolicy}, nil},
+				"GetSupportPolicy":       {nil, errors.New("Fail to fetch iam support policies")},
+				"ListServerCertificates": {nil, errors.New("Fail to fetch iam certificates")},
+			},
+			account:            testAccount,
+			numExpectedResults: 1,
+		},
+		{
+			name: "Should only get a support policy",
+			mocksReturnVals: mocksReturnVals{
+				"GetPasswordPolicy":      {nil, errors.New("Fail to fetch iam pwd policy")},
+				"GetUsers":               {nil, errors.New("Fail to fetch iam users")},
+				"GetPolicies":            {nil, errors.New("Fail to fetch iam policies")},
+				"GetSupportPolicy":       {iamPolicy, nil},
+				"ListServerCertificates": {nil, errors.New("Fail to fetch iam certificates")},
+			},
+			account:            testAccount,
+			numExpectedResults: 1,
+		},
+		{
+			name: "Should only get iam certificates",
+			mocksReturnVals: mocksReturnVals{
+				"GetPasswordPolicy":      {nil, errors.New("Fail to fetch iam pwd policy")},
+				"GetUsers":               {nil, errors.New("Fail to fetch iam users")},
+				"GetPolicies":            {nil, errors.New("Fail to fetch iam policies")},
+				"GetSupportPolicy":       {nil, errors.New("Fail to fetch iam support policy")},
+				"ListServerCertificates": {&certificates, nil},
+			},
+			account:            testAccount,
+			numExpectedResults: 1,
 		},
 	}
 

--- a/resources/fetching/fetcher.go
+++ b/resources/fetching/fetcher.go
@@ -41,6 +41,7 @@ const (
 	EBSSnapshotType           = "aws-ebs-snapshot"
 	ElbType                   = "aws-elb"
 	IAMUserType               = "aws-iam-user"
+	IAMServerCertificateType  = "aws-iam-server-certificate"
 	PwdPolicyType             = "aws-password-policy"
 	EksType                   = "aws-eks"
 	S3Type                    = "aws-s3"

--- a/resources/providers/awslib/iam/iam.go
+++ b/resources/providers/awslib/iam/iam.go
@@ -19,6 +19,7 @@ package iam
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	iamsdk "github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
@@ -33,6 +34,7 @@ type AccessManagement interface {
 	GetAccountAlias(ctx context.Context) (string, error)
 	GetPolicies(ctx context.Context) ([]awslib.AwsResource, error)
 	GetSupportPolicy(ctx context.Context) (awslib.AwsResource, error)
+	ListServerCertificates(ctx context.Context) (awslib.AwsResource, error)
 }
 
 type Client interface {
@@ -54,6 +56,7 @@ type Client interface {
 	GetPolicy(ctx context.Context, params *iamsdk.GetPolicyInput, optFns ...func(*iamsdk.Options)) (*iamsdk.GetPolicyOutput, error)
 	GetPolicyVersion(ctx context.Context, params *iamsdk.GetPolicyVersionInput, optFns ...func(*iamsdk.Options)) (*iamsdk.GetPolicyVersionOutput, error)
 	ListEntitiesForPolicy(ctx context.Context, params *iamsdk.ListEntitiesForPolicyInput, optFns ...func(*iamsdk.Options)) (*iamsdk.ListEntitiesForPolicyOutput, error)
+	ListServerCertificates(ctx context.Context, params *iamsdk.ListServerCertificatesInput, optFns ...func(*iamsdk.Options)) (*iamsdk.ListServerCertificatesOutput, error)
 }
 
 type Provider struct {
@@ -127,6 +130,10 @@ type Policy struct {
 	types.Policy
 	Document map[string]interface{} `json:"document,omitempty"`
 	Roles    []types.PolicyRole     `json:"roles"`
+}
+
+type ServerCertificatesInfo struct {
+	Certificates []types.ServerCertificateMetadata `json:"certificates"`
 }
 
 type PolicyDocument struct {

--- a/resources/providers/awslib/iam/mock_access_management.go
+++ b/resources/providers/awslib/iam/mock_access_management.go
@@ -363,6 +363,60 @@ func (_c *MockAccessManagement_GetUsers_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+// ListServerCertificates provides a mock function with given fields: ctx
+func (_m *MockAccessManagement) ListServerCertificates(ctx context.Context) (awslib.AwsResource, error) {
+	ret := _m.Called(ctx)
+
+	var r0 awslib.AwsResource
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (awslib.AwsResource, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) awslib.AwsResource); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(awslib.AwsResource)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockAccessManagement_ListServerCertificates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListServerCertificates'
+type MockAccessManagement_ListServerCertificates_Call struct {
+	*mock.Call
+}
+
+// ListServerCertificates is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockAccessManagement_Expecter) ListServerCertificates(ctx interface{}) *MockAccessManagement_ListServerCertificates_Call {
+	return &MockAccessManagement_ListServerCertificates_Call{Call: _e.mock.On("ListServerCertificates", ctx)}
+}
+
+func (_c *MockAccessManagement_ListServerCertificates_Call) Run(run func(ctx context.Context)) *MockAccessManagement_ListServerCertificates_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockAccessManagement_ListServerCertificates_Call) Return(_a0 awslib.AwsResource, _a1 error) *MockAccessManagement_ListServerCertificates_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockAccessManagement_ListServerCertificates_Call) RunAndReturn(run func(context.Context) (awslib.AwsResource, error)) *MockAccessManagement_ListServerCertificates_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 type mockConstructorTestingTNewMockAccessManagement interface {
 	mock.TestingT
 	Cleanup(func())

--- a/resources/providers/awslib/iam/mock_client.go
+++ b/resources/providers/awslib/iam/mock_client.go
@@ -1089,6 +1089,76 @@ func (_c *MockClient_ListPolicies_Call) RunAndReturn(run func(context.Context, *
 	return _c
 }
 
+// ListServerCertificates provides a mock function with given fields: ctx, params, optFns
+func (_m *MockClient) ListServerCertificates(ctx context.Context, params *serviceiam.ListServerCertificatesInput, optFns ...func(*serviceiam.Options)) (*serviceiam.ListServerCertificatesOutput, error) {
+	_va := make([]interface{}, len(optFns))
+	for _i := range optFns {
+		_va[_i] = optFns[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, params)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *serviceiam.ListServerCertificatesOutput
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *serviceiam.ListServerCertificatesInput, ...func(*serviceiam.Options)) (*serviceiam.ListServerCertificatesOutput, error)); ok {
+		return rf(ctx, params, optFns...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *serviceiam.ListServerCertificatesInput, ...func(*serviceiam.Options)) *serviceiam.ListServerCertificatesOutput); ok {
+		r0 = rf(ctx, params, optFns...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*serviceiam.ListServerCertificatesOutput)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *serviceiam.ListServerCertificatesInput, ...func(*serviceiam.Options)) error); ok {
+		r1 = rf(ctx, params, optFns...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClient_ListServerCertificates_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListServerCertificates'
+type MockClient_ListServerCertificates_Call struct {
+	*mock.Call
+}
+
+// ListServerCertificates is a helper method to define mock.On call
+//   - ctx context.Context
+//   - params *serviceiam.ListServerCertificatesInput
+//   - optFns ...func(*serviceiam.Options)
+func (_e *MockClient_Expecter) ListServerCertificates(ctx interface{}, params interface{}, optFns ...interface{}) *MockClient_ListServerCertificates_Call {
+	return &MockClient_ListServerCertificates_Call{Call: _e.mock.On("ListServerCertificates",
+		append([]interface{}{ctx, params}, optFns...)...)}
+}
+
+func (_c *MockClient_ListServerCertificates_Call) Run(run func(ctx context.Context, params *serviceiam.ListServerCertificatesInput, optFns ...func(*serviceiam.Options))) *MockClient_ListServerCertificates_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]func(*serviceiam.Options), len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(func(*serviceiam.Options))
+			}
+		}
+		run(args[0].(context.Context), args[1].(*serviceiam.ListServerCertificatesInput), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *MockClient_ListServerCertificates_Call) Return(_a0 *serviceiam.ListServerCertificatesOutput, _a1 error) *MockClient_ListServerCertificates_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClient_ListServerCertificates_Call) RunAndReturn(run func(context.Context, *serviceiam.ListServerCertificatesInput, ...func(*serviceiam.Options)) (*serviceiam.ListServerCertificatesOutput, error)) *MockClient_ListServerCertificates_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListUserPolicies provides a mock function with given fields: ctx, params, optFns
 func (_m *MockClient) ListUserPolicies(ctx context.Context, params *serviceiam.ListUserPoliciesInput, optFns ...func(*serviceiam.Options)) (*serviceiam.ListUserPoliciesOutput, error) {
 	_va := make([]interface{}, len(optFns))

--- a/resources/providers/awslib/iam/server_cerfiticates.go
+++ b/resources/providers/awslib/iam/server_cerfiticates.go
@@ -63,3 +63,7 @@ func (c ServerCertificatesInfo) GetResourceName() string {
 func (c ServerCertificatesInfo) GetResourceType() string {
 	return fetching.IAMServerCertificateType
 }
+
+func (p ServerCertificatesInfo) GetRegion() string {
+	return awslib.GlobalRegion
+}

--- a/resources/providers/awslib/iam/server_cerfiticates.go
+++ b/resources/providers/awslib/iam/server_cerfiticates.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iam
+
+import (
+	"context"
+
+	iamsdk "github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/providers/awslib"
+)
+
+func (p Provider) ListServerCertificates(ctx context.Context) (awslib.AwsResource, error) {
+
+	p.log.Debug("IAMProvider.ListServerCertificates")
+
+	var certificates []types.ServerCertificateMetadata
+	input := &iamsdk.ListServerCertificatesInput{}
+
+	for {
+		certs, err := p.client.ListServerCertificates(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+
+		certificates = append(certificates, certs.ServerCertificateMetadataList...)
+		if !certs.IsTruncated {
+			break
+		}
+
+		input.Marker = certs.Marker
+	}
+
+	return &ServerCertificatesInfo{
+		Certificates: certificates,
+	}, nil
+}
+
+func (c ServerCertificatesInfo) GetResourceArn() string {
+	return ""
+}
+
+func (c ServerCertificatesInfo) GetResourceName() string {
+	return "account-iam-server-certificates"
+}
+
+func (c ServerCertificatesInfo) GetResourceType() string {
+	return fetching.IAMServerCertificateType
+}

--- a/resources/providers/awslib/iam/server_certificates_test.go
+++ b/resources/providers/awslib/iam/server_certificates_test.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iam
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	iamsdk "github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/elastic/cloudbeat/resources/providers/awslib"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvider_ListServerCertificates(t *testing.T) {
+
+	certificates := []types.ServerCertificateMetadata{
+		{
+			Expiration: &time.Time{},
+		},
+	}
+
+	certificatesResponse := iamsdk.ListServerCertificatesOutput{
+		ServerCertificateMetadataList: certificates,
+	}
+
+	certificatesInfo := ServerCertificatesInfo{
+		Certificates: certificates,
+	}
+
+	tests := []struct {
+		name             string
+		mockReturnValues mocksReturnVals
+		want             awslib.AwsResource
+		wantErr          bool
+	}{
+		{
+			name: "Should return an error when listing server certificates fails",
+			mockReturnValues: mocksReturnVals{
+				"ListServerCertificates": {
+					{
+						nil,
+						errors.New("some error"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Should return a resource when listing server certificates succeeds",
+			mockReturnValues: mocksReturnVals{
+				"ListServerCertificates": {
+					{
+						&certificatesResponse,
+						nil,
+					},
+				},
+			},
+			want:    &certificatesInfo,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := createProviderFromMockValues(tt.mockReturnValues)
+
+			got, err := p.ListServerCertificates(context.Background())
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
### Summary of your changes

1. Uses `aws iam list-server-certificates` to fetch resources
2. Adds a new sub type: `aws-iam-server-certificate`


### Screenshot/Data
![Screenshot 2023-04-24 at 18 11 11](https://user-images.githubusercontent.com/20814186/234040136-b983ba7b-2d0d-4893-be23-5db39101f967.png)

### Related Issues
- closes https://github.com/elastic/csp-security-policies/issues/221

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
