### PR TITLE
Test EC2 types CFT allow to encrypt instances

### DIFF
--- a/deploy/cloudformation/ec2-types.yml
+++ b/deploy/cloudformation/ec2-types.yml
@@ -38,6 +38,10 @@ Resources:
             VolumeType: gp2
             DeleteOnTermination: "true"
             Encrypted: !Ref Encrypted
+      UserData:
+        "Fn::Base64": !Sub |
+          #!/bin/bash
+          mkfs -t ext4 /dev/sda1
   armRHLinuxIO1xfs:
     Type: "AWS::EC2::Instance"
     Properties:
@@ -63,6 +67,10 @@ Resources:
             Iops: "100"
             DeleteOnTermination: "true"
             Encrypted: !Ref Encrypted
+      UserData:
+        "Fn::Base64": !Sub |
+          #!/bin/bash
+          mkfs -t xfs /dev/sda1
   x86SuseLinuxStandardext4:
     Type: "AWS::EC2::Instance"
     Properties:
@@ -87,6 +95,10 @@ Resources:
             VolumeType: standard
             DeleteOnTermination: "true"
             Encrypted: !Ref Encrypted
+      UserData:
+        "Fn::Base64": !Sub |
+          #!/bin/bash
+          mkfs -t ext4 /dev/sda1
   x86UbuntuLinuxGP3xfs:
     Type: "AWS::EC2::Instance"
     Properties:
@@ -111,6 +123,10 @@ Resources:
             VolumeType: gp3
             DeleteOnTermination: "true"
             Encrypted: !Ref Encrypted
+      UserData:
+        "Fn::Base64": !Sub |
+          #!/bin/bash
+          mkfs -t xfs /dev/sda1
   x86DebianLinuxIO2ext4:
     Type: "AWS::EC2::Instance"
     Properties:
@@ -136,6 +152,10 @@ Resources:
             Iops: "100"
             DeleteOnTermination: "true"
             Encrypted: !Ref Encrypted
+      UserData:
+        "Fn::Base64": !Sub |
+          #!/bin/bash
+          mkfs -t ext4 /dev/sda1
   SecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:

--- a/deploy/cloudformation/ec2-types.yml
+++ b/deploy/cloudformation/ec2-types.yml
@@ -41,7 +41,7 @@ Resources:
       UserData:
         "Fn::Base64": !Sub |
           #!/bin/bash
-          mkfs -t ext4 /dev/sda1
+          mkfs -t ext4 /dev/xvda
   armRHLinuxIO1xfs:
     Type: "AWS::EC2::Instance"
     Properties:
@@ -155,7 +155,7 @@ Resources:
       UserData:
         "Fn::Base64": !Sub |
           #!/bin/bash
-          mkfs -t ext4 /dev/sda1
+          mkfs -t ext4 /dev/xvda
   SecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:

--- a/deploy/cloudformation/ec2-types.yml
+++ b/deploy/cloudformation/ec2-types.yml
@@ -3,13 +3,16 @@
 # Currently this process is being done manually, but eventually we would like to automate it.
 # This template is separate to the elastic-agent-ec2.yml template and is not used in the production deployment process.
 AWSTemplateFormatVersion: 2010-09-09
-# Parameters:
-# ARMImages:
-#   Type: CommaDelimitedList
-#   Default: >-
-#     ami-0a0ae3c8519bff7f0, ami-062e673cc4273dad8, ami-0b2dd5cb6105dcd18,
-#     ami-0e6902f007857ad9c, ami-0083086bc808b1d71
-# Transform: Count
+Parameters:
+  Encrypted:
+    Type: String
+    Description: Whether to encrypt the EC2 instance root volume
+    Default: "false"
+    AllowedValues:
+      - "true"
+      - "false"
+Conditions:
+  Encrypted: !Equals ["true", !Ref Encrypted]
 Resources:
   armAWSLinuxGP2ext4:
     Type: "AWS::EC2::Instance"
@@ -28,23 +31,13 @@ Resources:
       InstanceType: t4g.nano
       ImageId:
         ami-0a0ae3c8519bff7f0
-        # Fn::GetAtt: [ARMImages, %d]
-      # !Select
-      #         - !Ref %d
-      #         - !Ref ARMImages
       BlockDeviceMappings:
-        - DeviceName: /dev/sda1
+        - DeviceName: /dev/xvda
           Ebs:
             VolumeSize: "8"
             VolumeType: gp2
             DeleteOnTermination: "true"
-            Encrypted: "false"
-      UserData:
-        "Fn::Base64": !Sub |
-          #!/bin/bash
-          mkfs -t ext4 /dev/sda1
-    # Count: !Length
-    #   - !Ref ARMImages
+            Encrypted: !Ref Encrypted
   armRHLinuxIO1xfs:
     Type: "AWS::EC2::Instance"
     Properties:
@@ -62,10 +55,6 @@ Resources:
       InstanceType: t4g.small
       ImageId:
         ami-062e673cc4273dad8
-        # Fn::GetAtt: [ARMImages, %d]
-      # !Select
-      #         - !Ref %d
-      #         - !Ref ARMImages
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
@@ -73,13 +62,7 @@ Resources:
             VolumeType: io1
             Iops: "100"
             DeleteOnTermination: "true"
-            Encrypted: "false"
-      UserData:
-        "Fn::Base64": !Sub |
-          #!/bin/bash
-          mkfs -t xfs /dev/sda1
-    # Count: !Length
-    #   - !Ref ARMImages
+            Encrypted: !Ref Encrypted
   x86SuseLinuxStandardext4:
     Type: "AWS::EC2::Instance"
     Properties:
@@ -97,23 +80,13 @@ Resources:
       InstanceType: t2.nano
       ImageId:
         ami-09ee771fad415a6d7
-        # Fn::GetAtt: [ARMImages, %d]
-      # !Select
-      #         - !Ref %d
-      #         - !Ref ARMImages
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: "10"
             VolumeType: standard
             DeleteOnTermination: "true"
-            Encrypted: "false"
-      UserData:
-        "Fn::Base64": !Sub |
-          #!/bin/bash
-          mkfs -t ext4 /dev/sda1
-    # Count: !Length
-    #   - !Ref ARMImages
+            Encrypted: !Ref Encrypted
   x86UbuntuLinuxGP3xfs:
     Type: "AWS::EC2::Instance"
     Properties:
@@ -131,23 +104,13 @@ Resources:
       InstanceType: t2.nano
       ImageId:
         ami-00aa9d3df94c6c354
-        # Fn::GetAtt: [ARMImages, %d]
-      # !Select
-      #         - !Ref %d
-      #         - !Ref ARMImages
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             VolumeSize: "10"
             VolumeType: gp3
             DeleteOnTermination: "true"
-            Encrypted: "false"
-      UserData:
-        "Fn::Base64": !Sub |
-          #!/bin/bash
-          mkfs -t xfs /dev/sda1
-    # Count: !Length
-    #   - !Ref ARMImages
+            Encrypted: !Ref Encrypted
   x86DebianLinuxIO2ext4:
     Type: "AWS::EC2::Instance"
     Properties:
@@ -165,24 +128,14 @@ Resources:
       InstanceType: t2.nano
       ImageId:
         ami-089f338f3a2e69431
-        # Fn::GetAtt: [ARMImages, %d]
-      # !Select
-      #         - !Ref %d
-      #         - !Ref ARMImages
       BlockDeviceMappings:
-        - DeviceName: /dev/sda1
+        - DeviceName: /dev/xvda
           Ebs:
             VolumeSize: "10"
             VolumeType: io2
             Iops: "100"
             DeleteOnTermination: "true"
-            Encrypted: "false"
-      UserData:
-        "Fn::Base64": !Sub |
-          #!/bin/bash
-          mkfs -t ext4 /dev/sda1
-    # Count: !Length
-    #   - !Ref ARMImages
+            Encrypted: !Ref Encrypted
   SecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:


### PR DESCRIPTION
### Summary of your changes
- In our test EC2 template, I've added the option to encrypt the root volume.
- Some root volumes where misconfigured (mixed between `/dev/sda1` and `/dev/xvda`).

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
