### PR TITLE
Revert "CloudFormation: Fix missing tags in cloud-security account"

### DIFF
--- a/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
@@ -33,11 +33,6 @@ Parameters:
     Description: The version of elastic-agent to install
     Type: String
 
-Conditions:
-  UseElasticTags: !Equals
-    - !Ref "AWS::AccountId"
-    - 704479110758
-
 Resources:
 
   # Security Group for EC2 instance
@@ -139,26 +134,6 @@ Resources:
                   - !Ref "AWS::StackId"
         - Key: Task
           Value: Vulnerability Management Scanner
-        - Key: division
-          Value: !If
-            - UseElasticTags
-            - engineering
-            - AWS::NoValue
-        - Key: org
-          Value: !If
-            - UseElasticTags
-            - security
-            - AWS::NoValue
-        - Key: team
-          Value: !If
-            - UseElasticTags
-            - cloud-security
-            - AWS::NoValue
-        - Key: project
-          Value: !If
-            - UseElasticTags
-            - cloudformation
-            - AWS::NoValue
       ImageId: !Ref LatestAmiId
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref ElasticAgentInstanceProfile

--- a/deploy/cloudformation/elastic-agent-ec2-cspm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm.yml
@@ -33,11 +33,6 @@ Parameters:
     Description: The version of elastic-agent to install
     Type: String
 
-Conditions:
-  UseElasticTags: !Equals
-    - !Ref "AWS::AccountId"
-    - 704479110758
-
 Resources:
 
   # Security Group for EC2 instance
@@ -107,26 +102,6 @@ Resources:
                   - !Ref "AWS::StackId"
         - Key: Task
           Value: Cloud Security Posture Management Scanner
-        - Key: division
-          Value: !If
-            - UseElasticTags
-            - engineering
-            - AWS::NoValue
-        - Key: org
-          Value: !If
-            - UseElasticTags
-            - security
-            - AWS::NoValue
-        - Key: team
-          Value: !If
-            - UseElasticTags
-            - cloud-security
-            - AWS::NoValue
-        - Key: project
-          Value: !If
-            - UseElasticTags
-            - cloudformation
-            - AWS::NoValue
       ImageId: !Ref LatestAmiId
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref ElasticAgentInstanceProfile


### PR DESCRIPTION
### Summary of your changes
This reverts commit d4ad5d46cd8ac89d6bee232cbc70f07b595f0aff before the 8.11 release.


### Related Issues
- Related: https://github.com/elastic/cloudbeat/pull/1415


### Checklist
- [ ] Make sure that 8.11 manifest is uploaded in a GH action
- [ ] Make sure the 1.6.5 integration links to the correct file
- [ ] Open follow up ticket for 8.12 release **OR** for fixing this issue in a better way