### PR TITLE
Azure add mapping for SKU property

### DIFF
--- a/resources/providers/azurelib/inventory/provider.go
+++ b/resources/providers/azurelib/inventory/provider.go
@@ -210,6 +210,7 @@ func (p *Provider) getAssetFromData(data map[string]any) AzureAsset {
 		SubscriptionId:   subId,
 		SubscriptionName: p.subscriptions[subId],
 		TenantId:         getString(data, "tenantId"),
+		Sku:              getString(data, "sku"),
 		Type:             getString(data, "type"),
 	}
 }

--- a/resources/providers/azurelib/inventory/provider_test.go
+++ b/resources/providers/azurelib/inventory/provider_test.go
@@ -50,6 +50,7 @@ var nonTruncatedResponse = armresourcegraph.QueryResponse{
 			"subscriptionId": "3",
 			"tenantId":       "3",
 			"type":           "3",
+			"sku":            "3",
 		},
 	},
 	ResultTruncated: to.Ptr(armresourcegraph.ResultTruncatedFalse),
@@ -67,6 +68,7 @@ var truncatedResponse = armresourcegraph.QueryResponse{
 			"subscriptionId": "1",
 			"tenantId":       "1",
 			"type":           "1",
+			"sku":            "1",
 		},
 		map[string]any{
 			"id":             "2",
@@ -77,6 +79,7 @@ var truncatedResponse = armresourcegraph.QueryResponse{
 			"subscriptionId": "2",
 			"tenantId":       "2",
 			"type":           "2",
+			"sku":            "2",
 		},
 	},
 	ResultTruncated: to.Ptr(armresourcegraph.ResultTruncatedTrue),
@@ -162,6 +165,7 @@ func (s *ProviderTestSuite) TestListAllAssetTypesByName() {
 		s.Assert().Equal(r.ResourceGroup, strIndex)
 		s.Assert().Equal(r.SubscriptionId, strIndex)
 		s.Assert().Equal(r.TenantId, strIndex)
+		s.Assert().Equal(r.Sku, strIndex)
 		s.Assert().Equal(r.Type, strIndex)
 		s.Assert().Equal(r.Properties, map[string]any{"test": "test"})
 	})


### PR DESCRIPTION
### Summary of your changes
Following the QA cycle we've noticed that an SKU rule is not being evaluated.
This is because we did not map the SKU property and OPA wasn't evaluating the rule.

### Related Issues
- Related: https://github.com/elastic/cloudbeat/issues/1256

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)
