### PR TITLE
Fix CloudFormation deployment config file

### DIFF
--- a/deploy/cloudformation/README.md
+++ b/deploy/cloudformation/README.md
@@ -12,7 +12,7 @@ The EC2 instance has elastic-agent preinstalled in it using the fleet URL and en
 *Steps:*
 1. Install the Vulnerability Management integration on a new agent policy, you might have to check the "Display beta integrations" checkbox.
 2. After you installed the integration you can install a new elastic-agent, you should keep the fleet URL and the enrollment token.
-3. On cloudbeat repo, create a `deploy/cloudformation/.env` file of the form:
+3. On cloudbeat repo, create a `deploy/cloudformation/config.env` file of the form:
 ```
 STACK_NAME="<Unique stack name>" # john-qa-bc2-8-9-0-May28
 FLEET_URL="<Elastic Agent Fleet URL>"

--- a/deploy/cloudformation/config.go
+++ b/deploy/cloudformation/config.go
@@ -52,6 +52,7 @@ type devConfig struct {
 }
 
 func parseConfig() (*config, error) {
+	// Read in configuration from on of the files: config.json, config.yml or config.env
 	viper.AddConfigPath("./")
 	err := viper.ReadInConfig()
 	if err != nil {

--- a/deploy/cloudformation/config.go
+++ b/deploy/cloudformation/config.go
@@ -53,7 +53,6 @@ type devConfig struct {
 
 func parseConfig() (*config, error) {
 	viper.AddConfigPath("./")
-	viper.SetConfigFile(".env")
 	err := viper.ReadInConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read configuration: %v", err)


### PR DESCRIPTION
### Summary of your changes
The `just deploy-cloudformation` command uses a config file to get the deployment configuration.
The config file has recently changed from `.env` to `config.env` (or `config.json`, `config.yml`) and we want to keep it that way as the sanity job is dependent on that.

### Screenshots
![image](https://github.com/elastic/cloudbeat/assets/34831306/a7a6f779-b382-4c6e-a7c2-6f2de8f11d01)

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
