### PR TITLE
k8s CIS 1.1.19: Scan pki/ folder recursively

### DIFF
--- a/_meta/config/cloudbeat.common.yml.tmpl
+++ b/_meta/config/cloudbeat.common.yml.tmpl
@@ -32,7 +32,7 @@ cloudbeat:
         "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
         "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
         "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-        "/hostfs/etc/kubernetes/pki/*",
+        "/hostfs/etc/kubernetes/pki/**",
         "/hostfs/var/lib/kubelet/config.yaml",
         "/hostfs/var/lib/etcd",
         "/hostfs/etc/kubernetes/pki"

--- a/cloudbeat.reference.yml
+++ b/cloudbeat.reference.yml
@@ -34,7 +34,7 @@ cloudbeat:
         "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
         "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
         "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-        "/hostfs/etc/kubernetes/pki/*",
+        "/hostfs/etc/kubernetes/pki/**",
         "/hostfs/var/lib/kubelet/config.yaml",
         "/hostfs/var/lib/etcd",
         "/hostfs/etc/kubernetes/pki"

--- a/cloudbeat.yml
+++ b/cloudbeat.yml
@@ -37,7 +37,7 @@ cloudbeat:
         "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
         "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
         "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-        "/hostfs/etc/kubernetes/pki/*",
+        "/hostfs/etc/kubernetes/pki/**",
         "/hostfs/var/lib/kubelet/config.yaml",
         "/hostfs/var/lib/etcd",
         "/hostfs/etc/kubernetes/pki"

--- a/deploy/kustomize/overlays/cloudbeat-vanilla-nocert/cloudbeat.yml
+++ b/deploy/kustomize/overlays/cloudbeat-vanilla-nocert/cloudbeat.yml
@@ -30,7 +30,7 @@ cloudbeat:
           "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
           "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
           "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-          "/hostfs/etc/kubernetes/pki/*",
+          "/hostfs/etc/kubernetes/pki/**",
           "/hostfs/var/lib/kubelet/config.yaml",
           "/hostfs/var/lib/etcd",
           "/hostfs/etc/kubernetes/pki",

--- a/tests/commonlib/io_utils.py
+++ b/tests/commonlib/io_utils.py
@@ -102,7 +102,7 @@ class FsClient:
     """
 
     @staticmethod
-    def exec_command(
+    def exec_command(  # noqa: C901
         container_name: str,
         command: str,
         param_value: str,
@@ -122,6 +122,10 @@ class FsClient:
                 return
             with open(param_value, "a+", encoding="utf-8"):
                 pass
+            return
+
+        if command == "mkdir":
+            os.makedirs(param_value, exist_ok=True)
             return
 
         if command == "cat":

--- a/tests/deploy/cloudbeat-pytest.yml
+++ b/tests/deploy/cloudbeat-pytest.yml
@@ -171,7 +171,7 @@ data:
             "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
             "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
             "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-            "/hostfs/etc/kubernetes/pki/*",
+            "/hostfs/etc/kubernetes/pki/**",
             "/hostfs/var/lib/kubelet/config.yaml",
             "/hostfs/var/lib/etcd",
             "/hostfs/etc/kubernetes/pki"

--- a/tests/deploy/k8s-cloudbeat-tests/templates/cloudbeat-ds.yml
+++ b/tests/deploy/k8s-cloudbeat-tests/templates/cloudbeat-ds.yml
@@ -167,7 +167,7 @@ data:
             "/hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml",
             "/hostfs/etc/kubernetes/manifests/kube-scheduler.yaml",
             "/hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf",
-            "/hostfs/etc/kubernetes/pki/*",
+            "/hostfs/etc/kubernetes/pki/**",
             "/hostfs/var/lib/kubelet/config.yaml",
             "/hostfs/var/lib/etcd",
             "/hostfs/etc/kubernetes/pki"

--- a/tests/deploy/sa-agent-pytest.yml
+++ b/tests/deploy/sa-agent-pytest.yml
@@ -250,7 +250,7 @@ data:
                     /hostfs/etc/kubernetes/manifests/kube-controller-manager.yaml
                   - /hostfs/etc/kubernetes/manifests/kube-scheduler.yaml
                   - /hostfs/etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-                  - /hostfs/etc/kubernetes/pki/*
+                  - /hostfs/etc/kubernetes/pki/**
                   - /hostfs/var/lib/kubelet/config.yaml
                   - /hostfs/var/lib/etcd
                   - /hostfs/etc/kubernetes/pki

--- a/tests/product/tests/conftest.py
+++ b/tests/product/tests/conftest.py
@@ -2,6 +2,7 @@
 This module provides fixtures and configurations for
 product tests.
 """
+import os.path
 from pathlib import Path
 import time
 import json
@@ -59,6 +60,7 @@ def config_node_pre_test(cloudbeat_start_stop):
     temp_file_list = [
         "/var/lib/etcd/some_file.txt",
         "/etc/kubernetes/pki/some_file.txt",
+        "/etc/kubernetes/pki/some_dir/some_file.txt",
     ]
 
     config_files = {
@@ -84,6 +86,12 @@ limits:
         if node.metadata.name != cloudbeat_agent.node_name:
             continue
         for temp_file in temp_file_list:
+            api_client.exec_command(
+                container_name=node.metadata.name,
+                command="mkdir",
+                param_value=os.path.dirname(temp_file),
+                resource="",
+            )
             api_client.exec_command(
                 container_name=node.metadata.name,
                 command="touch",

--- a/tests/product/tests/conftest.py
+++ b/tests/product/tests/conftest.py
@@ -2,7 +2,6 @@
 This module provides fixtures and configurations for
 product tests.
 """
-import os.path
 from pathlib import Path
 import time
 import json
@@ -89,7 +88,7 @@ limits:
             api_client.exec_command(
                 container_name=node.metadata.name,
                 command="mkdir",
-                param_value=os.path.dirname(temp_file),
+                param_value=str(Path(temp_file).parent),
                 resource="",
             )
             api_client.exec_command(

--- a/tests/product/tests/data/file_system/file_system_test_cases.py
+++ b/tests/product/tests/data/file_system/file_system_test_cases.py
@@ -260,6 +260,12 @@ cis_1_1_19 = [
         "/etc/kubernetes/pki/some_file.txt",
         "failed",
     ),
+    # Directory under pki/
+    ("CIS 1.1.19", "chown", "root:root", "/etc/kubernetes/pki/some_dir", "passed"),
+    ("CIS 1.1.19", "chown", "daemon:daemon", "/etc/kubernetes/pki/some_dir", "failed"),
+    # Check recursion
+    ("CIS 1.1.19", "chown", "root:root", "/etc/kubernetes/pki/some_dir/some_file.txt", "passed"),
+    ("CIS 1.1.19", "chown", "daemon:daemon", "/etc/kubernetes/pki/some_dir/some_file.txt", "failed"),
 ]
 
 cis_1_1_20 = [


### PR DESCRIPTION
### Summary of your changes

This seems to be just a configuration error. Both the rego rules and the `Glob` go code seem to work fine.
I've updated all config files and added new functional tests.

### Screenshot/Data

[finding.json](https://github.com/elastic/cloudbeat/files/11498836/finding.json.txt)

Made by running `docker exec -it kind-multi-worker bash` and then `cd /etc/kubernetes/pki` and creating non-root-owned files under `somedir/` 

### Checklist
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary README/documentation (if appropriate)
