### PR TITLE
[AWS Orgs] CloudFormation: Validate OrganizationalUnitIds

### DIFF
--- a/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
@@ -9,7 +9,7 @@ Parameters:
       Specify the unique IDs of the organizational units where the roles should be deployed.
       Example: ou-abc123,ou-def456,ou-ghi789
     Type: CommaDelimitedList
-    AllowedPattern: .+
+    AllowedPattern: ^(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32}|r-[0-9a-z]{4,32})$
 
   LatestAmiId:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>


### PR DESCRIPTION
### Summary of your changes

Validate that the `OrganizationalUnitIds` parameter is as expected

From the AWS docs:
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
> A regular expression that represents the patterns to allow for String
> or CommaDelimitedList types. When applied on a parameter of type
> String, the pattern must match the entire parameter value provided.
> When applied to a parameter of type CommaDelimitedList, the pattern
> must match each value in the list.

So, we are allowed to use it in a CommaDelimitedList

Sources for regex patterns:
- https://docs.aws.amazon.com/organizations/latest/APIReference/API_OrganizationalUnit.html
- https://docs.aws.amazon.com/organizations/latest/APIReference/API_Root.html

<!--
Please provide a detailed description of the changes introduced by this Pull Request.
Provide a description of the main changes, as well as any additional information the code reviewer should be aware of before beginning the review process.
-->

### Related Issues
- Related: https://github.com/elastic/cloudbeat/issues/1265

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary README/documentation (if appropriate)
