### PR TITLE
Populate vulnerability.reference with a link to NVD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ terraform.rc
 # Vulnerability management
 db/
 fanal/
+java-db/

--- a/vulnerability/events_creator.go
+++ b/vulnerability/events_creator.go
@@ -322,7 +322,7 @@ func (e EventsCreator) generateEvent(reportResult trivyTypes.Result, vul trivyTy
 				ID:             vul.VulnerabilityID,
 				Title:          vul.Title,
 				Enumeration:    getIdentifierType(vul.VulnerabilityID),
-				Reference:      vul.PrimaryURL,
+				Reference:      getReference(vul),
 				Description:    vul.Description,
 				Severity:       vul.Severity,
 				Classification: vulScoreSystemClass,
@@ -389,6 +389,20 @@ func (e EventsCreator) getCVSSScore(vul trivyTypes.DetectedVulnerability) float6
 
 	e.log.Debugf("No CVSS v3 score found for vulnerability: %s, fallback to v2", vul.VulnerabilityID)
 	return getCVSSValue(vul, func(cvss dbTypes.CVSS) float64 { return cvss.V2Score }, zeroVal)
+}
+
+const NVDVulnDetailBaseURL = "https://nvd.nist.gov/vuln/detail/"
+
+func getReference(vul trivyTypes.DetectedVulnerability) string {
+	if vul.CVSS == nil {
+		return vul.PrimaryURL
+	}
+
+	if _, ok := vul.CVSS[trivyVul.NVD]; ok {
+		return fmt.Sprintf("%s%s", NVDVulnDetailBaseURL, vul.VulnerabilityID)
+	}
+
+	return vul.PrimaryURL
 }
 
 func getCVSSValue[T comparable](vul trivyTypes.DetectedVulnerability, value func(cvss dbTypes.CVSS) T, zeroVal T) T {

--- a/vulnerability/events_creator.go
+++ b/vulnerability/events_creator.go
@@ -394,15 +394,11 @@ func (e EventsCreator) getCVSSScore(vul trivyTypes.DetectedVulnerability) float6
 const NVDVulnDetailBaseURL = "https://nvd.nist.gov/vuln/detail/"
 
 func getReference(vul trivyTypes.DetectedVulnerability) string {
-	if vul.CVSS == nil {
+	if _, ok := vul.CVSS[trivyVul.NVD]; !ok {
 		return vul.PrimaryURL
 	}
 
-	if _, ok := vul.CVSS[trivyVul.NVD]; ok {
-		return fmt.Sprintf("%s%s", NVDVulnDetailBaseURL, vul.VulnerabilityID)
-	}
-
-	return vul.PrimaryURL
+	return fmt.Sprintf("%s%s", NVDVulnDetailBaseURL, vul.VulnerabilityID)
 }
 
 func getCVSSValue[T comparable](vul trivyTypes.DetectedVulnerability, value func(cvss dbTypes.CVSS) T, zeroVal T) T {

--- a/vulnerability/events_creator_test.go
+++ b/vulnerability/events_creator_test.go
@@ -289,3 +289,66 @@ func TestEventsCreator_getCVSSScore(t *testing.T) {
 		})
 	}
 }
+
+func TestEventsCreator_getReference(t *testing.T) {
+	tests := []struct {
+		name string
+		vul  types.DetectedVulnerability
+		want string
+	}{
+		{
+			name: "CVSS is nil",
+			vul: types.DetectedVulnerability{
+				Vulnerability: dbTypes.Vulnerability{
+					CVSS: nil,
+				},
+				PrimaryURL:      "https://example.com/primary",
+				VulnerabilityID: "someID",
+			},
+			want: "https://example.com/primary",
+		},
+		{
+			name: "CVSS contains NVD",
+			vul: types.DetectedVulnerability{
+				Vulnerability: dbTypes.Vulnerability{
+					CVSS: dbTypes.VendorCVSS{
+						trivyVul.RedHat: dbTypes.CVSS{
+							V2Vector: "AV:N/AC:M/Au:N/C:V/I:P/A:N",
+							V2Score:  3.0,
+						},
+						trivyVul.NVD: dbTypes.CVSS{
+							V2Vector: "AV:L/AC:L/Au:N/C:C/I:C/A:C",
+							V2Score:  3.2,
+						},
+					},
+				},
+				PrimaryURL:      "https://example.com/primary",
+				VulnerabilityID: "someID",
+			},
+			want: "https://nvd.nist.gov/vuln/detail/someID",
+		},
+		{
+			name: "CVSS does not contain NVD",
+			vul: types.DetectedVulnerability{
+				Vulnerability: dbTypes.Vulnerability{
+					CVSS: dbTypes.VendorCVSS{
+						trivyVul.RedHat: dbTypes.CVSS{
+							V2Vector: "AV:N/AC:M/Au:N/C:V/I:P/A:N",
+							V2Score:  3.0,
+						},
+					},
+				},
+				PrimaryURL:      "https://example.com/primary",
+				VulnerabilityID: "someID",
+			},
+			want: "https://example.com/primary",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := getReference(test.vul)
+			assert.Equal(t, test.want, result)
+		})
+	}
+}


### PR DESCRIPTION
### Summary of your changes
<!--
Please provide a detailed description of the changes introduced by this Pull Request.
Provide a description of the main changes, as well as any additional information the code reviewer should be aware of before beginning the review process.
-->

This PR moves the logic existing in Kibana to Cloudbeat of populating the NVD link instead of the Aquasec link in `vulnerability.reference` field.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->
the field should look like the following after the change
```
{
...
"reference": "https://nvd.nist.gov/vuln/detail/CVE-2022-3080",
...
}
```

### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
- Fixes: https://github.com/elastic/cloudbeat/issues/869#top

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
