### PR TITLE
Improving Cloud Deployment test env docs

### DIFF
--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -17,7 +17,7 @@ on:
         required: true
       elk-stack-version:
         required: true
-        description: "Elastic Cloud stack SNAPSHOT or BC version"
+        description: "Stack version: For released/BC version use 8.x.y, for SNAPSHOT use 8.x.y-SNAPSHOT"
         default: "8.8.0"
       ess-region:
         required: true
@@ -25,7 +25,7 @@ on:
         default: "gcp-us-west2"
       docker-image-override:
         required: false
-        description: "Provide the full Docker image path to override the default image (BC versions only)"
+        description: "Provide the full Docker image path to override the default image (e.g. for testing BC/SNAPSHOT)"
       run-sanity-tests:
           description: "Run sanity tests after provision"
           default: false

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -1,4 +1,5 @@
 name: Create Environment
+run-name: Creating ${{ github.event.inputs.deployment_name }} by @${{ github.actor }}
 
 on:
   # Ability to execute on demand

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ We use [Hermit](https://cashapp.github.io/hermit/usage/get-started/) to manage o
 
 ___
 
-> **Note*** If you are a developer or contributor, or if you are looking for additional information, please visit our [development documentation](dev-docs/Development.md)
+> **Note** If you are a developer or contributor, or if you are looking for additional information, please visit our [development documentation](dev-docs/Development.md)

--- a/deploy/test-environments/delete_env.sh
+++ b/deploy/test-environments/delete_env.sh
@@ -35,7 +35,7 @@ done
 : "${TF_VAR_ec_api_key:?Please set TF_VAR_ec_api_key with an Elastic Cloud API Key}"
 
 BUCKET=s3://tf-state-bucket-test-infra
-ALL_ENVS=$(aws s3 ls $BUCKET/$ENV_PREFIX | awk '{print $2}' | sed 's/\///g')
+ALL_ENVS=$(aws s3 ls $BUCKET/"$ENV_PREFIX" | awk '{print $2}' | sed 's/\///g')
 
 # Divide environments into those to be deleted and those to be skipped
 TO_DELETE=()
@@ -66,17 +66,17 @@ fi
 for ENV in "${TO_DELETE[@]}"
 do
     echo "Deleting $ENV"
-    local="./$ENV-terraform.tfstate"
+    tfstate="./$ENV-terraform.tfstate"
 
     # Copy state file, destroy environment, and remove environment data from S3
-    if aws s3 cp $BUCKET/$ENV/terraform.tfstate $local && \
-    terraform destroy -var="region=eu-west-1" -state $local --auto-approve && \
-    aws s3 rm $BUCKET/$ENV --recursive; then
+    if aws s3 cp $BUCKET/"$ENV"/terraform.tfstate "$tfstate" && \
+    terraform destroy -var="region=eu-west-1" -state "$tfstate" --auto-approve && \
+    aws s3 rm $BUCKET/"$ENV" --recursive; then
         echo "Successfully deleted $ENV"
     else
         echo "Failed to delete $ENV"
         exit 1
     fi
 
-    rm $local
+    rm "$tfstate"
 done

--- a/deploy/test-environments/delete_env.sh
+++ b/deploy/test-environments/delete_env.sh
@@ -1,54 +1,82 @@
 #!/bin/bash
-# Given a prefix, delete all the environments that match that prefix
-# Usage: ./delete_env.sh <prefix>
-# Example: ./delete_env.sh test
-# This will delete all the environments that start with "test"
-# It will ask for confirmation before deleting each environment
-# TF_VAR_ec_api_key environment variable should be set
-# AWS CLI should be installed and configured
-# Terraform CLI should be installed and configured
+set -e
 
-ENV_PREFIX=$1
-[ -z "$ENV_PREFIX" ] && echo "Please provide an environment prefix to delete" && exit -1
-[ -z "$TF_VAR_ec_api_key" ] && echo "Please set TF_VAR_ec_api_key with an Elastic Cloud API Key" && exit -1
+function usage() {
+  cat <<EOF
+Usage: $0 -p|--prefix ENV_PREFIX [-n|--ignore-prefix IGNORE_PREFIX] [-i|--interactive true|false]
+Cleanup script to delete environments based on a prefix.
+Required flag: -p|--prefix
+EOF
+}
 
-BUCKET=s3://tf-state-bucket-test-infra
-ENVS=$(aws s3 ls $BUCKET/$ENV_PREFIX | awk '{print $2}' | sed 's/\///g')
-COUNT=$(echo -n "$ENVS" | grep -c '^')
-echo "Found ${COUNT} environments:"
-echo "${ENVS[@]}"
+# Defaults
+INTERACTIVE=true
 
-FAILED=()
-SUCCEED=()
-SKIPPED=()
-
-for ENV in $ENVS
-do
-    echo "Are you sure you want to delete $ENV? (yes/no)"
-    read approve
-    if [ "$approve" != "yes" ]; then
-        echo "Skipping $ENV"
-        SKIPPED+=($ENV)
-        continue
-    fi
-    # Download the state file, destroy the environment, and delete the environment data from S3
-    local="./$ENV-terraform.tfstate"
-    aws s3 cp $BUCKET/$ENV/terraform.tfstate $local && \
-    terraform destroy -var="region=eu-west-1" -state $local --auto-approve && \
-    aws s3 rm $BUCKET/$ENV --recursive && \
-    SUCCEED+=($ENV) || FAILED+=($ENV)
-    rm $local
+# Parsing command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -p|--prefix) ENV_PREFIX="$2"; shift ;;
+        -n|--ignore-prefix) IGNORE_PREFIX="$2"; shift ;;
+        -i|--interactive)
+            shift
+            case $1 in
+                true|True|TRUE) INTERACTIVE=true ;;
+                false|False|FALSE) INTERACTIVE=false ;;
+                *) echo "Invalid value for --interactive. Please use true or false"; usage; exit 1 ;;
+            esac
+            ;;
+        *) echo "Unknown parameter passed: $1"; usage; exit 1 ;;
+    esac
+    shift
 done
 
-# Print results
-echo
-echo "Successfully deleted:"
-printf "%s\n" "${SUCCEED[@]}"
+# Ensure required environment variables and parameters are set
+: "${ENV_PREFIX:?$(echo "Missing -p|--prefix. Please provide an environment prefix to delete" && usage && exit 1)}"
+: "${TF_VAR_ec_api_key:?Please set TF_VAR_ec_api_key with an Elastic Cloud API Key}"
 
-echo
-echo "Skipped deletion:"
-printf "%s\n" "${SKIPPED[@]}"
+BUCKET=s3://tf-state-bucket-test-infra
+ALL_ENVS=$(aws s3 ls $BUCKET/$ENV_PREFIX | awk '{print $2}' | sed 's/\///g')
 
-echo
-echo "Failed to delete:"
-printf "%s\n" "${FAILED[@]}"
+# Divide environments into those to be deleted and those to be skipped
+TO_DELETE=()
+TO_SKIP=()
+
+for ENV in $ALL_ENVS
+do
+    if [[ -n "$IGNORE_PREFIX" && "$ENV" == "$IGNORE_PREFIX"* ]]; then
+        TO_SKIP+=("$ENV")
+    else
+        TO_DELETE+=("$ENV")
+    fi
+done
+
+# Print the lists of environments to be deleted and skipped
+echo "Environments to delete (${#TO_DELETE[@]}):"
+printf "%s\n" "${TO_DELETE[@]}"
+
+echo "Environments to skip (${#TO_SKIP[@]}):"
+printf "%s\n" "${TO_SKIP[@]}"
+
+# Ask for user confirmation if interactive mode is enabled
+if [ "$INTERACTIVE" = true ]; then
+    read -r -p "Are you sure you want to delete these environments? (y/n): " confirm && [[ $confirm == [yY] || $confirm == [yY][eE][sS] ]] || exit 1
+fi
+
+# Delete the environments
+for ENV in "${TO_DELETE[@]}"
+do
+    echo "Deleting $ENV"
+    local="./$ENV-terraform.tfstate"
+
+    # Copy state file, destroy environment, and remove environment data from S3
+    if aws s3 cp $BUCKET/$ENV/terraform.tfstate $local && \
+    terraform destroy -var="region=eu-west-1" -state $local --auto-approve && \
+    aws s3 rm $BUCKET/$ENV --recursive; then
+        echo "Successfully deleted $ENV"
+    else
+        echo "Failed to delete $ENV"
+        exit 1
+    fi
+
+    rm $local
+done

--- a/deploy/test-environments/variables.tf
+++ b/deploy/test-environments/variables.tf
@@ -16,7 +16,7 @@ variable "ami_map" {
   }
 }
 
-# Elactic Cloud variables
+# Elastic Cloud variables
 # ===========================================
 variable "ec_api_key" {
   description = "Provide Elastic Cloud API key or use export TF_VAR_ec_api_key={TOKEN}"

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -27,7 +27,8 @@ Follow these steps to run the workflow:
 
     - **`elk-stack-version`**: Specify the version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC)
       version. The default value is `8.8.0`. Check the available
-      versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
+      versions [here](https://artifacts-staging.elastic.co/dra-info/index.html). For BC, enter only the
+      version without additions/commit sha, e.g. `8.8.1`. For SNAPSHOT, enter the full version, e.g. `8.8.1-SNAPSHOT`.
 
     - **`ess-region`**: Indicate the Elastic Cloud deployment region. The default value is `gcp-us-west2`, which
       supports
@@ -37,10 +38,14 @@ Follow these steps to run the workflow:
 
 4. Optionally, modify other input values if required:
 
-    - `docker-image-override` (optional): Use this to replace the default Docker image for build candidate (BC)
-      versions.
+    - `docker-image-override` (optional): Use this to replace the default Docker image for build candidate (BC) or
+      SNAPSHOT versions.
       Provide the full image path. Leave this field blank for snapshot versions. Follow this format for the image
-      path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.8.1-9ac7eb02`.
+      path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.8.1-9ac7eb02`. If you're not sure where to get this
+      image path from, look for message like [this](https://elastic.slack.com/archives/C0JFN9HJL/p1689227472876399) in
+      #mission-control channel, you can see it specify the stack version and the BC commit sha in the first line,
+      e.g. `elastic / unified-release - staging # 8.9 - 11 - 8.9.0-c6bb8f7a Success after 4 hr 58 min`. Now just copy it
+      and replace it the image path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.9.0-c6bb8f7a`.
 
     - `cleanup-env` (optional): Set to `true` if you want the resources to be cleaned up after provisioning.
       Default: `false`.

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -1,6 +1,8 @@
 # Cloud Environment Testing
 
-The [Create Environment](https://github.com/elastic/cloudbeat/actions/workflows/test-environment.yml) GitHub action deploys a full-featured cloud environment, pre-configured with all our integrations. It also includes features for running sanity testing and automated deletion.
+The [Create Environment](https://github.com/elastic/cloudbeat/actions/workflows/test-environment.yml) GitHub action
+deploys a full-featured cloud environment, pre-configured with all our integrations. It also includes features for
+running sanity testing and automated deletion.
 
 ## How to Run the Workflow
 
@@ -8,37 +10,49 @@ Follow these steps to run the workflow:
 
 1. Go to [`Actions > Create Environment`](https://github.com/elastic/cloudbeat/actions/workflows/test-environment.yml).
 
-![Navigate to Actions](https://github.com/elastic/cloudbeat/assets/99176494/2686668f-7be6-4b55-a37b-e37426c1a0e1)
+   ![Navigate to Actions](https://github.com/elastic/cloudbeat/assets/99176494/2686668f-7be6-4b55-a37b-e37426c1a0e1)
 
 2. Click the `Run workflow` button.
 
-![Run Workflow](https://github.com/elastic/cloudbeat/assets/99176494/115fdd53-cff7-406a-bc3d-d65d5199389f)
+   ![Run Workflow](https://github.com/elastic/cloudbeat/assets/99176494/115fdd53-cff7-406a-bc3d-d65d5199389f)
 
 3. Complete the required input fields:
 
-- **`deployment_name`**: Name your environment (Allowed characters: a-zA-Z0-9 and `-`). For instance: `john-8-7-2-June01`.
+    - **`deployment_name`**: Name your environment (Allowed characters: a-zA-Z0-9 and `-`). For
+      instance: `john-8-7-2-June01`.
 
-- **`ec-api-key`**: Elastic Cloud API Key. Refer to the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation to generate your token.
+    - **`ec-api-key`**: Elastic Cloud API Key. Refer to
+      the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation to
+      generate your token.
 
-- **`elk-stack-version`**: Specify the version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC) version. The default value is `8.8.0`. Check the available versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
+    - **`elk-stack-version`**: Specify the version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC)
+      version. The default value is `8.8.0`. Check the available
+      versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
 
-- **`ess-region`**: Indicate the Elastic Cloud deployment region. The default value is `gcp-us-west2`, which supports snapshot and build candidate (BC) versions. Specify a different region only if necessary.
+    - **`ess-region`**: Indicate the Elastic Cloud deployment region. The default value is `gcp-us-west2`, which
+      supports
+      snapshot and build candidate (BC) versions. Specify a different region only if necessary.
 
-![Enter Inputs](https://github.com/elastic/cloudbeat/assets/99176494/06d8144d-13cc-4e13-92fc-19f52ce8206b)
+   ![Enter Inputs](https://github.com/elastic/cloudbeat/assets/99176494/06d8144d-13cc-4e13-92fc-19f52ce8206b)
 
 4. Optionally, modify other input values if required:
 
-- `docker-image-override` (optional): Use this to replace the default Docker image for build candidate (BC) versions. Provide the full image path. Leave this field blank for snapshot versions. Follow this format for the image path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.8.1-9ac7eb02`.
+    - `docker-image-override` (optional): Use this to replace the default Docker image for build candidate (BC)
+      versions.
+      Provide the full image path. Leave this field blank for snapshot versions. Follow this format for the image
+      path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.8.1-9ac7eb02`.
 
-- `cleanup-env` (optional): Set to `true` if you want the resources to be cleaned up after provisioning. Default: `false`.
+    - `cleanup-env` (optional): Set to `true` if you want the resources to be cleaned up after provisioning.
+      Default: `false`.
 
-- `run-sanity-tests` (optional): Set to `true` to run sanity tests after the environment is set up. Default: `false`.
+    - `run-sanity-tests` (optional): Set to `true` to run sanity tests after the environment is set up. Default: `false`
+      .
 
-![Adjust Inputs](https://github.com/elastic/cloudbeat/assets/99176494/bac5004d-7cbc-4a34-8127-3acd11acc90e)
+   ![Adjust Inputs](https://github.com/elastic/cloudbeat/assets/99176494/bac5004d-7cbc-4a34-8127-3acd11acc90e)
 
 5. Click the `Run workflow` button to start.
 
-![Run Workflow](https://github.com/elastic/cloudbeat/assets/99176494/5e5131ba-264e-4444-8879-aa612d5de778)
+   ![Run Workflow](https://github.com/elastic/cloudbeat/assets/99176494/5e5131ba-264e-4444-8879-aa612d5de778)
 
 ## Tracking Workflow Execution
 
@@ -46,19 +60,19 @@ Monitor the progress of the workflow execution as follows:
 
 1. Click `Create Environment` for details.
 
-![Create Environment](https://github.com/elastic/cloudbeat/assets/99176494/abe8182d-4229-41bd-8604-ed5202d23574)
+   ![Create Environment](https://github.com/elastic/cloudbeat/assets/99176494/abe8182d-4229-41bd-8604-ed5202d23574)
 
 2. Click `Deploy`.
 
-![Deploy](https://github.com/elastic/cloudbeat/assets/99176494/230743cf-02ff-40cb-9069-d747b460824c)
+   ![Deploy](https://github.com/elastic/cloudbeat/assets/99176494/230743cf-02ff-40cb-9069-d747b460824c)
 
 3. Once the workflow execution finishes, click the `Summary` button to view the summary report.
 
-![Summary Report](https://github.com/elastic/cloudbeat/assets/99176494/7751d919-1605-4d07-9cfd-c98336051e3d)
+   ![Summary Report](https://github.com/elastic/cloudbeat/assets/99176494/7751d919-1605-4d07-9cfd-c98336051e3d)
 
 4. Review the details in the Summary.
 
-![Summary Details](https://github.com/elastic/cloudbeat/assets/99176494/1b41fba0-0ee5-4d37-b2f8-cdd6f632eadc)
+   ![Summary Details](https://github.com/elastic/cloudbeat/assets/99176494/1b41fba0-0ee5-4d37-b2f8-cdd6f632eadc)
 
 ## Logging into the Environment
 
@@ -66,15 +80,15 @@ Follow these steps to log in to the created environment:
 
 1. Click the `kibana` link.
 
-![Kibana Link](https://github.com/elastic/cloudbeat/assets/99176494/500351cf-6029-4bd5-bc6f-e6e046fbb73d)
+   ![Kibana Link](https://github.com/elastic/cloudbeat/assets/99176494/500351cf-6029-4bd5-bc6f-e6e046fbb73d)
 
 2. Select `Login with Elastic Cloud`.
 
-![Login](https://github.com/elastic/cloudbeat/assets/99176494/c3c1521e-e997-43ce-af76-b00aa0fa353a)
+   ![Login](https://github.com/elastic/cloudbeat/assets/99176494/c3c1521e-e997-43ce-af76-b00aa0fa353a)
 
 3. Choose the `Google` authentication method.
 
-![Google Authentication](https://github.com/elastic/cloudbeat/assets/99176494/f5209ed8-3bd7-420e-a3d1-cffb4c3711c9)
+   ![Google Authentication](https://github.com/elastic/cloudbeat/assets/99176494/f5209ed8-3bd7-420e-a3d1-cffb4c3711c9)
 
 4. In the Elastic Cloud dashboard, click `Open` next to the created environment.
 
@@ -82,9 +96,16 @@ Follow these steps to log in to the created environment:
 
 ## Cleanup Procedure
 
-If you wish to remove the provisioned infrastructure, set the `cleanup-env` input to `true` when initiating the workflow. The cleanup procedure will be executed at the end.
+If you wish to automatically delete the environment after the tests finish, set the `cleanup-env` input to `true`.
 
-In addition to the automatic cleanup, you can manually delete environments using the provided script [`delete_env.sh`](../deploy/test-environments/delete_env.sh). This script deletes all environments that match a given prefix.
+In addition to the automatic cleanup, you can manually delete environments using:
+
+```bash
+just delete-cloud-env <prefix> <ignore-prefix> <interactive>
+```
+
+This script deletes all environments that match a given prefix, and ignores environments that match a given ignore
+prefix.
 
 Before running the script, ensure that:
 
@@ -92,14 +113,5 @@ Before running the script, ensure that:
 - The Terraform CLI is installed and configured.
 - The `TF_VAR_ec_api_key` environment variable is set.
 
-The script usage is as follows:
-
-```bash
-./deploy/test-environments/delete_env.sh <prefix>
-```
-
-The above command will delete all environments that start with the prefix `<prefix>`.
-
-**Note**: The script will ask for confirmation before deleting each environment.
-
-The script fetches all environments starting with the provided prefix from the defined S3 bucket. After seeking your confirmation, it proceeds to destroy each Terraform environment and remove the related data from the S3 bucket. If the deletion is successful, the script lists the environments in the "Successfully deleted" section. In case of any issues, the environment's name is listed under "Failed to delete". Environments that you chose to skip will be listed under "Skipped deletion".
+**Note**: The script will ask for confirmation before deleting each environment, unless you set the `interactive` flag
+to `false`.

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -1,88 +1,85 @@
-# Cloud Enviorment Testing
+# Cloud Environment Testing
 
-[Create Environment](https://github.com/elastic/cloudbeat/actions/workflows/test-environment.yml) GitHub action deploys a complete cloud environment, preinstalled with all of our integrations, and also supports running sainty testing and auto-deletion.
+The [Create Environment](https://github.com/elastic/cloudbeat/actions/workflows/test-environment.yml) GitHub action deploys a full-featured cloud environment, pre-configured with all our integrations. It also includes features for running sanity testing and automated deletion.
 
-## Running the Workflow
+## How to Run the Workflow
 
-To run the workflow, perform the following steps:
+Follow these steps to run the workflow:
 
-1. Navigate to [`Actions > Create Environment`](https://github.com/elastic/cloudbeat/actions/workflows/test-environment.yml)
+1. Go to [`Actions > Create Environment`](https://github.com/elastic/cloudbeat/actions/workflows/test-environment.yml).
 
-![image](https://github.com/elastic/cloudbeat/assets/99176494/2686668f-7be6-4b55-a37b-e37426c1a0e1)
+![Navigate to Actions](https://github.com/elastic/cloudbeat/assets/99176494/2686668f-7be6-4b55-a37b-e37426c1a0e1)
 
-2. Click on the `Run workflow` button.
+2. Click the `Run workflow` button.
 
-![image](https://github.com/elastic/cloudbeat/assets/99176494/115fdd53-cff7-406a-bc3d-d65d5199389f)
+![Run Workflow](https://github.com/elastic/cloudbeat/assets/99176494/115fdd53-cff7-406a-bc3d-d65d5199389f)
 
-3. Fill in the required inputs:
+3. Complete the required input fields:
 
-- **`deployment_name`**: Name your environment (Only a-zA-Z0-9 and `-`). For example: `john-8-7-2-June01`.
+- **`deployment_name`**: Name your environment (Allowed characters: a-zA-Z0-9 and `-`). For instance: `john-8-7-2-June01`.
 
-- **`ec-api-key`**: Elastic Cloud API KEY. Follow the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for step-by-step instructions on generating the token.
+- **`ec-api-key`**: Elastic Cloud API Key. Refer to the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation to generate your token.
 
-- **`elk-stack-version`**: The version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC) version. The default value is `8.7.2-SNAPSHOT`. You can find the available versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
+- **`elk-stack-version`**: Specify the version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC) version. The default value is `8.8.0`. Check the available versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
 
-- **`ess-region`**: Elastic Cloud deployment region. By default, use the value `gcp-us-west2`, which includes snapshot versions and build candidate (BC) versions. Only specify a different region if there are specific requirements.
+- **`ess-region`**: Indicate the Elastic Cloud deployment region. The default value is `gcp-us-west2`, which supports snapshot and build candidate (BC) versions. Specify a different region only if necessary.
 
+![Enter Inputs](https://github.com/elastic/cloudbeat/assets/99176494/06d8144d-13cc-4e13-92fc-19f52ce8206b)
 
-![image](https://github.com/elastic/cloudbeat/assets/99176494/06d8144d-13cc-4e13-92fc-19f52ce8206b)
+4. Optionally, modify other input values if required:
 
-4. Optionally, adjust the other input values as needed.
+- `docker-image-override` (optional): Use this to replace the default Docker image for build candidate (BC) versions. Provide the full image path. Leave this field blank for snapshot versions. Follow this format for the image path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.8.1-9ac7eb02`.
 
-- `docker-image-override` (optional): To override the default Docker image for build candidate (BC) versions, provide the full image path. For snapshot versions, leave this field empty. The image path should follow this format: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.8.1-9ac7eb02`, where `8.8.1-9ac7eb02` should be replaced with the latest build candidate version.
+- `cleanup-env` (optional): Set to `true` if you want the resources to be cleaned up after provisioning. Default: `false`.
 
-- `cleanup-env` (optional): Boolean value to indicate if resources should be cleaned up after provision. Default: `false`.
+- `run-sanity-tests` (optional): Set to `true` to run sanity tests after the environment is set up. Default: `false`.
 
-- `run-sanity-tests` (optional): Boolean value to run the sanity tests after the environment is already up and running. Default: `false`.
+![Adjust Inputs](https://github.com/elastic/cloudbeat/assets/99176494/bac5004d-7cbc-4a34-8127-3acd11acc90e)
 
-![image](https://github.com/elastic/cloudbeat/assets/99176494/bac5004d-7cbc-4a34-8127-3acd11acc90e)
+5. Click the `Run workflow` button to start.
 
-5. Click on the `Run workflow`
+![Run Workflow](https://github.com/elastic/cloudbeat/assets/99176494/5e5131ba-264e-4444-8879-aa612d5de778)
 
-![image](https://github.com/elastic/cloudbeat/assets/99176494/5e5131ba-264e-4444-8879-aa612d5de778)
+## Tracking Workflow Execution
 
+Monitor the progress of the workflow execution as follows:
 
-### To track the execution of the workflow progress, follow these steps:
+1. Click `Create Environment` for details.
 
-1. Click on the `Create Environment` to access its details.
+![Create Environment](https://github.com/elastic/cloudbeat/assets/99176494/abe8182d-4229-41bd-8604-ed5202d23574)
 
-![image](https://github.com/elastic/cloudbeat/assets/99176494/abe8182d-4229-41bd-8604-ed5202d23574)
+2. Click `Deploy`.
 
+![Deploy](https://github.com/elastic/cloudbeat/assets/99176494/230743cf-02ff-40cb-9069-d747b460824c)
 
-2. Click on `Deploy`
+3. Once the workflow execution finishes, click the `Summary` button to view the summary report.
 
-![image](https://github.com/elastic/cloudbeat/assets/99176494/230743cf-02ff-40cb-9069-d747b460824c)
+![Summary Report](https://github.com/elastic/cloudbeat/assets/99176494/7751d919-1605-4d07-9cfd-c98336051e3d)
 
-3. Once the flow execution is complete, click the `Summary` button to get the summary report.
+4. Review the details in the Summary.
 
-![image](https://github.com/elastic/cloudbeat/assets/99176494/7751d919-1605-4d07-9cfd-c98336051e3d)
+![Summary Details](https://github.com/elastic/cloudbeat/assets/99176494/1b41fba0-0ee5-4d37-b2f8-cdd6f632eadc)
 
-4. Review Summary details
+## Logging into the Environment
 
-![image](https://github.com/elastic/cloudbeat/assets/99176494/1b41fba0-0ee5-4d37-b2f8-cdd6f632eadc)
+Follow these steps to log in to the created environment:
 
+1. Click the `kibana` link.
 
-### Environment Login Instructions
+![Kibana Link](https://github.com/elastic/cloudbeat/assets/99176494/500351cf-6029-4bd5-bc6f-e6e046fbb73d)
 
-To log in to the created environment, please follow these steps:
+2. Select `Login with Elastic Cloud`.
 
-1. Click on the `kibana` link.
-
-![image](https://github.com/elastic/cloudbeat/assets/99176494/500351cf-6029-4bd5-bc6f-e6e046fbb73d)
-
-2. Select the `Login with Elastic Cloud` option.
-
-![image](https://github.com/elastic/cloudbeat/assets/99176494/c3c1521e-e997-43ce-af76-b00aa0fa353a)
+![Login](https://github.com/elastic/cloudbeat/assets/99176494/c3c1521e-e997-43ce-af76-b00aa0fa353a)
 
 3. Choose the `Google` authentication method.
 
-![image](https://github.com/elastic/cloudbeat/assets/99176494/f5209ed8-3bd7-420e-a3d1-cffb4c3711c9)
+![Google Authentication](https://github.com/elastic/cloudbeat/assets/99176494/f5209ed8-3bd7-420e-a3d1-cffb4c3711c9)
 
-4. On the Elastic Cloud dashboard, click on `Open` next to the provisioned environment.
+4. In the Elastic Cloud dashboard, click `Open` next to the created environment.
 
-![image](https://github.com/elastic/cloudbeat/assets/99176494/b2bcf5f3-d463-4d2c-8073-8ef9183c9ada)
+![Open Environment](https://github.com/elastic/cloudbeat/assets/99176494/b2bcf5f3-d463-4d2c-8073-8ef9183c9ada)
 
+## Cleanup Procedure
 
-## Cleanup
-
-If you want to destroy the provisioned infrastructure, set the `cleanup-env` input to `true` when running the workflow. The cleanup step will be executed at the end.
+If you wish to remove the provisioned infrastructure, set the `cleanup-env` input to `true` when initiating the workflow. The cleanup procedure will be executed at the end.

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -83,3 +83,23 @@ Follow these steps to log in to the created environment:
 ## Cleanup Procedure
 
 If you wish to remove the provisioned infrastructure, set the `cleanup-env` input to `true` when initiating the workflow. The cleanup procedure will be executed at the end.
+
+In addition to the automatic cleanup, you can manually delete environments using the provided script [`delete_env.sh`](deploy/test-environments/delete_env.sh). This script deletes all environments that match a given prefix. 
+
+Before running the script, ensure that:
+
+- The AWS CLI is installed and configured.
+- The Terraform CLI is installed and configured.
+- The `TF_VAR_ec_api_key` environment variable is set.
+
+The script usage is as follows:
+
+```bash
+./deploy/test-environments/delete_env.sh <prefix>
+```
+
+The above command will delete all environments that start with the prefix `<prefix>`.
+
+**Note**: The script will ask for confirmation before deleting each environment.
+
+The script fetches all environments starting with the provided prefix from the defined S3 bucket. After seeking your confirmation, it proceeds to destroy each Terraform environment and remove the related data from the S3 bucket. If the deletion is successful, the script lists the environment in the "Successfully deleted" section. In case of any issues, the environment's name is listed under "Failed to delete". Environments that you chose to skip will be listed under "Skipped deletion".

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -1,37 +1,33 @@
-# Sanity Tests
+# Cloud Enviorment Testing
 
-This GitHub workflow deploys the environment, saves state and data, performs sanity checks, and provides an option to destroy the infrastructure.
+[Create Environment](https://github.com/elastic/cloudbeat/actions/workflows/test-environment.yml) GitHub action deploys a complete cloud environment, preinstalled with all of our integrations, and also supports running sainty testing and auto-deletion.
 
 ## Running the Workflow
 
 To run the workflow, perform the following steps:
 
-1. Click on the `Actions` tab in [Cloudbeat](https://github.com/elastic/cloudbeat) repository.
+1. Navigate to [`Actions > Create Environment`](https://github.com/elastic/cloudbeat/actions/workflows/test-environment.yml)
 
 ![image](https://github.com/elastic/cloudbeat/assets/99176494/2686668f-7be6-4b55-a37b-e37426c1a0e1)
 
-1. Select the `Create Environment` workflow. If the workflow is not visible, click on `Show more workflows...` link
-
-![image](https://github.com/elastic/cloudbeat/assets/99176494/f2e8ce8f-11f5-483d-b067-b24db3f58114)
-
-3. Click on the `Run workflow` button.
+2. Click on the `Run workflow` button.
 
 ![image](https://github.com/elastic/cloudbeat/assets/99176494/115fdd53-cff7-406a-bc3d-d65d5199389f)
 
-4. Fill in the required inputs: `deployment_name`, `ec-api-key`, `elk-stack-version`, `ess-region`.
+3. Fill in the required inputs:
 
-- `deployment_name` (required): Name your environment (Only a-zA-Z0-9 and `-`). For example: `john-8-7-2-June01`.
+- **`deployment_name`**: Name your environment (Only a-zA-Z0-9 and `-`). For example: `john-8-7-2-June01`.
 
-- `ec-api-key` (required): Elastic Cloud API KEY. Follow the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for step-by-step instructions on generating the token.
+- **`ec-api-key`**: Elastic Cloud API KEY. Follow the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for step-by-step instructions on generating the token.
 
-- `elk-stack-version` (required): The version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC) version. The default value is `8.7.2-SNAPSHOT`. You can find the available versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
+- **`elk-stack-version`**: The version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC) version. The default value is `8.7.2-SNAPSHOT`. You can find the available versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
 
-- `ess-region` (required): Elastic Cloud deployment region. By default, use the value `gcp-us-west2`, which includes snapshot versions and build candidate (BC) versions. Only specify a different region if there are specific requirements.
+- **`ess-region`**: Elastic Cloud deployment region. By default, use the value `gcp-us-west2`, which includes snapshot versions and build candidate (BC) versions. Only specify a different region if there are specific requirements.
 
 
 ![image](https://github.com/elastic/cloudbeat/assets/99176494/06d8144d-13cc-4e13-92fc-19f52ce8206b)
 
-5. Optionally, adjust the other input values as needed.
+4. Optionally, adjust the other input values as needed.
 
 - `docker-image-override` (optional): To override the default Docker image for build candidate (BC) versions, provide the full image path. For snapshot versions, leave this field empty. The image path should follow this format: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.8.1-9ac7eb02`, where `8.8.1-9ac7eb02` should be replaced with the latest build candidate version.
 
@@ -41,12 +37,12 @@ To run the workflow, perform the following steps:
 
 ![image](https://github.com/elastic/cloudbeat/assets/99176494/bac5004d-7cbc-4a34-8127-3acd11acc90e)
 
-6. Click on the `Run workflow`
+5. Click on the `Run workflow`
 
 ![image](https://github.com/elastic/cloudbeat/assets/99176494/5e5131ba-264e-4444-8879-aa612d5de778)
 
 
-### To track the execution of the Sanity flow, follow these steps:
+### To track the execution of the workflow progress, follow these steps:
 
 1. Click on the `Create Environment` to access its details.
 
@@ -57,7 +53,7 @@ To run the workflow, perform the following steps:
 
 ![image](https://github.com/elastic/cloudbeat/assets/99176494/230743cf-02ff-40cb-9069-d747b460824c)
 
-3. Once the flow execution is complete, click on the `Summary` button to get the summary report.
+3. Once the flow execution is complete, click the `Summary` button to get the summary report.
 
 ![image](https://github.com/elastic/cloudbeat/assets/99176494/7751d919-1605-4d07-9cfd-c98336051e3d)
 

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -84,7 +84,7 @@ Follow these steps to log in to the created environment:
 
 If you wish to remove the provisioned infrastructure, set the `cleanup-env` input to `true` when initiating the workflow. The cleanup procedure will be executed at the end.
 
-In addition to the automatic cleanup, you can manually delete environments using the provided script [`delete_env.sh`](deploy/test-environments/delete_env.sh). This script deletes all environments that match a given prefix. 
+In addition to the automatic cleanup, you can manually delete environments using the provided script [`delete_env.sh`](../deploy/test-environments/delete_env.sh). This script deletes all environments that match a given prefix.
 
 Before running the script, ensure that:
 
@@ -102,4 +102,4 @@ The above command will delete all environments that start with the prefix `<pref
 
 **Note**: The script will ask for confirmation before deleting each environment.
 
-The script fetches all environments starting with the provided prefix from the defined S3 bucket. After seeking your confirmation, it proceeds to destroy each Terraform environment and remove the related data from the S3 bucket. If the deletion is successful, the script lists the environment in the "Successfully deleted" section. In case of any issues, the environment's name is listed under "Failed to delete". Environments that you chose to skip will be listed under "Skipped deletion".
+The script fetches all environments starting with the provided prefix from the defined S3 bucket. After seeking your confirmation, it proceeds to destroy each Terraform environment and remove the related data from the S3 bucket. If the deletion is successful, the script lists the environments in the "Successfully deleted" section. In case of any issues, the environment's name is listed under "Failed to delete". Environments that you chose to skip will be listed under "Skipped deletion".

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -34,7 +34,7 @@ Follow these steps to run the workflow:
       supports
       snapshot and build candidate (BC) versions. Specify a different region only if necessary.
 
-![Enter Inputs](https://github.com/elastic/cloudbeat/assets/99176494/06d8144d-13cc-4e13-92fc-19f52ce8206b)
+   ![Enter Inputs](https://github.com/elastic/cloudbeat/assets/99176494/06d8144d-13cc-4e13-92fc-19f52ce8206b)
 
 4. Optionally, modify other input values if required:
 

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -21,9 +21,9 @@ Follow these steps to run the workflow:
     - **`deployment_name`**: Name your environment (Allowed characters: a-zA-Z0-9 and `-`). For
       instance: `john-8-7-2-June01`.
 
-    - **`ec-api-key`**: Elastic Cloud API Key. Refer to
-      the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation to
-      generate your token.
+    - `ec-api-key` (required): Use the [Production Elastic Cloud](https://cloud.elastic.co/home) API KEY. Follow
+      the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for
+      step-by-step instructions on generating the token.
 
     - **`elk-stack-version`**: Specify the version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC)
       version. The default value is `8.8.0`. Check the available
@@ -34,7 +34,7 @@ Follow these steps to run the workflow:
       supports
       snapshot and build candidate (BC) versions. Specify a different region only if necessary.
 
-   ![Enter Inputs](https://github.com/elastic/cloudbeat/assets/99176494/06d8144d-13cc-4e13-92fc-19f52ce8206b)
+![Enter Inputs](https://github.com/elastic/cloudbeat/assets/99176494/06d8144d-13cc-4e13-92fc-19f52ce8206b)
 
 4. Optionally, modify other input values if required:
 

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -47,7 +47,8 @@ Follow these steps to run the workflow:
       e.g. `elastic / unified-release - staging # 8.9 - 11 - 8.9.0-c6bb8f7a Success after 4 hr 58 min`. Now just copy it
       and replace it the image path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.9.0-c6bb8f7a`.
 
-    - `cleanup-env` (optional): Set to `true` if you want the resources to be cleaned up after provisioning.
+    - `cleanup-env` (optional): Set to `true` if you want the resources to automatically be cleaned up after
+      provisioning - useful if you don't want to test the env manually after deployment.
       Default: `false`.
 
     - `run-sanity-tests` (optional): Set to `true` to run sanity tests after the environment is set up. Default: `false`

--- a/justfile
+++ b/justfile
@@ -151,7 +151,7 @@ expose-ports:
   kubectl port-forward $CLOUDBEAT_POD -n kube-system 40000:40000 8080:8080
 
 
-delete-cloud-env prefix ignore-prefix interactive:
+delete-cloud-env prefix ignore-prefix="" interactive="true":
   # delete all cloud environments that start with {{prefix}} and do not start with {{ignore-prefix}}
   # ask for confirmation before deleting each environment: {{interactive}}
   cd deploy/test-environments && \

--- a/justfile
+++ b/justfile
@@ -156,7 +156,7 @@ delete-cloud-env prefix ignore-prefix="" interactive="true":
   # ask for confirmation before deleting each environment: {{interactive}}
   cd deploy/test-environments && \
   terraform init && \
-  pwd && ./delete_env.sh --prefix {{prefix}} --ignore-prefix {{ignore-prefix}} --interactive {{interactive}}
+  pwd && ./delete_env.sh --prefix {{prefix}} --ignore-prefix '{{ignore-prefix}}' --interactive {{interactive}}
 
 
 #### MOCKS #####

--- a/justfile
+++ b/justfile
@@ -114,7 +114,8 @@ create-eks-deployment-file:
 deploy-eks-cloudbeat:
   kubectl delete -k {{kustomizeEksOverlay}} -n kube-system & kubectl apply -k {{kustomizeEksOverlay}} -n kube-system
 
-#General
+
+#### GENERAL ####
 
 logs-cloudbeat:
   CLOUDBEAT_POD=$( kubectl get pods -o=name -n kube-system | grep -m 1 "cloudbeat" ) && \
@@ -149,6 +150,15 @@ expose-ports:
   CLOUDBEAT_POD=$( kubectl get pods -o=name -n kube-system | grep -m 1 "cloudbeat" ) && \
   kubectl port-forward $CLOUDBEAT_POD -n kube-system 40000:40000 8080:8080
 
+
+delete-cloud-env prefix ignore-prefix interactive:
+  # delete all cloud environments that start with {{prefix}} and do not start with {{ignore-prefix}}
+  # ask for confirmation before deleting each environment: {{interactive}}
+  cd deploy/test-environments && \
+  terraform init && \
+  pwd && ./delete_env.sh --prefix {{prefix}} --ignore-prefix {{ignore-prefix}} --interactive {{interactive}}
+
+
 #### MOCKS #####
 
 # generate new and update existing mocks from golang interfaces
@@ -164,13 +174,7 @@ validate-mocks:
 
 #### TESTS ####
 
-TEST_POD := 'test-pod-v1'
-
 TESTS_RELEASE := 'cloudbeat-test'
-TEST_LOGS_DIRECTORY := 'test-logs'
-POD_STATUS_UNKNOWN := 'Unknown'
-POD_STATUS_PENDING := 'Pending'
-POD_STATUS_RUNNING := 'Running'
 TIMEOUT := '1200s'
 TESTS_TIMEOUT := '60m'
 ELK_STACK_VERSION := env_var('ELK_VERSION')
@@ -213,61 +217,3 @@ cleanup-create-local-helm-cluster target range='..' $GOARCH=LOCAL_GOARCH: delete
   just load-cloudbeat-image
   just deploy-tests-helm {{target}} tests/deploy/values/ci.yml {{range}}
 
-
-test-pod-status:
-  #!/usr/bin/env sh
-
-  if [ ${STATUS=`kubectl get pod -n kube-system test-pod-v1 --template {{{{.status.phase}}`} ]; then
-    echo $STATUS
-  else
-    echo {{POD_STATUS_UNKNOWN}}
-  fi
-
-collect-logs target:
-  #!/usr/bin/env sh
-
-  echo 'Collecting logs for target {{target}}...'
-
-  LOG_FILE={{TEST_LOGS_DIRECTORY}}/{{target}}.log
-  LOG_FILE_TMP={{TEST_LOGS_DIRECTORY}}/{{target}}.log.tmp
-
-  mkdir -p {{TEST_LOGS_DIRECTORY}}
-  echo '' > $LOG_FILE
-
-  STATUS={{POD_STATUS_UNKNOWN}}
-  while [ $STATUS = {{POD_STATUS_UNKNOWN}} ] || [ $STATUS = {{POD_STATUS_PENDING}} ] || [ $STATUS = {{POD_STATUS_RUNNING}} ]; do
-    sleep 5
-
-    STATUS=`just test-pod-status`
-    if [ $STATUS = {{POD_STATUS_UNKNOWN}} ]; then
-      continue
-    fi
-
-    kubectl logs test-pod-v1 -n kube-system 2>&1 > $LOG_FILE_TMP
-
-    if [ `stat -c%s "${LOG_FILE_TMP}"` -gt `stat -c%s "${LOG_FILE}"` ]; then
-      cp $LOG_FILE_TMP $LOG_FILE
-      echo "Wrote logs to ${LOG_FILE}"
-    fi
-  done
-
-  rm $LOG_FILE_TMP
-  echo 'Done collecting logs for target {{target}}.'
-
-run-test-target target range='..':
-  echo 'Cleaning up cluster for running test target: {{target}}'
-  just cleanup-create-local-helm-cluster {{target}} {{range}}
-
-  echo 'Running test target: {{target}}'
-  just build-load-run-tests &
-
-
-run-test-targets range='..' +targets='file_system_rules k8s_object_rules process_api_server_rules process_controller_manager_rules process_etcd_rules process_kubelet_rules process_scheduler_rules':
-  #!/usr/bin/env sh
-
-  echo 'Running tests: {{targets}}'
-
-  for TARGET in {{targets}}; do
-    just run-test-target $TARGET {{range}}
-    just collect-logs $TARGET
-  done

--- a/tests/README.md
+++ b/tests/README.md
@@ -277,25 +277,6 @@ just load-pytest-kind
 
 ## Tests Execution
 
-Tests execution depends on the developers needs and currently this framework supports the following modes:
-
-1. Dev Mode - Writing test and executing tests on dev machine
-2. Integration Mode (Production) - Writing tests on dev machine, building test's docker image, and executing tests in
-   kubernetes cluster.
-
-### Dev Mode
-
-To run all test targets with just cloudbeat, without testing against Kibana or Elasticsearch, run
-
-```
-just run-test-targets
-```
-
-Note that this will create and destroy the test cluster several times. Logs can be found in the `test-logs` directory
-and test results can be found in `tests/allure/results`.
-
-----
-
 Before running tests verify that **System Under Test (SUT) Setup** is done and running.
 Since elasticsearch is deployed inside cluster, for reaching it from outside execute the following command:
 


### PR DESCRIPTION
### Summary of your changes
Updated the Cloud testing env workflow usage readme for:
- Clarity Improvements
- Recent changes docs updates
- Added information for the manual deletion script
- Cloud env name will be shown in github actions UI
- Improved cloud stack deletion script:
  - can run from any folder
  - wrapped by just command
  - interactive flow is togglable 
  
tested with `just delete-cloud-env "oren" "amir"`
![image](https://github.com/elastic/cloudbeat/assets/85433724/41276feb-cfdb-44aa-8b9f-bc3d798a8d9f)

and docs:
![image](https://github.com/elastic/cloudbeat/assets/85433724/f83bce11-5854-4301-98ce-3028a41687e0)
