### PR TITLE
[Create Environment] Add deployment name validation

### DIFF
--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -61,6 +61,13 @@ jobs:
       STACK_VERSION: ${{ github.event.inputs.elk-stack-version }}
       CNVM_STACK_NAME: "${{ github.event.inputs.deployment_name }}-cnvm-sanity-test-stack"
     steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Init Hermit
+        run: ./bin/hermit env -r >> $GITHUB_ENV
+        working-directory: ./
+
       - name: Check Deployment Name
         run: |
           deployment_name="${{ github.event.inputs.deployment_name }}"
@@ -76,13 +83,6 @@ jobs:
             echo "error: Deployment name doesn't match the required pattern"
             exit 1
           fi
-
-      - name: Check out the repo
-        uses: actions/checkout@v3
-
-      - name: Init Hermit
-        run: ./bin/hermit env -r >> $GITHUB_ENV
-        working-directory: ./
 
       - name: Mask API Key
         run: |

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -10,6 +10,8 @@ on:
         description: |
           Name your environment (Only a-zA-Z0-9 and `-`).
           For example: john-8-7-2-June01'
+          Supported pattern: [a-zA-Z][-a-zA-Z0-9]*
+          Max chars: 20
         required: true
       ec-api-key:
         type: string
@@ -59,6 +61,22 @@ jobs:
       STACK_VERSION: ${{ github.event.inputs.elk-stack-version }}
       CNVM_STACK_NAME: "${{ github.event.inputs.deployment_name }}-cnvm-sanity-test-stack"
     steps:
+      - name: Check Deployment Name
+        run: |
+          deployment_name="${{ github.event.inputs.deployment_name }}"
+
+          # Check length
+          if [ ${#deployment_name} -gt 20 ]; then
+            echo "error: Deployment name is too long (max 20 characters)"
+            exit 1
+          fi
+
+          # Check pattern required for CNVM deployment
+          if ! [[ $deployment_name =~ ^[a-zA-Z][-a-zA-Z0-9]*$ ]]; then
+            echo "error: Deployment name doesn't match the required pattern"
+            exit 1
+          fi
+
       - name: Check out the repo
         uses: actions/checkout@v3
 

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -80,7 +80,7 @@ jobs:
 
           # Check pattern required for CNVM deployment
           if ! [[ $deployment_name =~ ^[a-zA-Z][-a-zA-Z0-9]*$ ]]; then
-            echo "error: Deployment name doesn't match the required pattern"
+            echo "error: Deployment name doesn't match the required pattern [a-zA-Z][-a-zA-Z0-9]*"
             exit 1
           fi
 


### PR DESCRIPTION
### Summary of your changes

This PR introduces a new GitHub workflow action called "Check Deployment Name" to ensure the validity of deployment names. The action performs two critical checks:

- **Length Check**: It verifies that the deployment name is not longer than 20 characters, as this is the maximum allowed length.

- **Pattern Check**: It ensures that the deployment name adheres to the required pattern, which should start with a letter (a-z or A-Z) and can include letters, numbers, and hyphens.

This action is an important step in maintaining naming conventions and ensuring that deployment names align with our standards, particularly for CNVM deployments.

### Screenshot/Data

#### Documentation

![Documentation](https://github.com/elastic/cloudbeat/assets/99176494/b05a6958-d5bf-40e0-9e67-3eb91fb5465a)

#### Length Check

![Lenght Check](https://github.com/elastic/cloudbeat/assets/99176494/dabff50a-d36b-4837-a298-be1cfb0b829d)

#### CNVM pattern check failure

![Pattern Check](https://github.com/elastic/cloudbeat/assets/99176494/0088b753-33f3-412d-8806-58dc8e87d9a0)





### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
