### PR TITLE
Dependabot: Create groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,17 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      azure:
+        "github.com/Azure/*"
+      aws:
+        "github.com/aws/*"
+      google:
+        "cloud.google.com/*"
+      elastic:
+        "github.com/elastic/*"
+      k8s:
+        "k8s.io/*"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
### Summary of your changes
Groups should update together, helps avoid PR spam and make sure we always keep dependencies in sync for each cloud provider.

Closes https://github.com/elastic/cloudbeat/pull/1429
Closes https://github.com/elastic/cloudbeat/pull/1430
Closes https://github.com/elastic/cloudbeat/pull/1431
Closes https://github.com/elastic/cloudbeat/pull/1433