### PR TITLE
backport: Add 8.9 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -222,6 +222,19 @@ pull_request_rules:
   - name: backport patches to 8.9 branch
     conditions:
       - merged
+      - label=backport-v8.10.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.9"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 8.9 branch
+    conditions:
+      - merged
       - label=backport-v8.9.0
     actions:
       backport:


### PR DESCRIPTION
Merge as soon as 8.9 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821