### PR TITLE
update run-tests command

### DIFF
--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -369,7 +369,7 @@ jobs:
       - name: Run Tests
         id: run_tests
         run: |
-          just run-tests ${{ matrix.test-target }} ${{ env.KIND_CONFIG }}
+          just run-tests ${{ matrix.test-target }} kind-${{ env.KIND_CONFIG }}
 
       - name: Upload Test Results
         if: always()

--- a/justfile
+++ b/justfile
@@ -196,8 +196,8 @@ purge-tests:
 gen-report:
   allure generate tests/allure/results --clean -o tests/allure/reports && cp tests/allure/reports/history/* tests/allure/results/history/. && allure open tests/allure/reports
 
-run-tests target='default' context='kind-multi':
-  helm test {{TESTS_RELEASE}} -n {{NAMESPACE}} --kube-context kind-{{context}} --timeout {{TESTS_TIMEOUT}} --logs
+run-tests target='default' context='kind-kind-multi':
+  helm test {{TESTS_RELEASE}} -n {{NAMESPACE}} --kube-context {{context}} --timeout {{TESTS_TIMEOUT}} --logs
 
 build-load-run-tests: build-pytest-docker load-pytest-kind run-tests
 


### PR DESCRIPTION
### Summary of your changes
EKS tests failed due to incorrect args provided.
This PR fixes `just run-tests` command both for EKS and k8s workflows.
