### PR TITLE
Update GCP's ECS fields

### DIFF
--- a/dataprovider/providers/cloud/data_provider.go
+++ b/dataprovider/providers/cloud/data_provider.go
@@ -32,16 +32,12 @@ const (
 	cloudAccountNameField = "cloud.account.name"
 	cloudProviderField    = "cloud.provider"
 	cloudRegionField      = "cloud.region"
-	cloudProjectIdField   = "cloud.project.id"
-	cloudProjectNameField = "cloud.project.name"
 )
 
 type Identity struct {
 	Provider     string
 	Account      string
 	AccountAlias string
-	ProjectId    string
-	ProjectName  string
 }
 
 type DataProvider struct {
@@ -49,8 +45,6 @@ type DataProvider struct {
 	accountId    string
 	accountName  string
 	providerName string
-	projectName  string
-	projectId    string
 }
 
 func NewDataProvider(options ...Option) DataProvider {
@@ -88,16 +82,6 @@ func (a DataProvider) EnrichEvent(event *beat.Event, resMetadata fetching.Resour
 	}
 
 	err = insertIfNotEmpty(cloudRegionField, resMetadata.Region, event)
-	if err != nil {
-		return err
-	}
-
-	err = insertIfNotEmpty(cloudProjectIdField, a.projectId, event)
-	if err != nil {
-		return err
-	}
-
-	err = insertIfNotEmpty(cloudProjectNameField, a.projectName, event)
 	if err != nil {
 		return err
 	}

--- a/dataprovider/providers/cloud/data_provider_test.go
+++ b/dataprovider/providers/cloud/data_provider_test.go
@@ -164,15 +164,15 @@ func TestDataProvider_EnrichEvent(t *testing.T) {
 				Region: someRegion,
 			},
 			identity: Identity{
-				Provider:    gcpProvider,
-				ProjectId:   gcpProjectId,
-				ProjectName: gcpProjectName,
+				Provider:     gcpProvider,
+				Account:      gcpProjectId,
+				AccountAlias: gcpProjectName,
 			},
 			expectedFields: map[string]string{
 				cloudProviderField:    gcpProvider,
 				cloudRegionField:      someRegion,
-				cloudProjectIdField:   gcpProjectId,
-				cloudProjectNameField: gcpProjectName,
+				cloudAccountIdField:   gcpProjectId,
+				cloudAccountNameField: gcpProjectName,
 			},
 		},
 	}

--- a/dataprovider/providers/cloud/option.go
+++ b/dataprovider/providers/cloud/option.go
@@ -34,7 +34,5 @@ func WithAccount(identity Identity) Option {
 		dp.accountId = identity.Account
 		dp.accountName = identity.AccountAlias
 		dp.providerName = identity.Provider
-		dp.projectId = identity.ProjectId
-		dp.projectName = identity.ProjectName
 	}
 }

--- a/flavors/benchmark/gcp_test.go
+++ b/flavors/benchmark/gcp_test.go
@@ -148,9 +148,9 @@ func mockGcpIdentityProvider(err error) *identity.MockProviderGetter {
 	if err == nil {
 		on.Return(
 			&cloud.Identity{
-				Provider:    "gcp",
-				ProjectId:   "test-project-id",
-				ProjectName: "test-project-name",
+				Provider:     "gcp",
+				Account:      "test-project-id",
+				AccountAlias: "test-project-name",
 			},
 			nil,
 		)

--- a/resources/providers/gcplib/identity/identity_provider.go
+++ b/resources/providers/gcplib/identity/identity_provider.go
@@ -59,9 +59,9 @@ func (p *Provider) GetIdentity(ctx context.Context, factoryConfig *auth.GcpFacto
 	}
 
 	return &cloud.Identity{
-		Provider:    provider,
-		ProjectId:   proj.ProjectId,
-		ProjectName: proj.DisplayName,
+		Provider:     provider,
+		Account:      proj.ProjectId,
+		AccountAlias: proj.DisplayName,
 	}, nil
 }
 

--- a/resources/providers/gcplib/identity/identity_provider_test.go
+++ b/resources/providers/gcplib/identity/identity_provider_test.go
@@ -58,9 +58,9 @@ func TestIdentityProvider_GetIdentity(t *testing.T) {
 				return &m
 			},
 			want: &cloud.Identity{
-				Provider:    "gcp",
-				ProjectId:   "test-proj",
-				ProjectName: "my proj",
+				Provider:     "gcp",
+				Account:      "test-proj",
+				AccountAlias: "my proj",
 			},
 		},
 	}


### PR DESCRIPTION
### Summary of your changes
Assign GCP fields to `cloud.account.id` and `cloud.account.name` to align with AWS CSPM. 
We communicate with the ECS team to modify and extend the cloud schema in the future

### Screenshot/Data
<img width="475" alt="Screenshot 2023-08-01 at 12 29 18" src="https://github.com/elastic/cloudbeat/assets/68195305/02f11c1e-f2e4-4dd8-bdd9-c457999b0bdc">



### Related Issues
- Related: https://github.com/elastic/cloudbeat/issues/1120

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
