### PR TITLE
Remove extra build step

### DIFF
--- a/.github/workflows/cloudbeat-ci.yml
+++ b/.github/workflows/cloudbeat-ci.yml
@@ -82,12 +82,6 @@ jobs:
           version: latest
           args: build
 
-      - name: build opa bundle
-        uses: magefile/mage-action@v3
-        with:
-          version: latest
-          args: BuildOpaBundle
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/eks-ci.yml
+++ b/.github/workflows/eks-ci.yml
@@ -83,12 +83,6 @@ jobs:
           version: latest
           args: build
 
-      - name: build opa bundle
-        uses: magefile/mage-action@v3
-        with:
-          version: latest
-          args: BuildOpaBundle
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -53,12 +53,6 @@ jobs:
           version: latest
           args: build
 
-      - name: build opa bundle
-        uses: magefile/mage-action@v3
-        with:
-          version: latest
-          args: BuildOpaBundle
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
looks like `Build` already includes a call to `BuildOpaBundle`:
https://github.com/elastic/cloudbeat/blob/48e17af899402c9121ce177379294053e396f482/magefile.go#L81-L84