### PR TITLE
Skip AWS post-merge tests

### DIFF
--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -189,9 +189,10 @@ jobs:
           - test-target: pre_merge
             range: ""
             values_file: tests/deploy/values/ci.yml
-          - test-target: aws
-            range: ""
-            values_file: tests/deploy/values/ci-aws-services.yml
+          # Skipping until https://github.com/elastic/security-team/issues/6757 is resolved
+          # - test-target: aws
+          #   range: ""
+          #   values_file: tests/deploy/values/ci-aws-services.yml
           - test-target: file_system_rules
             range: "0..5"
             values_file: tests/deploy/values/ci.yml


### PR DESCRIPTION
### Summary of your changes
Skipping AWS post-merge tests until resource migration is done @gurevichdmitry 

### Related Issues
- Related: https://github.com/elastic/security-team/issues/6757
- Related: https://github.com/elastic/security-team/issues/6760

