### PR TITLE
[GCP] Add api key asset type

### DIFF
--- a/resources/fetching/fetchers/gcp/assets_fetcher.go
+++ b/resources/fetching/fetchers/gcp/assets_fetcher.go
@@ -43,11 +43,13 @@ type GcpAsset struct {
 	Asset *assetpb.Asset `json:"asset,omitempty"`
 }
 
+// https://cloud.google.com/asset-inventory/docs/supported-asset-types
 // map of types to asset types.
 // sub-type is derived from asset type by using the first and last segments of the asset type name
 // example: gcp-cloudkms-crypto-key
 var GcpAssetTypes = map[string][]string{
 	fetching.KeyManagement: {
+		"apikeys.googleapis.com/Key",
 		"cloudkms.googleapis.com/CryptoKey",
 	},
 	fetching.CloudIdentity: {


### PR DESCRIPTION
### Summary of your changes

this adds an asset type to the assets map (required for rule 1.12)

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
- https://github.com/elastic/security-team/issues/6179)

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
