### PR TITLE
golangci-lint: Make order of imports deterministic

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,10 +7,12 @@ linters:
     - contextcheck
     - exhaustruct
     - exportloopref
+    - gci
     - gocyclo
-    - reassign
+    - gofmt
     - misspell
     - nolintlint
+    - reassign
     - unconvert
     - unparam
     - whitespace
@@ -19,6 +21,20 @@ linters:
 #    - revive
 
 linters-settings:
+  gci:
+    # Section configuration to compare against.
+    # Section names are case-insensitive and may contain parameters in ().
+    # The default order of sections is `standard > default > custom > blank > dot`,
+    # If `custom-order` is `true`, it follows the order of `sections` option.
+    # Default: ["standard", "default"]
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/elastic/cloudbeat) # Custom section: groups all imports with the specified Prefix.
+    skip-generated: true
+    # Enable custom order of sections.
+    # If `true`, make the section order the same as the order of `sections`.
+    custom-order: false
   govet:
     settings:
       printf:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,9 +25,6 @@ repos:
   - repo: https://github.com/dnephin/pre-commit-golang
     rev: v0.5.1
     hooks:
-      - id: go-imports
-        args: [-local, "github.com/elastic/cloudbeat"]
-        exclude: 'mock_.*\.go'
       - id: golangci-lint
 
   ## Python

--- a/flavors/benchmark/gcp.go
+++ b/flavors/benchmark/gcp.go
@@ -29,7 +29,6 @@ import (
 	"github.com/elastic/cloudbeat/resources/fetching"
 	"github.com/elastic/cloudbeat/resources/fetching/factory"
 	"github.com/elastic/cloudbeat/resources/fetching/registry"
-
 	gcplib "github.com/elastic/cloudbeat/resources/providers/gcplib/auth"
 )
 

--- a/resources/fetching/fetchers/gcp/assets_fetcher.go
+++ b/resources/fetching/fetchers/gcp/assets_fetcher.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/huandu/xstrings"
-
 	"cloud.google.com/go/asset/apiv1/assetpb"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/huandu/xstrings"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib/inventory"

--- a/resources/providers/gcplib/inventory/provider.go
+++ b/resources/providers/gcplib/inventory/provider.go
@@ -22,12 +22,11 @@ import (
 	"fmt"
 	"sync"
 
+	asset "cloud.google.com/go/asset/apiv1"
+	"cloud.google.com/go/asset/apiv1/assetpb"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/iterator"
-
-	asset "cloud.google.com/go/asset/apiv1"
-	"cloud.google.com/go/asset/apiv1/assetpb"
 
 	gcplib "github.com/elastic/cloudbeat/resources/providers/gcplib/auth"
 )

--- a/resources/providers/gcplib/inventory/provider_test.go
+++ b/resources/providers/gcplib/inventory/provider_test.go
@@ -25,11 +25,10 @@ import (
 	iampb "cloud.google.com/go/iam/apiv1/iampb"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/googleapis/gax-go/v2"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
-
-	"github.com/samber/lo"
 
 	gcplib "github.com/elastic/cloudbeat/resources/providers/gcplib/auth"
 )

--- a/vulnerability/events_creator_test.go
+++ b/vulnerability/events_creator_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/cloudbeat/dataprovider"
-
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 


### PR DESCRIPTION
### Summary of your changes

Replaces goimports with gci: https://github.com/daixiang0/gci