### PR TITLE
Test EC2 types use defaults FS

### DIFF
--- a/deploy/cloudformation/ec2-types.yml
+++ b/deploy/cloudformation/ec2-types.yml
@@ -14,7 +14,7 @@ Parameters:
 Conditions:
   Encrypted: !Equals ["true", !Ref Encrypted]
 Resources:
-  armAWSLinuxGP2ext4:
+  arm64AmazonLinux2:
     Type: "AWS::EC2::Instance"
     Properties:
       Tags:
@@ -22,27 +22,16 @@ Resources:
           Value:
             "Fn::Join":
               - "-"
-              - - vuln-mgmt-types-armAWSLinuxGP2ext4
+              - - vuln-mgmt-types-arm64AmazonLinux2
                 - "Fn::Select":
                     - 2
                     - "Fn::Split":
                         - /
                         - Ref: "AWS::StackId"
       InstanceType: t4g.nano
-      ImageId:
-        ami-0a0ae3c8519bff7f0
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: "8"
-            VolumeType: gp2
-            DeleteOnTermination: "true"
-            Encrypted: !Ref Encrypted
-      UserData:
-        "Fn::Base64": !Sub |
-          #!/bin/bash
-          mkfs -t ext4 /dev/xvda
-  armRHLinuxIO1xfs:
+      ImageId: ami-0a0ae3c8519bff7f0
+
+  arm64RHLinux9:
     Type: "AWS::EC2::Instance"
     Properties:
       Tags:
@@ -50,28 +39,16 @@ Resources:
           Value:
             "Fn::Join":
               - "-"
-              - - vuln-mgmt-types-armRHLinuxIO1xfs
+              - - vuln-mgmt-types-arm64RHLinux9
                 - "Fn::Select":
                     - 2
                     - "Fn::Split":
                         - /
                         - Ref: "AWS::StackId"
       InstanceType: t4g.small
-      ImageId:
-        ami-062e673cc4273dad8
-      BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-            VolumeSize: "10"
-            VolumeType: io1
-            Iops: "100"
-            DeleteOnTermination: "true"
-            Encrypted: !Ref Encrypted
-      UserData:
-        "Fn::Base64": !Sub |
-          #!/bin/bash
-          mkfs -t xfs /dev/sda1
-  x86SuseLinuxStandardext4:
+      ImageId: ami-062e673cc4273dad8
+
+  x86SuseLinux15:
     Type: "AWS::EC2::Instance"
     Properties:
       Tags:
@@ -79,27 +56,16 @@ Resources:
           Value:
             "Fn::Join":
               - "-"
-              - - vuln-mgmt-types-x86SuseLinuxStandardext4
+              - - vuln-mgmt-types-x86SuseLinux15
                 - "Fn::Select":
                     - 2
                     - "Fn::Split":
                         - /
                         - Ref: "AWS::StackId"
       InstanceType: t2.nano
-      ImageId:
-        ami-09ee771fad415a6d7
-      BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-            VolumeSize: "10"
-            VolumeType: standard
-            DeleteOnTermination: "true"
-            Encrypted: !Ref Encrypted
-      UserData:
-        "Fn::Base64": !Sub |
-          #!/bin/bash
-          mkfs -t ext4 /dev/sda1
-  x86UbuntuLinuxGP3xfs:
+      ImageId: ami-09ee771fad415a6d7
+
+  x86UbuntuLinux2204:
     Type: "AWS::EC2::Instance"
     Properties:
       Tags:
@@ -107,27 +73,16 @@ Resources:
           Value:
             "Fn::Join":
               - "-"
-              - - vuln-mgmt-types-x86UbuntuLinuxGP3xfs
+              - - vuln-mgmt-types-x86UbuntuLinux2204
                 - "Fn::Select":
                     - 2
                     - "Fn::Split":
                         - /
                         - Ref: "AWS::StackId"
       InstanceType: t2.nano
-      ImageId:
-        ami-00aa9d3df94c6c354
-      BlockDeviceMappings:
-        - DeviceName: /dev/sda1
-          Ebs:
-            VolumeSize: "10"
-            VolumeType: gp3
-            DeleteOnTermination: "true"
-            Encrypted: !Ref Encrypted
-      UserData:
-        "Fn::Base64": !Sub |
-          #!/bin/bash
-          mkfs -t xfs /dev/sda1
-  x86DebianLinuxIO2ext4:
+      ImageId: ami-00aa9d3df94c6c354
+
+  x86DebianLinux11:
     Type: "AWS::EC2::Instance"
     Properties:
       Tags:
@@ -135,27 +90,32 @@ Resources:
           Value:
             "Fn::Join":
               - "-"
-              - - vuln-mgmt-types-x86DebianLinuxIO2ext4
+              - - vuln-mgmt-types-x86DebianLinux11
                 - "Fn::Select":
                     - 2
                     - "Fn::Split":
                         - /
                         - Ref: "AWS::StackId"
       InstanceType: t2.nano
-      ImageId:
-        ami-089f338f3a2e69431
-      BlockDeviceMappings:
-        - DeviceName: /dev/xvda
-          Ebs:
-            VolumeSize: "10"
-            VolumeType: io2
-            Iops: "100"
-            DeleteOnTermination: "true"
-            Encrypted: !Ref Encrypted
-      UserData:
-        "Fn::Base64": !Sub |
-          #!/bin/bash
-          mkfs -t ext4 /dev/xvda
+      ImageId: ami-089f338f3a2e69431
+
+  x86AmazonLinux2023:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      Tags:
+        - Key: Name
+          Value:
+            "Fn::Join":
+              - "-"
+              - - vuln-mgmt-types-x86AmazonLinux2023
+                - "Fn::Select":
+                    - 2
+                    - "Fn::Split":
+                        - /
+                        - Ref: "AWS::StackId"
+      InstanceType: t2.nano
+      ImageId: ami-04b1c88a6bbd48f8e
+
   SecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:


### PR DESCRIPTION
### Summary of your changes
`ec2-types.yml` contains test purposes EC2 instances for running vulnerability management.
Since we want to test CNVM on an environment as close as possible to our customers, we should run it with the default file system provided by the AMI.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
