### PR TITLE
Update ec-API-Key bullet in sanity workflow doc

### DIFF
--- a/dev-docs/sanity-workflow.md
+++ b/dev-docs/sanity-workflow.md
@@ -22,7 +22,7 @@ To run the workflow, perform the following steps:
 
 - `deployment_name` (required): Name your environment (Only a-zA-Z0-9 and `-`). For example: `john-8-7-2-June01`.
 
-- `ec-api-key` (required): Use the [*Production Elastic Cloud*](https://cloud.elastic.co/home) API KEY. Follow the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for step-by-step instructions on generating the token.
+- `ec-api-key` (required): Use the [Production Elastic Cloud](https://cloud.elastic.co/home) API KEY. Follow the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for step-by-step instructions on generating the token.
 
 - `elk-stack-version` (required): The version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC) version. The default value is `8.7.2-SNAPSHOT`. You can find the available versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
 

--- a/dev-docs/sanity-workflow.md
+++ b/dev-docs/sanity-workflow.md
@@ -22,7 +22,7 @@ To run the workflow, perform the following steps:
 
 - `deployment_name` (required): Name your environment (Only a-zA-Z0-9 and `-`). For example: `john-8-7-2-June01`.
 
-- `ec-api-key` (required): Elastic Cloud API KEY. Follow the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for step-by-step instructions on generating the token.
+- `ec-api-key` (required): Use the [*Production Elastic Cloud*](https://cloud.elastic.co/home) API KEY. Follow the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for step-by-step instructions on generating the token.
 
 - `elk-stack-version` (required): The version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC) version. The default value is `8.7.2-SNAPSHOT`. You can find the available versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
 


### PR DESCRIPTION
### Summary of your changes
I create a PR to specify which environment to create the API keys.  After I created workflows with  ec-stack API Keys from Elastic Cloud Staging. I received the error below.

![image (1)](https://github.com/elastic/cloudbeat/assets/17135495/ebbb6af7-e43f-4eb6-9eed-0a0d6aff6443)

I specify the correct Elastic Cloud environment with  a link 

### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary README/documentation (if appropriate)
