### PR TITLE
CNVM CI remove pull_request_target trigger

### DIFF
--- a/.github/workflows/cnvm-ci.yml
+++ b/.github/workflows/cnvm-ci.yml
@@ -29,13 +29,6 @@ jobs:
           curl -sSL https://install.python-poetry.org | python3 -
           poetry --version
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: 'us-east-2'
-
       - name: Build cloudbeat binary
         uses: magefile/mage-action@v2
         with:
@@ -53,6 +46,9 @@ jobs:
           ES_HOST: http://localhost:9200
           ES_USERNAME: elastic
           ES_PASSWORD: changeme
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-2
         run: |
           ./cloudbeat -c deploy/vulnerability/cloudbeat-vuln-mgmt.yml -d '*' &
 

--- a/.github/workflows/cnvm-ci.yml
+++ b/.github/workflows/cnvm-ci.yml
@@ -1,7 +1,7 @@
 name: CNVM-CI
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - "[0-9]+.[0-9]+"

--- a/.github/workflows/cnvm-ci.yml
+++ b/.github/workflows/cnvm-ci.yml
@@ -46,8 +46,8 @@ jobs:
           ES_HOST: http://localhost:9200
           ES_USERNAME: elastic
           ES_PASSWORD: changeme
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_TEST_ACC }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST_ACC }}
           AWS_REGION: us-east-2
         run: |
           ./cloudbeat -c deploy/vulnerability/cloudbeat-vuln-mgmt.yml -d '*' &


### PR DESCRIPTION
### Summary of your changes
CNVM CI - Change trigger from `pull_request_target` to `pull_request`.
`pull_request` trigger doesn't have write secret permissions which is being used by `aws-actions/configure-aws-credentials`.
As part of this PR we also remove this action and use environment variables instead.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
