### PR TITLE
Add publish_cft script as a publish trigger

### DIFF
--- a/.github/workflows/publish-cloudformation.yml
+++ b/.github/workflows/publish-cloudformation.yml
@@ -7,6 +7,7 @@ on:
       - "[0-9]+.[0-9]+"
     paths:
       - deploy/cloudformation/*.yml
+      - scripts/publish_cft.sh
       - .github/workflows/publish-cloudformation.yml
 
 jobs:


### PR DESCRIPTION
### Summary of your changes
When `scripts/publish_cft.sh` has changed, we should publish a new S3 CloudFormation template

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/1132

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
