### PR TITLE
Make CollectResourcesWithTimeout less flaky

### DIFF
--- a/resources/fetching/factory/aws_factory_test.go
+++ b/resources/fetching/factory/aws_factory_test.go
@@ -92,13 +92,21 @@ func subtest(t *testing.T, drain bool) {
 	assert.Lenf(t, fetcherMap, nFetchers*nAccounts, "Correct amount of fetchers")
 
 	if drain {
-		resources := testhelper.CollectResourcesWithTimeout(rootCh, 10*time.Millisecond)
+		expectedResources := nAccounts * resourcesPerAccount
+		resources := testhelper.CollectResourcesWithTimeout(rootCh, expectedResources, 1*time.Second)
 		assert.Lenf(
 			t,
 			resources,
-			nAccounts*resourcesPerAccount,
+			expectedResources,
 			"Correct amount of resources fetched",
 		)
+		defer func() {
+			assert.Emptyf(
+				t,
+				testhelper.CollectResourcesWithTimeout(rootCh, 1, 100*time.Millisecond),
+				"Channel not drained",
+			)
+		}()
 
 		nameCounts := make(map[string]int)
 		for _, resource := range resources {

--- a/resources/utils/testhelper/helper.go
+++ b/resources/utils/testhelper/helper.go
@@ -47,9 +47,13 @@ func CollectResources[T any](ch chan T) []T {
 
 // CollectResourcesWithTimeout fetches items from a channel and returns them in a slice after no elements have been
 // received for the specified timeout duration.
-func CollectResourcesWithTimeout[T any](ch chan T, timeout time.Duration) []T {
+func CollectResourcesWithTimeout[T any](ch chan T, maxCount int, timeout time.Duration) []T {
 	var results []T
 	for {
+		if len(results) >= maxCount {
+			return results
+		}
+
 		select {
 		case value, ok := <-ch:
 			if !ok {


### PR DESCRIPTION
`TestNewCisAwsOrganizationFactory_Leak` has failed in many CI pipelines