### PR TITLE
update-beats: Use hermit for go

### DIFF
--- a/.ci/scripts/update-beats.sh
+++ b/.ci/scripts/update-beats.sh
@@ -4,3 +4,4 @@ set -euxo pipefail
 BEATS_VERSION=${1:?Missing version argument}
 go get "github.com/elastic/beats/v7@$BEATS_VERSION"
 go mod tidy
+git diff

--- a/.ci/scripts/update-beats.sh
+++ b/.ci/scripts/update-beats.sh
@@ -4,10 +4,13 @@ set -euxo pipefail
 BEATS_VERSION=${1:?Missing version argument}
 go get "github.com/elastic/beats/v7@$BEATS_VERSION"
 go mod tidy
-# updatecli needs some specific stdout when using the shell target,
+# updatecli needs standard output to not be empty for changes to be detected
 # see https://www.updatecli.io/docs/plugins/resource/shell/#_shell_target:
 # > When the commands runs successfully (e.g. with an exit code of zero), the behavior depends on the content of the
 # standard output:
 # > - If it is empty, then updatecli report a success with no changes applied.
 # > - Otherwise updatecli report a success with the content of the standard output as the resulting value of the change.
+# Non-empty stdout will trigger the "git add" stage which will commit all differences to the updatecli branch.
+# git diff is a safe choice because it will be non-empty when changes need to be committed and it's also good for
+# debugging.
 git diff

--- a/.ci/scripts/update-beats.sh
+++ b/.ci/scripts/update-beats.sh
@@ -4,4 +4,10 @@ set -euxo pipefail
 BEATS_VERSION=${1:?Missing version argument}
 go get "github.com/elastic/beats/v7@$BEATS_VERSION"
 go mod tidy
+# updatecli needs some specific stdout when using the shell target,
+# see https://www.updatecli.io/docs/plugins/resource/shell/#_shell_target:
+# > When the commands runs successfully (e.g. with an exit code of zero), the behavior depends on the content of the
+# standard output:
+# > - If it is empty, then updatecli report a success with no changes applied.
+# > - Otherwise updatecli report a success with the content of the standard output as the resulting value of the change.
 git diff

--- a/.github/workflows/update-beats.yml
+++ b/.github/workflows/update-beats.yml
@@ -16,9 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: go.mod
+      - name: Init Hermit
+        run: ./bin/hermit env -r >> $GITHUB_ENV
       - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
### Summary of your changes
Use hermit for proper go version.

For some reason, running `git diff` triggers the PR correctly. I haven't determined exactly why.

### Screenshot/Data
Example PR: https://github.com/orestisfl/cloudbeat/pull/14. Note that this is done without the apm CI actions because I don't have vault access. Instead, I called updatecli directly from the GH action: https://github.com/orestisfl/cloudbeat/blob/d517e53a6d27679912f6a89fd55660317b98df68/.github/workflows/update-beats.yml

CC @v1v 