### PR TITLE
[AWS Orgs] CloudFormation: Add more read permissions

### DIFF
--- a/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
@@ -86,7 +86,8 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - organizations:ListAccounts
+                  - organizations:List*
+                  - organizations:Describe*
                 Resource: '*'
               - Effect: Allow
                 Action:


### PR DESCRIPTION
### Summary of your changes

This will future-proof our CloudFormation template for future changes like #1177 and #1214 that will require more permissions in the organization level. After merging those, newer CloudFormation templates can trim down the required permissions again.