### PR TITLE
CloudFormation templates have identical signature

### DIFF
--- a/.github/workflows/publish-cloudformation.yml
+++ b/.github/workflows/publish-cloudformation.yml
@@ -25,11 +25,14 @@ jobs:
 
       - name: Upload to S3 if elastic-agent CloudFormation template has changed
         run: |
-          CNVM_FILENAME="cloudformation-cnvm-VERSION-DATE.yml"
+          DATE=$(date +"%Y-%m-%d-%H-%M-%S")
+          VERSION=$(grep defaultBeatVersion version/version.go | cut -f2 -d "\"")
+
+          CNVM_FILENAME="cloudformation-cnvm-$VERSION-$DATE.yml"
           ./scripts/publish_cft.sh deploy/cloudformation/elastic-agent-ec2-cnvm.yml $CNVM_FILENAME
 
-          CSPM_FILENAME="cloudformation-cspm-single-account-VERSION-DATE.yml"
+          CSPM_FILENAME="cloudformation-cspm-single-account-$VERSION-$DATE.yml"
           ./scripts/publish_cft.sh deploy/cloudformation/elastic-agent-ec2-cspm.yml $CSPM_FILENAME
 
-          CSPM_ORG_FILENAME="cloudformation-cspm-organization-account-VERSION-DATE.yml"
+          CSPM_ORG_FILENAME="cloudformation-cspm-organization-account-$VERSION-$DATE.yml"
           ./scripts/publish_cft.sh deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml $CSPM_ORG_FILENAME

--- a/scripts/publish_cft.sh
+++ b/scripts/publish_cft.sh
@@ -2,8 +2,7 @@
 
 function usage() {
   cat <<EOF
-Usage: $0 <local-file> <file-pattern>
-Create a concrete remote file name from the pattern.
+Usage: $0 <local-file> <remote-file>
 Replace CFT_VERSION with the remote file name.
 Upload the local file to the remote file name.
 
@@ -11,17 +10,12 @@ EOF
 }
 
 LOCAL_FILE=$1
-FILEPATTERN=$2
+REMOTE_FILE=$2
 : "${LOCAL_FILE:?$(echo "Missing local file" && usage && exit 1)}"
-: "${FILEPATTERN:?$(echo "Missing file pattern" && usage && exit 1)}"
+: "${REMOTE_FILE:?$(echo "Missing remote file" && usage && exit 1)}"
 
-VERSION=$(grep defaultBeatVersion version/version.go | cut -f2 -d "\"")
-DATE=$(date +"%Y-%m-%d-%H-%M-%S")
-FILEPATTERN=${FILEPATTERN/VERSION/$VERSION}
-FILEPATTERN=${FILEPATTERN/DATE/$DATE}
+sed --in-place'' s/CFT_VERSION/$REMOTE_FILE/g $LOCAL_FILE
 
-sed --in-place'' s/CFT_VERSION/$FILEPATTERN/g $LOCAL_FILE
-
-REMOTE_FILE="s3://elastic-cspm-cft/$FILEPATTERN"
-echo "Uploading $LOCAL_FILE to $REMOTE_FILE"
-aws s3 cp $LOCAL_FILE $REMOTE_FILE
+S3_FILE="s3://elastic-cspm-cft/$REMOTE_FILE"
+echo "Uploading $LOCAL_FILE to $S3_FILE"
+aws s3 cp $LOCAL_FILE $S3_FILE

--- a/scripts/publish_cft.sh
+++ b/scripts/publish_cft.sh
@@ -3,8 +3,8 @@
 function usage() {
   cat <<EOF
 Usage: $0 <local-file> <remote-file>
-Replace CFT_VERSION with the remote file name.
-Upload the local file to the remote file name.
+Replace the CFT_VERSION placeholder in the local-file.
+Upload the local-file to S3 with the remote-file name.
 
 EOF
 }


### PR DESCRIPTION
### Summary of your changes
Because of a limitation in the `cloud_security_posutre` integration, all CloudFormation templates should have an identical signature (version + date).


### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/1132

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
