### PR TITLE
Make common data provider more efficient

### DIFF
--- a/dataprovider/providers/common/data_provider.go
+++ b/dataprovider/providers/common/data_provider.go
@@ -18,29 +18,29 @@
 package common
 
 import (
-	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/mitchellh/mapstructure"
 
 	"github.com/elastic/cloudbeat/version"
 )
 
 type DataProvider struct {
-	info version.CloudbeatVersionInfo
+	info map[string]any
 }
 
-func New(log *logp.Logger, info version.CloudbeatVersionInfo) *DataProvider {
-	return &DataProvider{
-		info: info,
-	}
-}
-
-func (c *DataProvider) GetElasticCommonData() (map[string]any, error) {
-	m := map[string]interface{}{}
-	err := mapstructure.Decode(c.info, &m)
+func New(cloudbeatVersionInfo version.CloudbeatVersionInfo) (*DataProvider, error) {
+	m := map[string]any{}
+	err := mapstructure.Decode(cloudbeatVersionInfo, &m)
 	if err != nil {
 		return nil, err
 	}
-	return map[string]interface{}{
-		"cloudbeat": m,
+
+	return &DataProvider{
+		info: m,
+	}, nil
+}
+
+func (c *DataProvider) GetElasticCommonData() (map[string]any, error) {
+	return map[string]any{
+		"cloudbeat": c.info,
 	}, nil
 }

--- a/dataprovider/providers/common/data_provider_test.go
+++ b/dataprovider/providers/common/data_provider_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/cloudbeat/dataprovider"
-	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 	"github.com/elastic/cloudbeat/version"
 )
 
@@ -69,12 +68,14 @@ func Test_CommonDataProvider_GetElasticCommonData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := New(testhelper.NewLogger(t), tt.info)
+			p, err := New(tt.info)
+			assert.NoError(t, err)
+
 			ev := &beat.Event{
 				Fields: map[string]interface{}{},
 			}
 
-			err := dataprovider.NewEnricher(p).EnrichEvent(ev)
+			err = dataprovider.NewEnricher(p).EnrichEvent(ev)
 			assert.NoError(t, err)
 
 			fl := ev.Fields.Flatten()

--- a/flavors/posture.go
+++ b/flavors/posture.go
@@ -94,11 +94,16 @@ func newPostureFromCfg(b *beat.Beat, cfg *config.Config) (*posture, error) {
 	// namespace will be passed as param from fleet on https://github.com/elastic/security-team/issues/2383 and it's user configurable
 	resultsIndex := config.Datastream("", config.ResultsDatastreamIndexPrefix)
 
-	cdp := common.New(log, version.CloudbeatVersionInfo{
+	cdp, err := common.New(version.CloudbeatVersionInfo{
 		Version: version.CloudbeatVersion(),
 		// Keeping Policy field for backward compatibility
 		Policy: version.CloudbeatVersion(),
 	})
+
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to init common data provider: %w", err)
+	}
 
 	t := transformer.NewTransformer(log, bdp, cdp, idp, resultsIndex)
 


### PR DESCRIPTION
### Summary of your changes
The data held by the CDP is static and should not be decoded for every new cloudbeat event.
Instead of decoding the shared data every new event, the common data provider will do so upon initialization.

### Related Issues
- #1305 

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
