### PR TITLE
Posture use publisher component

### DIFF
--- a/flavors/client.go
+++ b/flavors/client.go
@@ -23,7 +23,7 @@ import (
 )
 
 func NewClient(pipeline beat.Pipeline, processorsList processors.PluginConfig) (beat.Client, error) {
-	procs, err := ConfigureProcessors(processorsList)
+	procs, err := configureProcessors(processorsList)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func NewClient(pipeline beat.Pipeline, processorsList processors.PluginConfig) (
 	})
 }
 
-// ConfigureProcessors configure processors to be used by the beat
-func ConfigureProcessors(processorsList processors.PluginConfig) (procs *processors.Processors, err error) {
+// configureProcessors configure processors to be used by the beat
+func configureProcessors(processorsList processors.PluginConfig) (procs *processors.Processors, err error) {
 	return processors.New(processorsList)
 }


### PR DESCRIPTION
### Summary of your changes
`publisher` component buffers events and send them altogether to elasticsearch.
Same as the vulnerability flavor, posture can use the same component and keep our code DRY.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
https://github.com/elastic/cloudbeat/pull/1142

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
