### PR TITLE
[CloudFormation] Increase scanner volume size

### DIFF
--- a/deploy/cloudformation/elastic-agent-ec2.yml
+++ b/deploy/cloudformation/elastic-agent-ec2.yml
@@ -156,6 +156,10 @@ Resources:
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
           sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken}
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeSize: 32
 Outputs:
   Ec2InstanceId:
     Value: !Ref ElasticAgentEc2Instance


### PR DESCRIPTION
### Summary of your changes
Add a `BlockDeviceMappings` section to increase the root device volume size.
In AMI we are using the root device is `/dev/sda1`.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/1098

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
