### PR TITLE
 CloudFormation: Upload to path without "vuln-mgmt"

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -31,4 +31,6 @@ jobs:
           VERSION=$(grep defaultBeatVersion version/version.go | cut -f2 -d "\"")
           FILENAME=$(date +"cloudformation-$VERSION-%Y-%m-%d-%H-%M-%S.yml")
           echo "Uploading $FILENAME to S3"
+          # TODO: Remove upload to vuln-mgmt/ after integration starts using new link
           aws s3 cp deploy/cloudformation/elastic-agent-ec2.yml s3://elastic-cspm-cft/vuln-mgmt/$FILENAME
+          aws s3 cp deploy/cloudformation/elastic-agent-ec2.yml s3://elastic-cspm-cft/$FILENAME


### PR DESCRIPTION
### Summary of your changes

Line that needs to be updated: https://github.com/elastic/integrations/blob/85ee85e17a97be4a222b6071ce9e29207ae30e3b/packages/cloud_security_posture/manifest.yml#L138

### Related Issues

- Related: #596
- Related: #975 

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary README/documentation (if appropriate)
