### PR TITLE
Fix race condition in repeater unit test

### DIFF
--- a/flavors/repeater_test.go
+++ b/flavors/repeater_test.go
@@ -95,10 +95,11 @@ func TestRepeater_Run(t *testing.T) {
 		},
 		{
 			name:       "Context canceled",
-			interval:   100 * time.Millisecond,
-			ctxTimeout: 0 * time.Millisecond,
+			interval:   500 * time.Millisecond,
+			ctxTimeout: 100 * time.Millisecond,
 			fnMock: func(t *testing.T) *MockRepeaterFunc {
 				m := NewMockRepeaterFunc(t)
+				m.EXPECT().Execute().Return(nil).Once()
 				return m
 			},
 			expectedErrMsg: "",


### PR DESCRIPTION
### Summary of your changes
Fix race condition in test case, `ctx.Done()` and `immediate` are racing on who will be called first.

Evidence: 
- https://github.com/elastic/cloudbeat/actions/runs/5715372736/job/15484534048?pr=1172

### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
