### PR TITLE
Convert to test suites

### DIFF
--- a/vulnerability/fetcher_test.go
+++ b/vulnerability/fetcher_test.go
@@ -47,8 +47,6 @@ func TestFetcherTestSuite(t *testing.T) {
 }
 
 func (s *FetcherTestSuite) TearDownTest() {
-	// Verify no goroutines are leaking. Safest to keep this on top of the function.
-	// Go defers are implemented as a LIFO stack. This should be the last one to run.
 	goleak.VerifyNone(s.T(), s.opts)
 }
 

--- a/vulnerability/fetcher_test.go
+++ b/vulnerability/fetcher_test.go
@@ -37,15 +37,11 @@ import (
 
 type FetcherTestSuite struct {
 	suite.Suite
-
-	log  *logp.Logger
 	opts goleak.Option
 }
 
 func TestFetcherTestSuite(t *testing.T) {
 	s := new(FetcherTestSuite)
-	s.log = testhelper.NewLogger(t)
-
 	s.opts = goleak.IgnoreCurrent()
 	suite.Run(t, s)
 }

--- a/vulnerability/fetcher_test.go
+++ b/vulnerability/fetcher_test.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -35,14 +35,35 @@ import (
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
-func TestVulnerabilityFetcher_FetchInstances(t *testing.T) {
+type FetcherTestSuite struct {
+	suite.Suite
+
+	log  *logp.Logger
+	opts goleak.Option
+}
+
+func TestFetcherTestSuite(t *testing.T) {
+	s := new(FetcherTestSuite)
+	s.log = testhelper.NewLogger(t)
+
+	s.opts = goleak.IgnoreCurrent()
+	suite.Run(t, s)
+}
+
+func (s *FetcherTestSuite) TearDownTest() {
+	// Verify no goroutines are leaking. Safest to keep this on top of the function.
+	// Go defers are implemented as a LIFO stack. This should be the last one to run.
+	goleak.VerifyNone(s.T(), s.opts)
+}
+
+func (s *FetcherTestSuite) TestVulnerabilityFetcher_FetchInstances() {
 	provider := &mockInstancesProvider{}
 	expectedInstances := []ec2.Ec2Instance{
 		{Instance: types.Instance{InstanceId: aws.String("instance-1")}},
 		{Instance: types.Instance{InstanceId: aws.String("instance-2")}},
 	}
 	provider.EXPECT().DescribeInstances(mock.Anything).Return(expectedInstances, nil)
-	fetcher := NewVulnerabilityFetcher(testhelper.NewLogger(t), provider)
+	fetcher := NewVulnerabilityFetcher(testhelper.NewLogger(s.T()), provider)
 
 	ctx := context.TODO()
 
@@ -52,54 +73,46 @@ func TestVulnerabilityFetcher_FetchInstances(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		err := fetcher.FetchInstances(ctx)
-		assert.NoError(t, err)
+		s.Assertions.NoError(err)
 	}()
 
 	ch := fetcher.GetChan()
-	assert.NotNil(t, ch)
+	s.Assertions.NotNil(ch)
 
 	receivedInstances := make([]ec2.Ec2Instance, 0, len(expectedInstances))
 	for in := range ch {
 		receivedInstances = append(receivedInstances, in)
 	}
 	_, ok := <-ch
-	assert.False(t, ok)
+	s.Assertions.False(ok)
 
-	assert.ElementsMatch(t, expectedInstances, receivedInstances)
+	s.Assertions.ElementsMatch(expectedInstances, receivedInstances)
 	wg.Wait()
-
-	// Verify no goroutines are leaking. Safest to keep this on top of the function.
-	// Go defers are implemented as a LIFO stack. This should be the last one to run.
-	goleak.VerifyNone(t, goleak.IgnoreCurrent())
 }
 
-func TestVulnerabilityFetcher_FetchInstances_Cancel(t *testing.T) {
+func (s *FetcherTestSuite) TestVulnerabilityFetcher_FetchInstances_Cancel() {
 	provider := &mockInstancesProvider{}
 	expectedInstances := []ec2.Ec2Instance{
 		{Instance: types.Instance{InstanceId: aws.String("instance-1")}},
 		{Instance: types.Instance{InstanceId: aws.String("instance-2")}},
 	}
 	provider.EXPECT().DescribeInstances(mock.Anything).Return(expectedInstances, nil)
-	fetcher := NewVulnerabilityFetcher(testhelper.NewLogger(t), provider)
+	fetcher := NewVulnerabilityFetcher(testhelper.NewLogger(s.T()), provider)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel the context immediately
 
 	err := fetcher.FetchInstances(ctx)
-	assert.NoError(t, err)
+	s.Assertions.NoError(err)
 
 	ch := fetcher.GetChan()
-	assert.NotNil(t, ch)
+	s.Assertions.NotNil(ch)
 
 	_, ok := <-ch
-	assert.False(t, ok)
-
-	// Verify no goroutines are leaking. Safest to keep this on top of the function.
-	// Go defers are implemented as a LIFO stack. This should be the last one to run.
-	goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	s.Assertions.False(ok)
 }
 
-func TestVulnerabilityFetcher_FetchInstances_DelayCancel(t *testing.T) {
+func (s *FetcherTestSuite) TestVulnerabilityFetcher_FetchInstances_DelayCancel() {
 	log := logp.NewLogger("TestVulnerabilityFetcher_FetchInstances_Cancel")
 	provider := &mockInstancesProvider{}
 	expectedInstances := []ec2.Ec2Instance{
@@ -116,15 +129,11 @@ func TestVulnerabilityFetcher_FetchInstances_DelayCancel(t *testing.T) {
 	}()
 
 	err := fetcher.FetchInstances(ctx)
-	assert.NoError(t, err)
+	s.Assertions.NoError(err)
 
 	ch := fetcher.GetChan()
-	assert.NotNil(t, ch)
+	s.Assertions.NotNil(ch)
 
 	_, ok := <-ch
-	assert.False(t, ok)
-
-	// Verify no goroutines are leaking. Safest to keep this on top of the function.
-	// Go defers are implemented as a LIFO stack. This should be the last one to run.
-	goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	s.Assertions.False(ok)
 }

--- a/vulnerability/replicator_test.go
+++ b/vulnerability/replicator_test.go
@@ -25,18 +25,33 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
-
-	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
-func TestVulnerabilityReplicator_SnapshotInstance(t *testing.T) {
-	log := testhelper.NewLogger(t)
+type ReplicatorTestSuite struct {
+	suite.Suite
+	opts goleak.Option
+}
+
+func TestReplicatorTestSuite(t *testing.T) {
+	s := new(ReplicatorTestSuite)
+	s.opts = goleak.IgnoreCurrent()
+	suite.Run(t, s)
+}
+
+func (s *ReplicatorTestSuite) TearDownTest() {
+	// Verify no goroutines are leaking. Safest to keep this on top of the function.
+	// Go defers are implemented as a LIFO stack. This should be the last one to run.
+	goleak.VerifyNone(s.T(), s.opts)
+}
+
+func (s *ReplicatorTestSuite) TestVulnerabilityReplicator_SnapshotInstance() {
+	log := testhelper.NewLogger(s.T())
 
 	// Create a mock provider
 	provider := &mockReplicatorProvider{}
@@ -75,7 +90,7 @@ func TestVulnerabilityReplicator_SnapshotInstance(t *testing.T) {
 			receivedSnapshots = append(receivedSnapshots, s)
 		}
 
-		assert.ElementsMatch(t, expectedSnapshots, receivedSnapshots)
+		s.Assertions.ElementsMatch(expectedSnapshots, receivedSnapshots)
 	}()
 
 	// Send Ec2Instance data to the channel
@@ -86,14 +101,10 @@ func TestVulnerabilityReplicator_SnapshotInstance(t *testing.T) {
 	// Close the channel to indicate that no more data will be sent
 	close(insCh)
 	wg.Wait()
-
-	// Verify no goroutines are leaking. Safest to keep this on top of the function.
-	// Go defers are implemented as a LIFO stack. This should be the last one to run.
-	goleak.VerifyNone(t, goleak.IgnoreCurrent())
 }
 
-func TestVulnerabilityReplicator_SnapshotInstance_Cancel(t *testing.T) {
-	log := logp.NewLogger("TestVulnerabilityReplicator_SnapshotInstance")
+func (s *ReplicatorTestSuite) TestVulnerabilityReplicator_SnapshotInstance_Cancel() {
+	log := testhelper.NewLogger(s.T())
 
 	// Create a mock provider
 	provider := &mockReplicatorProvider{}
@@ -132,12 +143,8 @@ func TestVulnerabilityReplicator_SnapshotInstance_Cancel(t *testing.T) {
 	replicator.SnapshotInstance(ctx, insCh)
 
 	ch := replicator.GetChan()
-	assert.NotNil(t, ch)
+	s.Assertions.NotNil(ch)
 
 	_, ok := <-ch
-	assert.False(t, ok)
-
-	// Verify no goroutines are leaking. Safest to keep this on top of the function.
-	// Go defers are implemented as a LIFO stack. This should be the last one to run.
-	goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	s.Assertions.False(ok)
 }

--- a/vulnerability/replicator_test.go
+++ b/vulnerability/replicator_test.go
@@ -45,8 +45,6 @@ func TestReplicatorTestSuite(t *testing.T) {
 }
 
 func (s *ReplicatorTestSuite) TearDownTest() {
-	// Verify no goroutines are leaking. Safest to keep this on top of the function.
-	// Go defers are implemented as a LIFO stack. This should be the last one to run.
 	goleak.VerifyNone(s.T(), s.opts)
 }
 

--- a/vulnerability/verifier_test.go
+++ b/vulnerability/verifier_test.go
@@ -24,16 +24,33 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
-func TestVulnerabilityVerifier_VerifySnapshot_Cancel(t *testing.T) {
-	logger := testhelper.NewLogger(t)
+type VerifierTestSuite struct {
+	suite.Suite
+	opts goleak.Option
+}
+
+func TestVerifierTestSuite(t *testing.T) {
+	s := new(VerifierTestSuite)
+	s.opts = goleak.IgnoreCurrent()
+	suite.Run(t, s)
+}
+
+func (s *VerifierTestSuite) TearDownTest() {
+	// Verify no goroutines are leaking. Safest to keep this on top of the function.
+	// Go defers are implemented as a LIFO stack. This should be the last one to run.
+	goleak.VerifyNone(s.T(), s.opts)
+}
+
+func (s *VerifierTestSuite) TestVulnerabilityVerifier_VerifySnapshot_Cancel() {
+	logger := testhelper.NewLogger(s.T())
 	provider := &mockSnapshotProvider{}
 	provider.EXPECT().DescribeSnapshots(mock.Anything, mock.Anything).Return([]ec2.EBSSnapshot{
 		{SnapshotId: "snapshot-1", State: types.SnapshotStateCompleted},
@@ -56,18 +73,14 @@ func TestVulnerabilityVerifier_VerifySnapshot_Cancel(t *testing.T) {
 	verifier.VerifySnapshot(ctx, snapCh)
 
 	ch := verifier.GetChan()
-	assert.NotNil(t, ch)
+	s.Assertions.NotNil(ch)
 
 	_, ok := <-ch
-	assert.False(t, ok)
-
-	// Verify no goroutines are leaking. Safest to keep this on top of the function.
-	// Go defers are implemented as a LIFO stack. This should be the last one to run.
-	goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	s.Assertions.False(ok)
 }
 
-func TestVulnerabilityVerifier_verify(t *testing.T) {
-	logger := testhelper.NewLogger(t)
+func (s *VerifierTestSuite) TestVulnerabilityVerifier_verify() {
+	logger := testhelper.NewLogger(s.T())
 	provider := &mockSnapshotProvider{}
 	expectedSnapshots := []ec2.EBSSnapshot{
 		{SnapshotId: "snapshot-1", State: types.SnapshotStateCompleted},
@@ -85,7 +98,7 @@ func TestVulnerabilityVerifier_verify(t *testing.T) {
 	}
 
 	ch := verifier.GetChan()
-	assert.NotNil(t, ch)
+	s.Assertions.NotNil(ch)
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -103,12 +116,8 @@ func TestVulnerabilityVerifier_verify(t *testing.T) {
 			receivedSnapshots = append(receivedSnapshots, snap)
 		}
 
-		assert.ElementsMatch(t, expectedSnapshots, receivedSnapshots)
+		s.Assertions.ElementsMatch(expectedSnapshots, receivedSnapshots)
 	}()
 
 	wg.Wait()
-
-	// Verify no goroutines are leaking. Safest to keep this on top of the function.
-	// Go defers are implemented as a LIFO stack. This should be the last one to run.
-	goleak.VerifyNone(t, goleak.IgnoreCurrent())
 }

--- a/vulnerability/verifier_test.go
+++ b/vulnerability/verifier_test.go
@@ -44,8 +44,6 @@ func TestVerifierTestSuite(t *testing.T) {
 }
 
 func (s *VerifierTestSuite) TearDownTest() {
-	// Verify no goroutines are leaking. Safest to keep this on top of the function.
-	// Go defers are implemented as a LIFO stack. This should be the last one to run.
 	goleak.VerifyNone(s.T(), s.opts)
 }
 


### PR DESCRIPTION
### Summary of your changes
Convert tests into test suites to fix a bug where the `goleak.VerifyNone()` doesn't work.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
