### PR TITLE
Updatecli: Update pre-commit as well

### DIFF
--- a/.ci/updatecli/scripts/update-hermit.sh
+++ b/.ci/updatecli/scripts/update-hermit.sh
@@ -19,4 +19,9 @@ bin/hermit upgrade \
     shellcheck \
     shfmt \
     yq
-git status # git diff might not have output because only binaries change
+
+# Update pre-commit hooks
+pre-commit autoupdate
+pre-commit run --all || true # Run to generate diffs, fix failures in PR
+
+git status # git diff might not have output when only binaries change

--- a/.ci/updatecli/updatecli.d/update-hermit.yml
+++ b/.ci/updatecli/updatecli.d/update-hermit.yml
@@ -1,5 +1,5 @@
 ---
-name: Update Hermit Dependencies
+name: Update Hermit and Pre-commit Dependencies
 pipelineid: 'updatecli-hermit-{{ .github.branch }}'
 
 scms:
@@ -16,7 +16,7 @@ scms:
 
 actions:
   default:
-    title: '[updatecli] Update hermit dependencies'
+    title: '[updatecli] Update hermit and pre-commit dependencies'
     kind: github/pullrequest
     scmid: default
     spec:
@@ -27,13 +27,13 @@ actions:
         - dependency
       description: |-
         ### What
-        `hermit` automatic sync
+        Run `hermit upgrade` and `pre-commit autoupdate`.
 
         Generated automatically with {{ requiredEnv "JOB_URL" }}
 
 targets:
   hermit:
-    name: 'Update hermit packages'
+    name: 'Update hermit and pre-commit packages'
     scmid: default
     kind: shell
     spec:


### PR DESCRIPTION
### Summary of your changes
Added to hermit pipeline to reduce PR spam and because some of the hooks
are inter-connected with hermit packages. For example, this way we are
going to have the same version of `regal` in hermit and pre-commit.