### PR TITLE
CloudFormation: Add CSPM integration option

### DIFF
--- a/deploy/cloudformation/README.md
+++ b/deploy/cloudformation/README.md
@@ -19,7 +19,7 @@ FLEET_URL="<Elastic Agent Fleet URL>"
 ENROLLMENT_TOKEN="<Elastic Agent Enrollment Token>"
 ELASTIC_ARTIFACT_SERVER="https://artifacts.elastic.co/downloads/beats/elastic-agent" # Replace artifact URL with a pre-release version (BC or snapshot)
 ELASTIC_AGENT_VERSION="<Elastic Agent Version>" # e.g: 8.8.0 | 8.8.0-SNAPSHOT
-INTEGRATION=CloudSecurityPostureManagement # Defaults to VulnerabilityManagement if not specified
+# INTEGRATION=CloudSecurityPostureManagement # Defaults to VulnerabilityManagement if not specified
 
 DEV.ALLOW_SSH=false # Set to true to allow SSH connections to the deployed instance
 DEV.KEY_NAME="" # When SSH is allowed, you must provide the key name that will be used to ssh into the EC2

--- a/deploy/cloudformation/README.md
+++ b/deploy/cloudformation/README.md
@@ -10,7 +10,7 @@ The EC2 instance has elastic-agent preinstalled in it using the fleet URL and en
 2. You have AWS CLI installed on your laptop and configured to work with our dev account `elastic-security-cloud-security-dev` (in particular, `~/.aws/config` and `~/.aws/credentials` should be set, check https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html for more information)
 
 *Steps:*
-1. Install Vulnerability Management integration on a new agent policy, you might have to check the "Display beta integrations" checkbox.
+1. Install the Vulnerability Management integration on a new agent policy, you might have to check the "Display beta integrations" checkbox.
 2. After you installed the integration you can install a new elastic-agent, you should keep the fleet URL and the enrollment token.
 3. On cloudbeat repo, create a `deploy/cloudformation/.env` file of the form:
 ```
@@ -19,6 +19,7 @@ FLEET_URL="<Elastic Agent Fleet URL>"
 ENROLLMENT_TOKEN="<Elastic Agent Enrollment Token>"
 ELASTIC_ARTIFACT_SERVER="https://artifacts.elastic.co/downloads/beats/elastic-agent" # Replace artifact URL with a pre-release version (BC or snapshot)
 ELASTIC_AGENT_VERSION="<Elastic Agent Version>" # e.g: 8.8.0 | 8.8.0-SNAPSHOT
+INTEGRATION=CloudSecurityPostureManagement # Defaults to VulnerabilityManagement if not specified
 
 DEV.ALLOW_SSH=false # Set to true to allow SSH connections to the deployed instance
 DEV.KEY_NAME="" # When SSH is allowed, you must provide the key name that will be used to ssh into the EC2

--- a/deploy/cloudformation/config.go
+++ b/deploy/cloudformation/config.go
@@ -32,6 +32,7 @@ type config struct {
 	EnrollmentToken       string     `mapstructure:"ENROLLMENT_TOKEN"`
 	ElasticArtifactServer string     `mapstructure:"ELASTIC_ARTIFACT_SERVER"`
 	ElasticAgentVersion   string     `mapstructure:"ELASTIC_AGENT_VERSION"`
+	IntegrationType       *string    `mapstructure:"INTEGRATION"`
 	Dev                   *devConfig `mapstructure:"DEV"`
 }
 

--- a/deploy/cloudformation/elastic-agent-ec2.yml
+++ b/deploy/cloudformation/elastic-agent-ec2.yml
@@ -26,6 +26,46 @@ Parameters:
   ElasticAgentVersion:
     Type: String
     Description: The version of elastic-agent to install
+  Integration:
+    Type: String
+    Default: VulnerabilityManagement
+    AllowedValues:
+      - VulnerabilityManagement
+      - CloudSecurityPostureManagement
+Mappings:
+  IntegrationMap:
+    VulnerabilityManagement:
+      EC2TaskTag: "Vulnerability Management Scanner"
+      Policies:
+        - PolicyName: vuln-mgmt-permissions
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeInstances
+                  - ec2:DescribeImages
+                  - ec2:DescribeTags
+                  - ec2:DescribeSnapshots
+                  - ec2:CreateSnapshots
+                  - ec2:CreateTags
+                  - ec2:DeleteSnapshot
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ebs:ListSnapshotBlocks
+                  - ebs:ListChangedBlocks
+                  - ebs:GetSnapshotBlock
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - iam:ListAccountAliases
+                Resource: "*"
+      ManagedPolicyArns: []
+    CloudSecurityPostureManagement:
+      EC2TaskTag: "Cloud Security Posture Management Scanner"
+      Policies: []
+      ManagedPolicyArns: ["arn:aws:iam::aws:policy/SecurityAudit"]
 Resources:
   # Security Group for EC2 instance
   ElasticAgentSecurityGroup:
@@ -57,30 +97,15 @@ Resources:
               - sts:AssumeRole
       Path: /
       Policies:
-        - PolicyName: vuln-mgmt-permissions
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - ec2:DescribeInstances
-                  - ec2:DescribeImages
-                  - ec2:DescribeTags
-                  - ec2:DescribeSnapshots
-                  - ec2:CreateSnapshots
-                  - ec2:CreateTags
-                  - ec2:DeleteSnapshot
-                Resource: "*"
-              - Effect: Allow
-                Action:
-                  - ebs:ListSnapshotBlocks
-                  - ebs:ListChangedBlocks
-                  - ebs:GetSnapshotBlock
-                Resource: "*"
-              - Effect: Allow
-                Action:
-                  - iam:ListAccountAliases
-                Resource: "*"
+        Fn::FindInMap:
+          - IntegrationMap
+          - !Ref Integration
+          - Policies
+      ManagedPolicyArns:
+        Fn::FindInMap:
+          - IntegrationMap
+          - !Ref Integration
+          - ManagedPolicyArns
   # Instance profile to attach to EC2 instance
   ElasticAgentInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -113,7 +138,11 @@ Resources:
                         - '/'
                         - Ref: 'AWS::StackId'
         - Key: Task
-          Value: Vulnerability Management Scanner
+          Value:
+            Fn::FindInMap:
+              - IntegrationMap
+              - !Ref Integration
+              - EC2TaskTag
       ImageId: !Ref LatestAmiId
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref ElasticAgentInstanceProfile

--- a/deploy/cloudformation/gomain.go
+++ b/deploy/cloudformation/gomain.go
@@ -58,6 +58,10 @@ func createFromConfig(cfg *config) error {
 	params["ElasticAgentVersion"] = cfg.ElasticAgentVersion
 	params["ElasticArtifactServer"] = cfg.ElasticArtifactServer
 
+	if cfg.IntegrationType != nil {
+		params["Integration"] = *cfg.IntegrationType
+	}
+
 	templatePath := prodTemplatePath
 	if cfg.Dev != nil && cfg.Dev.AllowSSH {
 		params["KeyName"] = cfg.Dev.KeyName


### PR DESCRIPTION
### Summary of your changes

Add a CSPM integration option in the CloudFormation template, using a map to change the IAM role permissions depending on which of the two options is used

### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/596

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary README/documentation (if appropriate)
