### PR TITLE
update timeout and add stop run after 4 failures

### DIFF
--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -222,7 +222,7 @@ jobs:
         run: |
           cd ../../tests
           poetry install
-          poetry run pytest -m "sanity" --alluredir=./allure/results/ --clean-alluredir
+          poetry run pytest -m "sanity" --alluredir=./allure/results/ --clean-alluredir --maxfail=4
 
       - name: Cleanup Environment
         if: github.event.inputs.cleanup-env == 'true'

--- a/tests/integration/tests/test_sanity_checks.py
+++ b/tests/integration/tests/test_sanity_checks.py
@@ -9,17 +9,17 @@ verifying that there are findings of 'resource.type' for each feature.
 import pytest
 from commonlib.utils import get_findings
 
-CONFIG_TIMEOUT = 120
+CONFIG_TIMEOUT = 240
 
 tests_data = {
     "cis_aws": [
         "cloud-compute",
-        "cloud-storage",
         "identity-management",
         "monitoring",
         "cloud-audit",
         "cloud-database",
         "cloud-config",
+        "cloud-storage",
     ],
     "cis_k8s": ["file", "process", "k8s_object"],
     "cis_eks": ["process", "k8s_object"],  # Optimize search findings by excluding 'file'.


### PR DESCRIPTION
### Summary of your changes

This PR increases the test case timeout and introduces the functionality to stop the test run after encountering 4 failures.

Changes made in this PR:

- Increased the test case timeout to ensure sufficient time for execution.
- Added stop for the test run after 4 failures to minimize unnecessary test execution.

