### PR TITLE
Switching trigger for the CNVM workflow

### DIFF
--- a/.github/workflows/cnvm-ci.yml
+++ b/.github/workflows/cnvm-ci.yml
@@ -1,4 +1,5 @@
 name: CNVM-CI
+
 permissions:
   id-token: write
   contents: read
@@ -33,7 +34,7 @@ jobs:
           poetry --version
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2.1.0
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/cnvm-ci.yml
+++ b/.github/workflows/cnvm-ci.yml
@@ -1,9 +1,5 @@
 name: CNVM-CI
 
-permissions:
-  id-token: write
-  contents: read
-
 on:
   pull_request_target:
     branches:

--- a/.github/workflows/cnvm-ci.yml
+++ b/.github/workflows/cnvm-ci.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - "[0-9]+.[0-9]+"

--- a/.github/workflows/destroy-environment.yml
+++ b/.github/workflows/destroy-environment.yml
@@ -43,7 +43,7 @@ jobs:
           echo "TF_VAR_ec_api_key=$ec_api_key" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/eks-ci.yml
+++ b/.github/workflows/eks-ci.yml
@@ -136,7 +136,7 @@ jobs:
           key: ${{ runner.os }}-dockers-cache-${{ env.CONTAINER_SUFFIX }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish-cloudformation.yml
+++ b/.github/workflows/publish-cloudformation.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.CSPM_CFT_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.CSPM_CFT_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -72,7 +72,7 @@ jobs:
           ignoreMissingResults: true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2.1.0
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -89,7 +89,7 @@ jobs:
           poetry install
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ env.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
### Summary of your changes
switching to `pull_request_target` trigger instead of `pull_request` since PRs with `pull_request` from public forks [don't have the right permission](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).

![image](https://github.com/elastic/cloudbeat/assets/85433724/f67347f2-468f-4054-bae2-16740c539119)


