### PR TITLE
S3 provider handles missing public access block config better

### DIFF
--- a/version/policy.go
+++ b/version/policy.go
@@ -17,7 +17,7 @@
 
 package version
 
-const policyVersion = "v1.4.2"
+const policyVersion = "v1.4.3"
 
 // PolicyVersion returns cloudbeat version info used for the build.
 func PolicyVersion() Version {


### PR DESCRIPTION
### Summary of your changes
S3 provider now handles missing public access block configurations properly (logs a debug message instead of an error). Policy version has been updated to one that can handle null public access block configurations properly.

### Screenshot/Data

<img width="1840" alt="Screenshot 2023-05-15 at 14 14 05" src="https://github.com/elastic/cloudbeat/assets/94899776/6c1c372f-2326-4323-8f80-aa85e874eb87">


### Related Issues
Related: https://github.com/elastic/csp-security-policies/pull/234
Related: https://github.com/elastic/csp-security-policies/issues/233

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
