### PR TITLE
[AWS Orgs] Replace underscore in configuration with hyphen

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -75,8 +75,8 @@ type GcpClientOpt struct {
 }
 
 const (
-	SingleAccount       = "single_account"
-	OrganizationAccount = "organization_account"
+	SingleAccount       = "single-account"
+	OrganizationAccount = "organization-account"
 )
 
 func New(cfg *config.C) (*Config, error) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -64,7 +64,7 @@ config:
   v1:
     benchmark: cis_eks
     aws:
-      account_type: organization_account
+      account_type: organization-account
       credentials:
         access_key_id: key
         secret_access_key: secret
@@ -84,7 +84,7 @@ config:
 						ProfileName:          "credential_profile_name",
 						RoleArn:              "role_arn",
 					},
-					AccountType: "organization_account",
+					AccountType: "organization-account",
 				},
 			},
 			3,

--- a/flavors/benchmark/benchmark_test.go
+++ b/flavors/benchmark/benchmark_test.go
@@ -93,7 +93,7 @@ func TestNewBenchmark(t *testing.T) {
 						Cred: aws.ConfigAWS{
 							AccessKeyID: "test",
 						},
-						AccountType: "organization_account",
+						AccountType: "organization-account",
 					},
 				},
 			},


### PR DESCRIPTION
### Summary of your changes
As discussed with @JordanSh, for consistency with the url in the integration: https://github.com/elastic/cloudbeat/blob/25057a13ee224e9a220a53693ab1cdc1cf6ecf5f/.github/workflows/publish-cloudformation.yml#L37

# Related issues
- https://github.com/elastic/cloudbeat/issues/1036
- https://github.com/elastic/kibana/pull/162571