### PR TITLE
[Sanity] Assert that all agents are enrolled

### DIFF
--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -230,6 +230,12 @@ jobs:
           aws s3 cp "${{ env.FLEET_API_DIR}}/kspm_eks.yaml" "${{ env.S3_BUCKET }}/kspm_eks.yaml"
           aws s3 cp "${{ env.FLEET_API_DIR}}/cspm-linux.sh" "${{ env.S3_BUCKET }}/cspm-linux.sh"
 
+      - name: Wait for agents to enroll
+        if: success()
+        run: |
+          cd fleet_api
+          poetry run python src/agents_enrolled.py
+
       - name: Run Sanity checks
         if: success()
         run: |

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -231,7 +231,6 @@ jobs:
           aws s3 cp "${{ env.FLEET_API_DIR}}/cspm-linux.sh" "${{ env.S3_BUCKET }}/cspm-linux.sh"
 
       - name: Wait for agents to enroll
-        if: success()
         run: |
           cd fleet_api
           poetry run python src/agents_enrolled.py

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -78,8 +78,9 @@ jobs:
           poetry --version
 
       - name: Install Fleet API dependencies
+        id: fleet-api-deps
+        working-directory: ${{ env.WORKING_DIR }}/fleet_api
         run: |
-          cd fleet_api
           poetry install
 
       - name: Configure AWS credentials
@@ -167,8 +168,8 @@ jobs:
 
       - name: Install CNVM integration
         id: cnvm
+        working-directory: ${{ env.WORKING_DIR }}/fleet_api
         run: |
-          cd fleet_api
           poetry run python src/install_cnvm_integration.py
 
       - name: Deploy CNVM agent
@@ -178,8 +179,8 @@ jobs:
 
       - name: Install KSPM EKS integration
         id: kspm-eks
+        working-directory: ${{ env.WORKING_DIR }}/fleet_api
         run: |
-          cd fleet_api
           poetry run python src/install_kspm_eks_integration.py
 
       - name: Deploy KSPM EKS agent
@@ -195,8 +196,8 @@ jobs:
 
       - name: Install KSPM Unmanaged integration
         id: kspm-unmanaged
+        working-directory: ${{ env.WORKING_DIR }}/fleet_api
         run: |
-          cd fleet_api
           poetry run python src/install_kspm_unmanaged_integration.py
 
       - name: Deploy KSPM Unmanaged agent
@@ -209,8 +210,8 @@ jobs:
 
       - name: Install CSPM integration
         id: cspm
+        working-directory: ${{ env.WORKING_DIR }}/fleet_api
         run: |
-          cd fleet_api
           poetry run python src/install_cspm_integration.py
 
       - name: Deploy CSPM agent
@@ -231,14 +232,15 @@ jobs:
           aws s3 cp "${{ env.FLEET_API_DIR}}/cspm-linux.sh" "${{ env.S3_BUCKET }}/cspm-linux.sh"
 
       - name: Wait for agents to enroll
+        id: wait-for-agents
+        working-directory: ${{ env.WORKING_DIR }}/fleet_api
         run: |
-          cd fleet_api
           poetry run python src/agents_enrolled.py
 
       - name: Run Sanity checks
         if: success()
+        working-directory: ./tests
         run: |
-          cd ../../tests
           poetry install
           poetry run pytest -m "sanity" --alluredir=./allure/results/ --clean-alluredir --maxfail=4
 

--- a/deploy/test-environments/fleet_api/src/agents_enrolled.py
+++ b/deploy/test-environments/fleet_api/src/agents_enrolled.py
@@ -17,6 +17,7 @@ def get_expected_agents_mapping() -> dict:
     Returns:
         map: The name of the policy and the number of agents expected to be enrolled
     """
+
     logger.info("Loading agent policies state file")
     policies_map = {}
     for policy in state_manager.policies:
@@ -25,11 +26,11 @@ def get_expected_agents_mapping() -> dict:
 
 
 def get_actual_agents_mapping() -> dict:
-
     """
     Returns:
         map: The name of the policy and the number of agents enrolled
     """
+
     agents = get_agents(cfg=cnfg.elk_config)
     policies_map = {}
     for agent in agents:

--- a/deploy/test-environments/fleet_api/src/agents_enrolled.py
+++ b/deploy/test-environments/fleet_api/src/agents_enrolled.py
@@ -20,7 +20,7 @@ def get_expected_agents_mapping() -> dict:
 
     logger.info("Loading agent policies state file")
     policies_map = {}
-    for policy in state_manager.policies:
+    for policy in state_manager.get_policies():
         policies_map[policy.agnt_policy_id] = policy.expected_agents
     return policies_map
 

--- a/deploy/test-environments/fleet_api/src/agents_enrolled.py
+++ b/deploy/test-environments/fleet_api/src/agents_enrolled.py
@@ -12,7 +12,7 @@ from loguru import logger
 TIMEOUT = 600
 
 
-def get_expected_agents_mapping() -> dict:
+def get_expected_agents() -> dict:
     """
     Returns:
         dict: The name of the policy and the number of agents expected to be enrolled
@@ -24,7 +24,7 @@ def get_expected_agents_mapping() -> dict:
     return policies_dict
 
 
-def get_actual_agents_mapping() -> dict:
+def get_actual_agents() -> dict:
     """
     Returns:
         dict: The name of the policy and the number of agents enrolled
@@ -42,8 +42,8 @@ def verify_agents_enrolled() -> bool:
     """
     Verify that the expected number of agents are enrolled
     """
-    expected = get_expected_agents_mapping()
-    actual = get_actual_agents_mapping()
+    expected = get_expected_agents()
+    actual = get_actual_agents()
     result = True
     for policy_id, expected_count in expected.items():
         if policy_id not in actual:

--- a/deploy/test-environments/fleet_api/src/agents_enrolled.py
+++ b/deploy/test-environments/fleet_api/src/agents_enrolled.py
@@ -32,9 +32,7 @@ def get_actual_agents() -> dict:
     agents = get_agents(cfg=cnfg.elk_config)
     policies_dict = {}
     for agent in agents:
-        if agent.policy_id not in policies_dict:
-            policies_dict[agent.policy_id] = 0
-        policies_dict[agent.policy_id] += 1
+        policies_dict[agent.policy_id] = policies_dict.get(agent.policy_id, 0) + 1
     return policies_dict
 
 
@@ -49,11 +47,9 @@ def verify_agents_enrolled() -> bool:
         if policy_id not in actual:
             result = False
             logger.info(f"Policy {policy_id} not found in the actual agents mapping")
-            continue
-        if actual[policy_id] != expected_count:
+        elif actual[policy_id] != expected_count:
             result = False
             logger.info(f"Policy {policy_id} expected {expected_count} agents, but got {actual[policy_id]}")
-            continue
     return result
 
 

--- a/deploy/test-environments/fleet_api/src/agents_enrolled.py
+++ b/deploy/test-environments/fleet_api/src/agents_enrolled.py
@@ -1,0 +1,78 @@
+"""
+Wait for agents to be enrolled for a given policies
+If the expected number of agents is not enrolled within the timeout, the test will fail
+"""
+import time
+from api.agent_policy_api import get_agents
+import configuration_fleet as cnfg
+from state_file_manager import state_manager
+from loguru import logger
+
+TIMEOUT = 600
+
+def get_expected_agents_mapping() -> dict:
+    """
+    Returns:
+        map: The name of the policy and the number of agents expected to be enrolled
+    """
+    logger.info("Loading agent policies state file")
+    policies_map = {}
+    for policy in state_manager.policies:
+        policies_map[policy.agnt_policy_id] = policy.expected_agents
+    return policies_map
+
+
+def get_actual_agents_mapping() -> dict:
+
+    """
+    Returns:
+        map: The name of the policy and the number of agents enrolled
+    """
+    agents = get_agents(cfg=cnfg.elk_config)
+    policies_map = {}
+    for agent in agents:
+        if agent.policy_id not in policies_map:
+            policies_map[agent.policy_id] = 0
+        policies_map[agent.policy_id] += 1
+    return policies_map
+
+
+def verify_agents_enrolled() -> bool:
+    """
+    Verify that the expected number of agents are enrolled
+    """
+    expected = get_expected_agents_mapping()
+    actual = get_actual_agents_mapping()
+    result = True
+    for policy_id, expected_count in expected.items():
+        if policy_id not in actual:
+            result = False
+            logger.info(f"Policy {policy_id} not found in the actual agents mapping")
+            continue
+        if actual[policy_id] != expected_count:
+            result = False
+            logger.info(f"Policy {policy_id} expected {expected_count} agents, but got {actual[policy_id]}")
+            continue
+    return result
+
+
+def wait_for_agents_enrolled(timeout) -> bool:
+    """
+    Wait for agents to be enrolled
+    """
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        if verify_agents_enrolled():
+            return True
+        time.sleep(10)
+
+    return False
+
+
+if __name__ == "__main__":
+    logger.info("Waiting for agents to be enrolled...")
+    if wait_for_agents_enrolled(TIMEOUT):
+        logger.info("All agents enrolled successfully")
+    else:
+        logger.error("Not all agents were enrolled")
+        exit(1)

--- a/deploy/test-environments/fleet_api/src/agents_enrolled.py
+++ b/deploy/test-environments/fleet_api/src/agents_enrolled.py
@@ -15,29 +15,27 @@ TIMEOUT = 600
 def get_expected_agents_mapping() -> dict:
     """
     Returns:
-        map: The name of the policy and the number of agents expected to be enrolled
+        dict: The name of the policy and the number of agents expected to be enrolled
     """
-
     logger.info("Loading agent policies state file")
-    policies_map = {}
+    policies_dict = {}
     for policy in state_manager.get_policies():
-        policies_map[policy.agnt_policy_id] = policy.expected_agents
-    return policies_map
+        policies_dict[policy.agnt_policy_id] = policy.expected_agents
+    return policies_dict
 
 
 def get_actual_agents_mapping() -> dict:
     """
     Returns:
-        map: The name of the policy and the number of agents enrolled
+        dict: The name of the policy and the number of agents enrolled
     """
-
     agents = get_agents(cfg=cnfg.elk_config)
-    policies_map = {}
+    policies_dict = {}
     for agent in agents:
-        if agent.policy_id not in policies_map:
-            policies_map[agent.policy_id] = 0
-        policies_map[agent.policy_id] += 1
-    return policies_map
+        if agent.policy_id not in policies_dict:
+            policies_dict[agent.policy_id] = 0
+        policies_dict[agent.policy_id] += 1
+    return policies_dict
 
 
 def verify_agents_enrolled() -> bool:

--- a/deploy/test-environments/fleet_api/src/agents_enrolled.py
+++ b/deploy/test-environments/fleet_api/src/agents_enrolled.py
@@ -2,6 +2,7 @@
 Wait for agents to be enrolled for a given policies
 If the expected number of agents is not enrolled within the timeout, the test will fail
 """
+import sys
 import time
 from api.agent_policy_api import get_agents
 import configuration_fleet as cnfg
@@ -75,4 +76,4 @@ if __name__ == "__main__":
         logger.info("All agents enrolled successfully")
     else:
         logger.error("Not all agents were enrolled")
-        exit(1)
+        sys.exit(1)

--- a/deploy/test-environments/fleet_api/src/agents_enrolled.py
+++ b/deploy/test-environments/fleet_api/src/agents_enrolled.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 TIMEOUT = 600
 
+
 def get_expected_agents_mapping() -> dict:
     """
     Returns:

--- a/deploy/test-environments/fleet_api/src/api/agent_policy_api.py
+++ b/deploy/test-environments/fleet_api/src/api/agent_policy_api.py
@@ -37,7 +37,7 @@ def create_agent_policy(cfg: Munch, json_policy: dict) -> str:
         logger.error(
             f"API call failed, status code {api_ex.status_code}. Response: {api_ex.response_text}",
         )
-        return ""
+        raise api_ex
 
 
 def delete_agent_policy(cfg: Munch, agent_policy_id: str):

--- a/deploy/test-environments/fleet_api/src/api/package_policy_api.py
+++ b/deploy/test-environments/fleet_api/src/api/package_policy_api.py
@@ -133,7 +133,7 @@ def create_integration(cfg: Munch, pkg_policy: dict, agent_policy_id: str, data:
         logger.error(
             f"API call failed, status code {api_ex.status_code}. Response: {api_ex.response_text}",
         )
-        return ""
+        raise api_ex
 
 
 def delete_package_policy(cfg: Munch, policy_ids: list):

--- a/deploy/test-environments/fleet_api/src/configuration_fleet.py
+++ b/deploy/test-environments/fleet_api/src/configuration_fleet.py
@@ -16,7 +16,6 @@ the ELK configuration (ES_USER, ES_PASSWORD, KIBANA_URL)
 have been set in the system environment.
 """
 import os
-from pathlib import Path
 from munch import Munch
 
 elk_config = Munch()
@@ -32,5 +31,3 @@ kspm_config.docker_image_override = os.getenv("DOCKER_IMAGE_OVERRIDE", "")
 aws_config = Munch()
 aws_config.access_key_id = os.getenv("AWS_ACCESS_KEY_ID", "NA")
 aws_config.secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY", "NA")
-
-state_data_file = Path(__file__).parent / "state_data.json"

--- a/deploy/test-environments/fleet_api/src/install_cnvm_integration.py
+++ b/deploy/test-environments/fleet_api/src/install_cnvm_integration.py
@@ -20,13 +20,12 @@ from api.common_api import (
     get_artifact_server,
 )
 from loguru import logger
-from utils import (
-    read_json,
-    save_state,
-)
+from utils import read_json
+from state_file_manager import state_manager, PolicyState
 
 CNVM_AGENT_POLICY = "../../../cloud/data/agent_policy_cnvm_aws.json"
 CNVM_PACKAGE_POLICY = "../../../cloud/data/package_policy_cnvm_aws.json"
+CNVM_EXPECTED_AGENTS = 1
 CNVM_CLOUDFORMATION_CONFIG = "../../../cloudformation/config.json"
 
 cnvm_agent_policy_data = Path(__file__).parent / CNVM_AGENT_POLICY
@@ -61,15 +60,8 @@ if __name__ == "__main__":
         agent_policy_id=agent_policy_id,
     )
 
-    save_state(
-        cnfg.state_data_file,
-        [
-            {
-                "pkg_policy_id": package_policy_id,
-                "agnt_policy_id": agent_policy_id,
-            },
-        ],
-    )
+    state_manager.add_policy(PolicyState(agent_policy_id, package_policy_id, CNVM_EXPECTED_AGENTS))
+
     cloudformation_params = Munch()
     cloudformation_params.ENROLLMENT_TOKEN = get_enrollment_token(
         cfg=cnfg.elk_config,

--- a/deploy/test-environments/fleet_api/src/install_cspm_integration.py
+++ b/deploy/test-environments/fleet_api/src/install_cspm_integration.py
@@ -24,12 +24,13 @@ from api.common_api import (
 from loguru import logger
 from utils import (
     read_json,
-    save_state,
     render_template,
 )
+from state_file_manager import state_manager, PolicyState
 
 CSPM_AGENT_POLICY = "../../../cloud/data/agent_policy_cspm_aws.json"
 CSPM_PACKAGE_POLICY = "../../../cloud/data/package_policy_cspm_aws.json"
+CSPM_EXPECTED_AGENTS = 1
 
 cspm_agent_policy_data = Path(__file__).parent / CSPM_AGENT_POLICY
 cspm_pkg_policy_data = Path(__file__).parent / CSPM_PACKAGE_POLICY
@@ -75,15 +76,8 @@ if __name__ == "__main__":
         cspm_data=cspm_data,
     )
 
-    save_state(
-        cnfg.state_data_file,
-        [
-            {
-                "pkg_policy_id": package_policy_id,
-                "agnt_policy_id": agent_policy_id,
-            },
-        ],
-    )
+    state_manager.add_policy(PolicyState(agent_policy_id, package_policy_id, CSPM_EXPECTED_AGENTS))
+
     manifest_params = Munch()
     manifest_params.enrollment_token = get_enrollment_token(
         cfg=cnfg.elk_config,

--- a/deploy/test-environments/fleet_api/src/install_kspm_eks_integration.py
+++ b/deploy/test-environments/fleet_api/src/install_kspm_eks_integration.py
@@ -22,14 +22,12 @@ from api.common_api import (
     update_package_version,
 )
 from loguru import logger
-from utils import (
-    read_json,
-    save_state,
-)
+from utils import read_json
+from state_file_manager import state_manager, PolicyState
 
 KSPM_EKS_AGENT_POLICY = "../../../cloud/data/agent_policy_eks.json"
 KSPM_EKS_PACKAGE_POLICY = "../../../cloud/data/package_policy_eks.json"
-
+KSPM_EKS_EXPECTED_AGENTS = 2
 
 kspm_agent_policy_data = Path(__file__).parent / KSPM_EKS_AGENT_POLICY
 kspm_eks_pkg_policy_data = Path(__file__).parent / KSPM_EKS_PACKAGE_POLICY
@@ -73,15 +71,8 @@ if __name__ == "__main__":
         eks_data=eks_data,
     )
 
-    save_state(
-        cnfg.state_data_file,
-        [
-            {
-                "pkg_policy_id": package_policy_id,
-                "agnt_policy_id": agent_policy_id,
-            },
-        ],
-    )
+    state_manager.add_policy(PolicyState(agent_policy_id, package_policy_id, KSPM_EKS_EXPECTED_AGENTS))
+
     manifest_params = Munch()
     manifest_params.enrollment_token = get_enrollment_token(
         cfg=cnfg.elk_config,

--- a/deploy/test-environments/fleet_api/src/install_kspm_unmanaged_integration.py
+++ b/deploy/test-environments/fleet_api/src/install_kspm_unmanaged_integration.py
@@ -22,10 +22,12 @@ from api.common_api import (
     update_package_version,
 )
 from loguru import logger
-from utils import read_json, save_state
+from utils import read_json
+from state_file_manager import state_manager, PolicyState
 
 KSPM_UNMANAGED_AGENT_POLICY = "../../../cloud/data/agent_policy_vanilla.json"
 KSPM_UNMANAGED_PACKAGE_POLICY = "../../../cloud/data/package_policy_vanilla.json"
+KSPM_UNMANAGED_EXPECTED_AGENTS = 2
 
 
 kspm_agent_policy_data = Path(__file__).parent / KSPM_UNMANAGED_AGENT_POLICY
@@ -64,15 +66,8 @@ if __name__ == "__main__":
         agent_policy_id=agent_policy_id,
     )
 
-    save_state(
-        cnfg.state_data_file,
-        [
-            {
-                "pkg_policy_id": package_policy_id,
-                "agnt_policy_id": agent_policy_id,
-            },
-        ],
-    )
+    state_manager.add_policy(PolicyState(agent_policy_id, package_policy_id, KSPM_UNMANAGED_EXPECTED_AGENTS))
+
     manifest_params = Munch()
     manifest_params.enrollment_token = get_enrollment_token(
         cfg=cnfg.elk_config,

--- a/deploy/test-environments/fleet_api/src/purge_integrations.py
+++ b/deploy/test-environments/fleet_api/src/purge_integrations.py
@@ -33,7 +33,7 @@ def purge_integrations():
 
     agents = get_agents(cfg=cnfg.elk_config)
     # Delete policies based on the stored IDs
-    for policy in state_manager.policies:
+    for policy in state_manager.get_policies():
         logger.info("Deleting policy", policy.pkg_policy_id, policy.agnt_policy_id)
         delete_package_policy(cfg=cnfg.elk_config, policy_ids=[policy.pkg_policy_id])
 

--- a/deploy/test-environments/fleet_api/src/purge_integrations.py
+++ b/deploy/test-environments/fleet_api/src/purge_integrations.py
@@ -24,6 +24,7 @@ from api.package_policy_api import delete_package_policy
 import configuration_fleet as cnfg
 from state_file_manager import state_manager
 
+
 def purge_integrations():
     """
     Purge integrations and policies based on stored IDs in the state_data.json file.

--- a/deploy/test-environments/fleet_api/src/purge_integrations.py
+++ b/deploy/test-environments/fleet_api/src/purge_integrations.py
@@ -33,7 +33,7 @@ def purge_integrations():
     agents = get_agents(cfg=cnfg.elk_config)
     # Delete policies based on the stored IDs
     for policy in state_manager.policies:
-        logger.info("Deleting policy", policy.pkg_policy_id, policy.agnt_policy_id )
+        logger.info("Deleting policy", policy.pkg_policy_id, policy.agnt_policy_id)
         delete_package_policy(cfg=cnfg.elk_config, policy_ids=[policy.pkg_policy_id])
 
         agents_list = [item.agent.id for item in agents if item.policy_id == policy.agnt_policy_id]

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -38,7 +38,7 @@ class StateFileManager:
 
     def __init__(self, state_file: str):
         self.state_file = state_file
-        self.policies = []
+        self.__policies = list[PolicyState]
         self.__load()
 
     def __load(self) -> None:
@@ -51,18 +51,18 @@ class StateFileManager:
         with self.state_file.open("r") as policies_file:
             policies_data = json.load(policies_file)
             for policy in policies_data["policies"]:
-                self.policies.append(PolicyState(**policy))
-        logger.info(f" {len(self.policies)} policies loaded to state from {self.state_file}")
+                self.__policies.append(PolicyState(**policy))
+        logger.info(f" {len(self.__policies)} policies loaded to state from {self.state_file}")
 
     def __save(self) -> None:
         """
         Save the policies data to a file.
         """
 
-        policies_data = munchify({"policies": self.policies})
+        policies_data = munchify({"policies": self.__policies})
         with self.state_file.open("w") as policies_file:
             json.dump(policies_data, policies_file, cls=PolicyStateEncoder)
-        logger.info(f" {len(self.policies)} policies saved to state in {self.state_file}")
+        logger.info(f" {len(self.__policies)} policies saved to state in {self.state_file}")
 
     def add_policy(self, data: PolicyState):
         """
@@ -72,15 +72,24 @@ class StateFileManager:
             data (PolicyState): Policy data to be added.
         """
 
-        self.policies.append(data)
+        self.__policies.append(data)
         self.__save()
+
+    def get_policies(self) -> list[PolicyState]:
+        """
+        Get the current state.
+
+        Returns:
+            list: List of policies.
+        """
+        return self.__policies
 
     def delete_all(self):
         """
         Delete the current state.
         """
 
-        self.policies = []
+        self.__policies = []
         delete_file(self.state_file)
 
 

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -1,8 +1,10 @@
 """
+Define a class to manage the policies state using a file.
+Exports state_manager object as a singleton.
 """
 import json
-from munch import munchify
 from pathlib import Path
+from munch import munchify
 from utils import delete_file
 from loguru import logger
 
@@ -10,11 +12,17 @@ __state_file = Path(__file__).parent / "state_data.json"
 
 
 class PolicyStateEncoder(json.JSONEncoder):
-        def default(self, o):
-            return o.__dict__
+    """
+    Custom JSON encoder for PolicyState objects.
+    """
+    def default(self, o):
+        return o.__dict__
 
 
 class PolicyState:
+    """
+    Class to represent a policy state.
+    """
     def __init__(self, agnt_policy_id, pkg_policy_id, expected_agents):
         self.agnt_policy_id = agnt_policy_id
         self.pkg_policy_id = pkg_policy_id
@@ -22,6 +30,9 @@ class PolicyState:
 
 
 class StateFileManager:
+    """
+    Class to manage the policies state using a file.
+    """
     def __init__(self, state_file: str):
         self.state_file = state_file
         self.policies = []

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -25,7 +25,7 @@ class PolicyState:
     Class to represent a policy state.
     """
 
-    def __init__(self, agnt_policy_id, pkg_policy_id, expected_agents):
+    def __init__(self, agnt_policy_id: str, pkg_policy_id: str, expected_agents: int):
         self.agnt_policy_id = agnt_policy_id
         self.pkg_policy_id = pkg_policy_id
         self.expected_agents = expected_agents
@@ -38,7 +38,7 @@ class StateFileManager:
 
     def __init__(self, state_file: str):
         self.__state_file = state_file
-        self.__policies = list[PolicyState]
+        self.__policies = []
         self.__load()
 
     def __load(self) -> None:
@@ -64,7 +64,7 @@ class StateFileManager:
             json.dump(policies_data, policies_file, cls=PolicyStateEncoder)
         logger.info(f" {len(self.__policies)} policies saved to state in {self.__state_file}")
 
-    def add_policy(self, data: PolicyState):
+    def add_policy(self, data: PolicyState) -> None:
         """
         Add a policy to the current state.
 
@@ -84,7 +84,7 @@ class StateFileManager:
         """
         return self.__policies
 
-    def delete_all(self):
+    def delete_all(self) -> None:
         """
         Delete the current state.
         """

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -27,6 +27,12 @@ class PolicyState:
     Class to represent a policy state.
     """
     def __init__(self, agnt_policy_id: str, pkg_policy_id: str, expected_agents: int):
+        """
+        Args:
+            agnt_policy_id (str): ID of the agent policy.
+            pkg_policy_id (str): ID of the package policy.
+            expected_agents (int): Expected number of deployed agents.
+        """
         self.agnt_policy_id = agnt_policy_id
         self.pkg_policy_id = pkg_policy_id
         self.expected_agents = expected_agents

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -15,6 +15,7 @@ class PolicyStateEncoder(json.JSONEncoder):
     """
     Custom JSON encoder for PolicyState objects.
     """
+
     def default(self, o):
         return o.__dict__
 
@@ -23,6 +24,7 @@ class PolicyState:
     """
     Class to represent a policy state.
     """
+
     def __init__(self, agnt_policy_id, pkg_policy_id, expected_agents):
         self.agnt_policy_id = agnt_policy_id
         self.pkg_policy_id = pkg_policy_id
@@ -33,6 +35,7 @@ class StateFileManager:
     """
     Class to manage the policies state using a file.
     """
+
     def __init__(self, state_file: str):
         self.state_file = state_file
         self.policies = []
@@ -42,6 +45,7 @@ class StateFileManager:
         """
         Load the policies data from a file.
         """
+
         if not self.state_file.exists():
             return
         with self.state_file.open("r") as policies_file:
@@ -54,6 +58,7 @@ class StateFileManager:
         """
         Save the policies data to a file.
         """
+
         policies_data = munchify({"policies": self.policies})
         with self.state_file.open("w") as policies_file:
             json.dump(policies_data, policies_file, cls=PolicyStateEncoder)
@@ -66,6 +71,7 @@ class StateFileManager:
         Args:
             data (PolicyState): Policy data to be added.
         """
+
         self.policies.append(data)
         self.__save()
 
@@ -73,6 +79,7 @@ class StateFileManager:
         """
         Delete the current state.
         """
+
         self.policies = []
         delete_file(self.state_file)
 

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -36,7 +36,11 @@ class StateFileManager:
     """
     Class to manage the policies state using a file.
     """
-    def __init__(self, state_file: str):
+    def __init__(self, state_file: Path):
+        """
+        Args:
+            state_file (Path): Path of a file to cache the state.
+        """
         self.__state_file = state_file
         self.__policies = []
         self.__load()

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -67,7 +67,7 @@ class StateFileManager:
         """
         Save the policies data to a file.
         """
-        policies_data = munchify({"policies": self.__policies})
+        policies_data = {"policies": self.__policies}
         with self.__state_file.open("w") as policies_file:
             json.dump(policies_data, policies_file, cls=PolicyStateEncoder)
         logger.info(f" {len(self.__policies)} policies saved to state in {self.__state_file}")

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -4,7 +4,6 @@ Exports state_manager object as a singleton.
 """
 import json
 from pathlib import Path
-from munch import munchify
 from utils import delete_file
 from loguru import logger
 

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -38,7 +38,6 @@ class StateFileManager:
         self.policies = []
         self.__load()
 
-
     def __load(self) -> None:
         """
         Load the policies data from a file.
@@ -51,7 +50,6 @@ class StateFileManager:
                 self.policies.append(PolicyState(**policy))
         logger.info(f" {len(self.policies)} policies loaded to state from {self.state_file}")
 
-
     def __save(self) -> None:
         """
         Save the policies data to a file.
@@ -60,7 +58,6 @@ class StateFileManager:
         with self.state_file.open("w") as policies_file:
             json.dump(policies_data, policies_file, cls=PolicyStateEncoder)
         logger.info(f" {len(self.policies)} policies saved to state in {self.state_file}")
-
 
     def add_policy(self, data: PolicyState):
         """
@@ -72,12 +69,12 @@ class StateFileManager:
         self.policies.append(data)
         self.__save()
 
-
     def delete_all(self):
         """
         Delete the current state.
         """
         self.policies = []
         delete_file(self.state_file)
+
 
 state_manager = StateFileManager(__state_file)

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -1,0 +1,72 @@
+"""
+"""
+import json
+from munch import munchify
+from pathlib import Path
+from utils import delete_file
+from loguru import logger
+
+__state_file = Path(__file__).parent / "state_data.json"
+
+
+class PolicyStateEncoder(json.JSONEncoder):
+        def default(self, o):
+            return o.__dict__
+
+
+class PolicyState:
+    def __init__(self, agnt_policy_id, pkg_policy_id, expected_agents):
+        self.agnt_policy_id = agnt_policy_id
+        self.pkg_policy_id = pkg_policy_id
+        self.expected_agents = expected_agents
+
+
+class StateFileManager:
+    def __init__(self, state_file: str):
+        self.state_file = state_file
+        self.policies = []
+        self.__load()
+
+
+    def __load(self) -> None:
+        """
+        Load the policies data from a file.
+        """
+        if not self.state_file.exists():
+            return
+        with self.state_file.open("r") as policies_file:
+            policies_data = json.load(policies_file)
+            for policy in policies_data["policies"]:
+                self.policies.append(PolicyState(**policy))
+        logger.info(f" {len(self.policies)} policies loaded to state from {self.state_file}")
+
+
+    def __save(self) -> None:
+        """
+        Save the policies data to a file.
+        """
+        policies_data = munchify({"policies": self.policies})
+        with self.state_file.open("w") as policies_file:
+            json.dump(policies_data, policies_file, cls=PolicyStateEncoder)
+        logger.info(f" {len(self.policies)} policies saved to state in {self.state_file}")
+
+
+    def add_policy(self, data: PolicyState):
+        """
+        Add a policy to the current state.
+
+        Args:
+            data (PolicyState): Policy data to be added.
+        """
+        self.policies.append(data)
+        self.__save()
+
+
+    def delete_all(self):
+        """
+        Delete the current state.
+        """
+        self.policies = []
+        delete_file(self.state_file)
+
+state_manager = StateFileManager(__state_file)

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -15,6 +15,7 @@ class PolicyStateEncoder(json.JSONEncoder):
     """
     Custom JSON encoder for PolicyState objects.
     """
+
     def default(self, o):
         """
         Encode a PolicyState object.
@@ -26,6 +27,7 @@ class PolicyState:
     """
     Class to represent a policy state.
     """
+
     def __init__(self, agnt_policy_id: str, pkg_policy_id: str, expected_agents: int):
         """
         Args:
@@ -42,6 +44,7 @@ class StateFileManager:
     """
     Class to manage the policies state using a file.
     """
+
     def __init__(self, state_file: Path):
         """
         Args:

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -37,7 +37,7 @@ class StateFileManager:
     """
 
     def __init__(self, state_file: str):
-        self.state_file = state_file
+        self.__state_file = state_file
         self.__policies = list[PolicyState]
         self.__load()
 
@@ -46,13 +46,13 @@ class StateFileManager:
         Load the policies data from a file.
         """
 
-        if not self.state_file.exists():
+        if not self.__state_file.exists():
             return
-        with self.state_file.open("r") as policies_file:
+        with self.__state_file.open("r") as policies_file:
             policies_data = json.load(policies_file)
             for policy in policies_data["policies"]:
                 self.__policies.append(PolicyState(**policy))
-        logger.info(f" {len(self.__policies)} policies loaded to state from {self.state_file}")
+        logger.info(f" {len(self.__policies)} policies loaded to state from {self.__state_file}")
 
     def __save(self) -> None:
         """
@@ -60,9 +60,9 @@ class StateFileManager:
         """
 
         policies_data = munchify({"policies": self.__policies})
-        with self.state_file.open("w") as policies_file:
+        with self.__state_file.open("w") as policies_file:
             json.dump(policies_data, policies_file, cls=PolicyStateEncoder)
-        logger.info(f" {len(self.__policies)} policies saved to state in {self.state_file}")
+        logger.info(f" {len(self.__policies)} policies saved to state in {self.__state_file}")
 
     def add_policy(self, data: PolicyState):
         """
@@ -90,7 +90,7 @@ class StateFileManager:
         """
 
         self.__policies = []
-        delete_file(self.state_file)
+        delete_file(self.__state_file)
 
 
 state_manager = StateFileManager(__state_file)

--- a/deploy/test-environments/fleet_api/src/state_file_manager.py
+++ b/deploy/test-environments/fleet_api/src/state_file_manager.py
@@ -15,8 +15,10 @@ class PolicyStateEncoder(json.JSONEncoder):
     """
     Custom JSON encoder for PolicyState objects.
     """
-
     def default(self, o):
+        """
+        Encode a PolicyState object.
+        """
         return o.__dict__
 
 
@@ -24,7 +26,6 @@ class PolicyState:
     """
     Class to represent a policy state.
     """
-
     def __init__(self, agnt_policy_id: str, pkg_policy_id: str, expected_agents: int):
         self.agnt_policy_id = agnt_policy_id
         self.pkg_policy_id = pkg_policy_id
@@ -35,7 +36,6 @@ class StateFileManager:
     """
     Class to manage the policies state using a file.
     """
-
     def __init__(self, state_file: str):
         self.__state_file = state_file
         self.__policies = []
@@ -45,7 +45,6 @@ class StateFileManager:
         """
         Load the policies data from a file.
         """
-
         if not self.__state_file.exists():
             return
         with self.__state_file.open("r") as policies_file:
@@ -58,7 +57,6 @@ class StateFileManager:
         """
         Save the policies data to a file.
         """
-
         policies_data = munchify({"policies": self.__policies})
         with self.__state_file.open("w") as policies_file:
             json.dump(policies_data, policies_file, cls=PolicyStateEncoder)
@@ -71,7 +69,6 @@ class StateFileManager:
         Args:
             data (PolicyState): Policy data to be added.
         """
-
         self.__policies.append(data)
         self.__save()
 
@@ -88,7 +85,6 @@ class StateFileManager:
         """
         Delete the current state.
         """
-
         self.__policies = []
         delete_file(self.__state_file)
 

--- a/deploy/test-environments/fleet_api/src/utils.py
+++ b/deploy/test-environments/fleet_api/src/utils.py
@@ -44,38 +44,6 @@ def read_json(json_path: Path) -> dict:
         return {}
 
 
-def save_state(file_path: Path, data: list) -> None:
-    """
-    Save data to a JSON file.
-
-    If the file already exists, the new data is appended to the existing data.
-    If the file does not exist, a new file is created with the provided data.
-
-    Args:
-        file_path (Path): Path to the JSON file.
-        data (list): List of data to be saved.
-
-    Raises:
-        Exception: If an error occurs while saving the JSON data.
-    """
-    try:
-        if file_path.exists():
-            with file_path.open("r") as exist_file:
-                policies_data = json.load(exist_file)
-            policies_data["policies"].extend(data)
-        else:
-            policies_data = {"policies": data}
-        with file_path.open("w") as policies_file:
-            json.dump(policies_data, policies_file)
-        logger.info(f"JSON data saved to {file_path}")
-    except FileNotFoundError as ex:
-        logger.error(f"Error occurred while saving JSON data: File '{file_path}' not found.")
-        raise ex
-    except IOError as ex:
-        logger.error(f"Error occurred while saving JSON data: {ex}")
-        raise ex
-
-
 def delete_file(file_path: Path):
     """
     Delete a file.


### PR DESCRIPTION
### Summary of your changes
Add step in the sanity environment to wait for all agents to be enrolled to the fleet

### Related Issues
- https://github.com/elastic/cloudbeat/issues/700

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
