### PR TITLE
Azure remove activity logs from single fetcher

### DIFF
--- a/resources/fetching/fetchers/azure/assets_fetcher.go
+++ b/resources/fetching/fetchers/azure/assets_fetcher.go
@@ -52,7 +52,6 @@ func newPair(subType string, tpe string) typePair {
 }
 
 var AzureAssetTypeToTypePair = map[string]typePair{
-	inventory.ActivityLogAlertAssetType:          newPair(fetching.AzureActivityLogAlertType, fetching.MonitoringIdentity),
 	inventory.ClassicStorageAccountAssetType:     newPair(fetching.AzureClassicStorageAccountType, fetching.CloudStorage),
 	inventory.ClassicVirtualMachineAssetType:     newPair(fetching.AzureClassicVMType, fetching.CloudCompute),
 	inventory.DiskAssetType:                      newPair(fetching.AzureDiskType, fetching.CloudCompute),

--- a/resources/fetching/fetchers/azure/assets_fetcher_test.go
+++ b/resources/fetching/fetchers/azure/assets_fetcher_test.go
@@ -55,7 +55,6 @@ func (s *AzureAssetsFetcherTestSuite) TestFetcher_Fetch() {
 	mockInventoryService := &inventory.MockServiceAPI{}
 	var mockAssets []inventory.AzureAsset
 	for _, assetType := range []string{
-		inventory.ActivityLogAlertAssetType,
 		inventory.ClassicStorageAccountAssetType,
 		inventory.ClassicVirtualMachineAssetType,
 		inventory.DiskAssetType,


### PR DESCRIPTION
### Summary of your changes
We need to evaluate activity rules as a batch and not as singles

### Related Issues
- Related: https://github.com/elastic/cloudbeat/issues/1256

- ### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
