### PR TITLE
pre-commit: golangci-lint: Auto fix supported failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     rev: v0.5.1
     hooks:
       - id: golangci-lint
+        args: [--fix]
 
   ## Python
   - repo: https://github.com/PyCQA/flake8


### PR DESCRIPTION
### Summary of your changes
Automatically fix `golangci-lint` failures before commit, e.g. `gci`.



### Related Issues
https://github.com/elastic/cloudbeat/pull/1335#pullrequestreview-1619727906