### PR TITLE
Set default value to CloudFormation param ElasticArtifactServer

### DIFF
--- a/deploy/cloudformation/elastic-agent-ec2.yml
+++ b/deploy/cloudformation/elastic-agent-ec2.yml
@@ -23,6 +23,7 @@ Parameters:
   ElasticArtifactServer:
     Type: String
     Description: The URL of the artifact server
+    Default: https://artifacts.elastic.co/downloads/beats/elastic-agent
   ElasticAgentVersion:
     Type: String
     Description: The version of elastic-agent to install


### PR DESCRIPTION
### Summary of your changes
Sets a default value to the CloudFormation parameter `ElasticArtifactServer`.
The default value is the URL of released artifacts, for dev process it should be replaced with snapshot or build candidates.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
- Related: https://github.com/elastic/cloudbeat/issues/937

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
