### PR TITLE
Update Cloud Env workflow to default to our Org API key

### DIFF
--- a/.github/workflows/destroy-environment.yml
+++ b/.github/workflows/destroy-environment.yml
@@ -5,10 +5,6 @@ on:
   # Ability to execute on demand
   workflow_dispatch:
     inputs:
-      ec-api-key:
-        type: string
-        description: "Elastic Cloud API key"
-        required: true
       prefix:
         type: string
         description: "Delete all environments starting with `prefix`"
@@ -16,6 +12,10 @@ on:
       ignore-prefix:
         type: string
         description: "Ignore all environments starting with `ignore-prefix`"
+      ec-api-key:
+        type: string
+        description: "**Optional** To delete env environments on your own organization, enter your Elastic Cloud API key."
+        required: true
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/destroy-environment.yml
+++ b/.github/workflows/destroy-environment.yml
@@ -15,7 +15,7 @@ on:
       ec-api-key:
         type: string
         description: "**Optional** To delete env environments on your own organization, enter your Elastic Cloud API key."
-        required: true
+        required: false
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -23,6 +23,7 @@ env:
   AWS_REGION: "eu-west-1"
   ENV_PREFIX: ${{ github.event.inputs.prefix }}
   ENV_IGNORE_PREFIX: ${{ github.event.inputs.ignore-prefix }}
+  TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
 
 jobs:
   Destroy:
@@ -41,6 +42,7 @@ jobs:
         working-directory: ./
 
       - name: Mask API Key
+        if: ${{ github.event.inputs.ec-api-key != '' }}
         run: |
           ec_api_key=$(jq -r '.inputs["ec-api-key"]' $GITHUB_EVENT_PATH)
           echo "::add-mask::$ec_api_key"

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -10,14 +10,10 @@ on:
         description: |
           Name with letters, numbers, hyphens; start with a letter. Max 20 chars. e.g., 'my-env-123'
         required: true
-      ec-api-key:
-        type: string
-        description: "Elastic Cloud API KEY"
-        required: true
       elk-stack-version:
         required: true
         description: "Stack version: For released/BC version use 8.x.y, for SNAPSHOT use 8.x.y-SNAPSHOT"
-        default: "8.8.0"
+        default: "8.10.0"
       ess-region:
         required: true
         description: "Elastic Cloud deployment region"
@@ -33,6 +29,10 @@ on:
         description: "Cleanup resources after provision"
         default: false
         type: boolean
+      ec-api-key:
+        type: string
+        description: "**Optional** By default, the environment will be created in our Cloud Security Organization. If you want to use your own cloud account, enter your Elastic Cloud API key."
+        required: true
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -32,7 +32,7 @@ on:
       ec-api-key:
         type: string
         description: "**Optional** By default, the environment will be created in our Cloud Security Organization. If you want to use your own cloud account, enter your Elastic Cloud API key."
-        required: true
+        required: false
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -42,6 +42,7 @@ env:
   FLEET_API_DIR: fleet_api/src
   AWS_DEFAULT_TAGS: "Key=division,Value=engineering Key=org,Value=security Key=team,Value=cloud-security-posture Key=project,Value=test-environments"
   GCP_DEFAULT_TAGS: "division=engineering,org=security,team=cloud-security-posture,project=test-environments"
+  TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
 
 jobs:
   Deploy:
@@ -88,9 +89,11 @@ jobs:
 
       - name: Mask Sensitive Data
         run: |
-          ec_api_key=$(jq -r '.inputs["ec-api-key"]' $GITHUB_EVENT_PATH)
-          echo "::add-mask::$ec_api_key"
-          echo "TF_VAR_ec_api_key=$ec_api_key" >> $GITHUB_ENV
+          if [ "${{ github.event.inputs.ec-api-key}}" != "" ]; then
+            ec_api_key=$(jq -r '.inputs["ec-api-key"]' $GITHUB_EVENT_PATH)
+            echo "::add-mask::$ec_api_key"
+            echo "TF_VAR_ec_api_key=$ec_api_key" >> $GITHUB_ENV
+          fi
           enrollment_token="init"
           echo "::add-mask::$enrollment_token"
           echo "ENROLLMENT_TOKEN=$enrollment_token" >> $GITHUB_ENV

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -88,12 +88,14 @@ jobs:
           fi
 
       - name: Mask Sensitive Data
+        if: github.event.inputs.ec-api-key != ''
         run: |
-          if [ "${{ github.event.inputs.ec-api-key}}" != "" ]; then
-            ec_api_key=$(jq -r '.inputs["ec-api-key"]' $GITHUB_EVENT_PATH)
-            echo "::add-mask::$ec_api_key"
-            echo "TF_VAR_ec_api_key=$ec_api_key" >> $GITHUB_ENV
-          fi
+          ec_api_key=$(jq -r '.inputs["ec-api-key"]' $GITHUB_EVENT_PATH)
+          echo "::add-mask::$ec_api_key"
+          echo "TF_VAR_ec_api_key=$ec_api_key" >> $GITHUB_ENV
+
+      - name: Init Enrollment Token
+        run: |
           enrollment_token="init"
           echo "::add-mask::$enrollment_token"
           echo "ENROLLMENT_TOKEN=$enrollment_token" >> $GITHUB_ENV

--- a/.github/workflows/weekly-enviroment.yml
+++ b/.github/workflows/weekly-enviroment.yml
@@ -23,7 +23,7 @@ on:
 env:
   WORKING_DIR: deploy/weekly-environment
   SCRIPTS_DIR: deploy/weekly-environment/scripts/benchmarks/kspm_vanilla
-  TF_VAR_ec_api_key: ${{ secrets.WEEKLY_ENVIRONMENT_EC_API_KEY }}
+  TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
   TF_VAR_environment: ${{ github.event.inputs.logLevel }}
   TF_LOG: ${{ github.event.inputs.logLevel }}
   TF_VAR_stack_version: 8.7.0-SNAPSHOT

--- a/dev-docs/CSPM-Cloud-Deployment.md
+++ b/dev-docs/CSPM-Cloud-Deployment.md
@@ -1,6 +1,6 @@
 # Install CSPM integration on a cloud deployment with standalone docker agent
 
-## Prerequiste
+## Prerequisites
 1. Docker
 2. [Connect to AWS account using the CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html)
 
@@ -9,7 +9,7 @@
 - Log into with your elastic account
 - Select `Create Deployment`
 - Adjust the settings for your need, note that certain versions only exist on certain regions.
-- At the time of writing this, `latest` and `snapshot` versions are avilable on `us-west2`
+- At the time of writing this, `latest` and `snapshot` versions are available on `us-west2`
 > **Note**
 > `latest` is the build candidate for pre-released versions
 
@@ -19,7 +19,7 @@ Launch your Cloud Deployment
 
 ## 2. Optional Step - Verify Cloud Deployment Commit
 
-To prevent cases of working with an incorrect commit, confirm that the commit SHA of your deployment is matching the desired commit SHA, wheter its the [DRA](https://artifacts-staging.elastic.co/dra-info/index.html), BC, or just a specific commit. for this guide, we will use the latest BC commit SHA
+To prevent cases of working with an incorrect commit, confirm that the commit SHA of your deployment is matching the desired commit SHA, whether it's the [DRA](https://artifacts-staging.elastic.co/dra-info/index.html), BC, or just a specific commit. for this guide, we will use the latest BC commit SHA
 
 - In your deployment, navigate to `/app/status`, the commit of your Kibana version will be displayed at the top
 
@@ -56,7 +56,7 @@ To prevent cases of working with an incorrect commit, confirm that the commit SH
 
 - In the Flyout, give it a name (you'll need it later) and click on `Create agent policy`
 - A new policy has been added to your list of agent policies, click on its name and then on `Add integration`
-- In the intergations screen, select the needed integration. For this tutorial, we will use CSPM
+- In the integrations screen, select the needed integration. For this tutorial, we will use CSPM
 
 <img width="900" alt="image" src="https://user-images.githubusercontent.com/51442161/222234500-39dbda6c-8880-4f43-99f4-9cc2d3c7a655.png">
 
@@ -67,11 +67,11 @@ To prevent cases of working with an incorrect commit, confirm that the commit SH
 
 <img width="900" alt="image" src="https://user-images.githubusercontent.com/51442161/222235991-5ea07776-d5fe-4a9c-9629-a619c5326970.png">
 
-Save the intergation
+Save the integration
 
 ## 4. Add Standalone Docker Agent
-- Now that you have an agent policy with a configured CSPM intergation navigate to Fleet > Agents and select `Add Agent`
-- Select your CSPM intergation from the drop down list under `What type of host are you adding?`
+- Now that you have an agent policy with a configured CSPM integration navigate to Fleet > Agents and select `Add Agent`
+- Select your CSPM integration from the drop-down list under `What type of host are you adding?`
 - On step 3 of the Flyout, you will be provided with the setup command for the agent, for example:
 
 ```
@@ -92,10 +92,10 @@ docker run -d --platform=linux/x86_64 \
 docker.elastic.co/cloud-release/elastic-agent-cloud:8.7.0-046d305b
 ```
 > **Note**
-> make sure to change the agent docker image according to what you are using)
+> make sure to change the agent docker image according to what you are using
 
 At this point you should see your agent working in your docker and under `Confirm agent enrollment` section of the Flyout.
 
 ## 5. Discover
-- Go to Discover and make sure you have docs in the `findings` and `findings-latest` indecies, `findings-latest` can take a few minutes to populate.
+- Go to Discover and make sure you have docs in the `findings` and `findings-latest` indices, `findings-latest` can take a few minutes to populate.
 - If you do, congrats you have a working CSPM cloud deployment.

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -22,9 +22,9 @@ Follow these steps to run the workflow:
       instance: `john-8-7-2-June01`.
 
     - **`elk-stack-version`**: Specify the version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC)
-      version. The default value is `8.8.0`. Check the available
-      versions [here](https://artifacts-staging.elastic.co/dra-info/index.html). For BC, enter only the
-      version without additions/commit sha, e.g. `8.8.1`. For SNAPSHOT, enter the full version, e.g. `8.8.1-SNAPSHOT`.
+      version. Check the available versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
+      For BC, enter only the version without additions/commit sha, e.g. `8.8.1`.
+      For SNAPSHOT, enter the full version, e.g. `8.8.1-SNAPSHOT`.
 
     - **`ess-region`**: Indicate the Elastic Cloud deployment region. The default value is `gcp-us-west2`, which
       supports

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -16,7 +16,7 @@ Follow these steps to run the workflow:
 
    ![Run Workflow](https://github.com/elastic/cloudbeat/assets/99176494/115fdd53-cff7-406a-bc3d-d65d5199389f)
 
-3. Complete the required input fields:
+3. Complete the required parameters:
 
     - **`deployment_name`**: Name your environment (Allowed characters: a-zA-Z0-9 and `-`). For
       instance: `john-8-7-2-June01`.
@@ -30,11 +30,14 @@ Follow these steps to run the workflow:
       supports
       snapshot and build candidate (BC) versions. Specify a different region only if necessary.
 
-   ![Enter Inputs](https://github.com/elastic/cloudbeat/assets/99176494/06d8144d-13cc-4e13-92fc-19f52ce8206b)
+   ![Required Parameters](https://github.com/oren-zohar/cloudbeat/assets/85433724/6159129e-6d4d-46b1-97a1-f0d3859500fd)
 
-4. Optionally, modify other input values if required:
 
-    - `docker-image-override` (optional): Use this to replace the default Docker image for build candidate (BC) or
+
+
+5. Optionally, modify other parameters if required:
+
+    - **`docker-image-override`** (**optional**): Use this to replace the default Docker image for build candidate (BC) or
       SNAPSHOT versions.
       Provide the full image path. Leave this field blank for snapshot versions. Follow this format for the image
       path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.8.1-9ac7eb02`. If you're not sure where to get this
@@ -43,23 +46,26 @@ Follow these steps to run the workflow:
       e.g. `elastic / unified-release - staging # 8.9 - 11 - 8.9.0-c6bb8f7a Success after 4 hr 58 min`. Now just copy it
       and replace it the image path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.9.0-c6bb8f7a`.
 
-    - `run-sanity-tests` (optional): Set to `true` to run sanity tests after the environment is set up. Default: `false`
+    - **`run-sanity-tests`** (**optional**): Set to `true` to run sanity tests after the environment is set up. Default: `false`
 
-    - `cleanup-env` (optional): Set to `true` if you want the resources to automatically be cleaned up after
+    - **`cleanup-env`** (**optional**): Set to `true` if you want the resources to automatically be cleaned up after
       provisioning - useful if you don't want to test the env manually after deployment.
       Default: `false`.
 
-    - `ec-api-key` (optional): By default, all the new environments will be created in our EC Cloud Security organization.
+    - **`ec-api-key`** (**optional**): By default, all the new environments will be created in our EC Cloud Security organization.
       If you want to create the environment on your personal org (`@elastic.co`) you can enter
       your private [Elastic Cloud](https://cloud.elastic.co/home) API key. Follow the
       [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for
       step-by-step instructions on generating the token.
 
-   ![Adjust Inputs](https://github.com/elastic/cloudbeat/assets/99176494/bac5004d-7cbc-4a34-8127-3acd11acc90e)
+   ![Optinal Parameters](https://github.com/oren-zohar/cloudbeat/assets/85433724/17933589-ee0e-4181-a244-f501f54bda6c)
 
-5. Click the `Run workflow` button to start.
 
-   ![Run Workflow](https://github.com/elastic/cloudbeat/assets/99176494/5e5131ba-264e-4444-8879-aa612d5de778)
+
+7. Click the `Run workflow` button to start.
+
+   ![Run Workflow](https://github.com/oren-zohar/cloudbeat/assets/85433724/7b05bf58-cc0b-4ec9-8e49-55d117673df8)
+
 
 ## Tracking Workflow Execution
 

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -32,10 +32,7 @@ Follow these steps to run the workflow:
 
    ![Required Parameters](https://github.com/oren-zohar/cloudbeat/assets/85433724/6159129e-6d4d-46b1-97a1-f0d3859500fd)
 
-
-
-
-5. Optionally, modify other parameters if required:
+4. Optionally, modify other parameters if required:
 
     - **`docker-image-override`** (**optional**): Use this to replace the default Docker image for build candidate (BC) or
       SNAPSHOT versions.
@@ -58,11 +55,9 @@ Follow these steps to run the workflow:
       [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for
       step-by-step instructions on generating the token.
 
-   ![Optinal Parameters](https://github.com/oren-zohar/cloudbeat/assets/85433724/17933589-ee0e-4181-a244-f501f54bda6c)
+   ![Optional Parameters](https://github.com/oren-zohar/cloudbeat/assets/85433724/17933589-ee0e-4181-a244-f501f54bda6c)
 
-
-
-7. Click the `Run workflow` button to start.
+5. Click the `Run workflow` button to start.
 
    ![Run Workflow](https://github.com/oren-zohar/cloudbeat/assets/85433724/7b05bf58-cc0b-4ec9-8e49-55d117673df8)
 

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -1,8 +1,8 @@
 # Cloud Environment Testing
 
-The [Create Environment](https://github.com/elastic/cloudbeat/actions/workflows/test-environment.yml) GitHub action
-deploys a full-featured cloud environment, pre-configured with all our integrations (KSPM, CSPM and D4C). It also includes features for
-running sanity testing and automated deletion.
+The [`Create Environment`](https://github.com/elastic/cloudbeat/actions/workflows/test-environment.yml) GitHub action
+deploys a full-featured cloud environment, pre-configured with all our integrations (KSPM, CSPM and D4C).
+It also includes features for running sanity testing and automated deletion.
 
 ## How to Run the Workflow
 
@@ -20,10 +20,6 @@ Follow these steps to run the workflow:
 
     - **`deployment_name`**: Name your environment (Allowed characters: a-zA-Z0-9 and `-`). For
       instance: `john-8-7-2-June01`.
-
-    - `ec-api-key` (required): Use the [Production Elastic Cloud](https://cloud.elastic.co/home) API KEY. Follow
-      the [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for
-      step-by-step instructions on generating the token.
 
     - **`elk-stack-version`**: Specify the version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC)
       version. The default value is `8.8.0`. Check the available
@@ -53,9 +49,13 @@ Follow these steps to run the workflow:
       provisioning - useful if you don't want to test the env manually after deployment.
       Default: `false`.
 
-      .
-   ![Adjust Inputs](https://github.com/elastic/cloudbeat/assets/99176494/bac5004d-7cbc-4a34-8127-3acd11acc90e)
+    - `ec-api-key` (optional): By default, all the new environments will be created in our EC Cloud Security organization.
+      If you want to create the environment on your personal org (`@elastic.co`) you can enter
+      your private [Elastic Cloud](https://cloud.elastic.co/home) API key. Follow the
+      [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for
+      step-by-step instructions on generating the token.
 
+   ![Adjust Inputs](https://github.com/elastic/cloudbeat/assets/99176494/bac5004d-7cbc-4a34-8127-3acd11acc90e)
 
 5. Click the `Run workflow` button to start.
 
@@ -107,7 +107,8 @@ Follow these steps to connect to your Amazon Elastic Kubernetes Service (EKS) cl
 
 1. **Assume Role for Access**:
 
-   Before connecting to the EKS cluster, you need to assume a role that provides the necessary permissions. Replace `<your-session-name>` with a meaningful session name and run the following command to assume the role:
+   Before connecting to the EKS cluster, you need to assume a role that provides the necessary permissions.
+   Replace `<your-session-name>` with a meaningful session name and run the following command to assume the role:
 
    ```bash
    export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s"  $(aws sts assume-role --role-arn arn:aws:iam::704479110758:role/Developer_eks --role-session-name <your-session-name> --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text))
@@ -156,18 +157,18 @@ Follow these steps to run the workflow:
 
 3. Complete the required input fields:
 
-    - `ec-api-key` (required): Use the [Production Elastic Cloud](https://cloud.elastic.co/home) API key.
     - `prefix` (required): The prefix used to identify the environments to be deleted.
 
    <img width="411" alt="Enter Inputs" src="https://github.com/elastic/cloudbeat/assets/99176494/04973b00-5411-4ace-ab3a-534371877c91">
 
-1. Optionally, modify other input value if required:
+4. Optionally, modify other input value if required:
 
     - `ignore-prefix` (optional): The prefix used to identify environments that should be excluded from deletion.
+    - `ec-api-key` (required): Use your own [Elastic Cloud](https://cloud.elastic.co/home) API key if you want to delete environments from your Elastic Cloud account.
 
    <img width="411" alt="Optional Inputs" src="https://github.com/elastic/cloudbeat/assets/99176494/aa89ad4e-fd32-461d-ab2d-3fee28094a9d">
 
-2. Click the `Run workflow` button to start.
+5. Click the `Run workflow` button to start.
 
    ![Run Workflow](https://github.com/gurevichdmitry/cloudbeat/assets/99176494/64b554d5-70f0-4cf3-b2b9-8f8429d1fc07)
 

--- a/dev-docs/Development.md
+++ b/dev-docs/Development.md
@@ -27,7 +27,7 @@ Self-Managed Kubernetes
 just create-vanilla-deployment-file
 ```
 
-Self-Managed Kubernetes wthout certificate
+Self-Managed Kubernetes without certificate
 
 ```zsh
 just create-vanilla-deployment-file-nocert
@@ -106,7 +106,7 @@ In general there are two major test suites:
 
 The tests written in Go use the Go Testing package. The tests written in Python depend on pytest and require a compiled and executable binary from the Go code. The python test run a beat with a specific config and params and either check if the output is as expected or if the correct things show up in the logs.
 
-Integration tests in Beats are tests which require an external system like Elasticsearch to test if the integration with this service works as expected. Beats provides in its testsuite docker containers and docker-compose files to start these environments but a developer can run the required services also locally.
+Integration tests in Beats are tests which require an external system like Elasticsearch to test if the integration with this service works as expected. Beats provide in its testsuite docker containers and docker-compose files to start these environments but a developer can run the required services also locally.
 
 For more information, see our [testing docs](/tests/README.md)
 
@@ -203,7 +203,7 @@ To run `act` with secrets, you can enter them interactively, supply them as envi
 
 ##### GitHub Upload Artifact
 
-[GithHub upload-artifact](https://github.com/actions/upload-artifact) action requires simple server running on local machine.
+[GitHub upload-artifact](https://github.com/actions/upload-artifact) action requires simple server running on local machine.
 
 The solution is described in [this](https://github.com/nektos/act/issues/329) issue.
 

--- a/dev-docs/ELK-Deployment.md
+++ b/dev-docs/ELK-Deployment.md
@@ -20,7 +20,7 @@ For example, spinning up 8.6.0 stack locally:
   ```
 
 ## Elastic Cloud Deployment
-This is the recommended way to deploy the stack for development and testing purposes. As it dosn't require any local resources, configuration, and maintenance.
+This is the recommended way to deploy the stack for development and testing purposes. As it doesn't require any local resources, configuration, and maintenance.
 You can just spin up a new deployment, and connect to it:
 
 Spin up Elastic stack using [cloud](https://cloud.elastic.co/home) or [staging](https://staging.found.no/home) (which will be deleted after 14 days)


### PR DESCRIPTION
### Summary of your changes
Updating our [cloud env testing](https://github.com/elastic/cloudbeat/blob/main/dev-docs/Cloud-Env-Testing.md) to use our cloud organization API key by default.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
