### PR TITLE
[CNVM] Update cloudformation ec2 instance type

### DIFF
--- a/deploy/cloudformation/elastic-agent-ec2.yml
+++ b/deploy/cloudformation/elastic-agent-ec2.yml
@@ -8,14 +8,15 @@ Parameters:
     Default: '/aws/service/canonical/ubuntu/server/jammy/stable/current/arm64/hvm/ebs-gp2/ami-id'
   InstanceType:
     Type: String
-    Default: a1.2xlarge
+    Default: c6g.xlarge
     AllowedValues:
-    - a1.2xlarge
-    - a1.4xlarge
+    - c6g.xlarge
+    - c6g.2xlarge
+    - c6g.4xlarge
     Description: The type of EC2 instance to create
   EnrollmentToken:
     Type: String
-    Description: The enrollment token of elasitc-agent
+    Description: The enrollment token of elastic-agent
   FleetUrl:
     Type: String
     Description: The fleet URL of elastic-agent


### PR DESCRIPTION
### Summary of your changes
Update the ec2 compute instance type to be with the newest Graviton processor.
Improve CPU utilization and avoid CPU throttling.


### Related Issues
- Fixes: https://github.com/elastic/security-team/issues/6338

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
