### PR TITLE
Add Azure credentials type in configuration 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,7 @@ type AzureConfig struct {
 }
 
 type AzureClientOpt struct {
+	ClientCredentialsType     string `config:"type"`
 	ClientID                  string `config:"client_id"`
 	TenantID                  string `config:"tenant_id"`
 	ClientSecret              string `config:"client_secret"`
@@ -98,6 +99,13 @@ type AzureClientOpt struct {
 	ClientCertificatePath     string `config:"client_certificate_path"`
 	ClientCertificatePassword string `config:"client_certificate_password"`
 }
+
+const (
+	AzureClientCredentialsTypeManagedIdentity  = "managed_identity"
+	AzureClientCredentialsTypeSecret           = "service_principal_with_client_secret"
+	AzureClientCredentialsTypeCertificate      = "service_principal_with_client_certificate"
+	AzureClientCredentialsTypeUsernamePassword = "service_principal_with_client_username_and_password"
+)
 
 const (
 	SingleAccount       = "single-account"

--- a/resources/providers/azurelib/auth/credentials.go
+++ b/resources/providers/azurelib/auth/credentials.go
@@ -49,9 +49,11 @@ func (p *ConfigProvider) GetAzureClientConfig(cfg config.AzureConfig) (*AzureFac
 			return nil, ErrIncompleteUsernamePassword
 		}
 		return p.getUsernamePasswordCredentialsConfig(cfg)
+	case "", config.AzureClientCredentialsTypeManagedIdentity:
+		return p.getDefaultCredentialsConfig()
 	}
 
-	return p.getDefaultCredentialsConfig()
+	return nil, ErrWrongCredentialsType
 }
 
 func (p *ConfigProvider) getDefaultCredentialsConfig() (*AzureFactoryConfig, error) {
@@ -115,4 +117,7 @@ func (p *ConfigProvider) getUsernamePasswordCredentialsConfig(cfg config.AzureCo
 	}, nil
 }
 
-var ErrIncompleteUsernamePassword = errors.New("incomplete username and password credentials")
+var (
+	ErrWrongCredentialsType       = errors.New("wrong credentials type")
+	ErrIncompleteUsernamePassword = errors.New("incomplete username and password credentials")
+)

--- a/resources/providers/azurelib/auth/credentials.go
+++ b/resources/providers/azurelib/auth/credentials.go
@@ -39,12 +39,12 @@ type ConfigProvider struct {
 }
 
 func (p *ConfigProvider) GetAzureClientConfig(cfg config.AzureConfig) (*AzureFactoryConfig, error) {
-	switch {
-	case cfg.Credentials.ClientSecret != "":
+	switch cfg.Credentials.ClientCredentialsType {
+	case config.AzureClientCredentialsTypeSecret:
 		return p.getSecretCredentialsConfig(cfg)
-	case cfg.Credentials.ClientCertificatePath != "":
+	case config.AzureClientCredentialsTypeCertificate:
 		return p.getCertificateCredentialsConfig(cfg)
-	case cfg.Credentials.ClientUsername != "" || cfg.Credentials.ClientPassword != "":
+	case config.AzureClientCredentialsTypeUsernamePassword:
 		if cfg.Credentials.ClientUsername == "" || cfg.Credentials.ClientPassword == "" {
 			return nil, ErrIncompleteUsernamePassword
 		}

--- a/resources/providers/azurelib/auth/credentials_test.go
+++ b/resources/providers/azurelib/auth/credentials_test.go
@@ -48,9 +48,10 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			name: "Should return a ClientSecretCredential",
 			config: config.AzureConfig{
 				Credentials: config.AzureClientOpt{
-					TenantID:     "tenant_a",
-					ClientID:     "client_id",
-					ClientSecret: "secret",
+					ClientCredentialsType: config.AzureClientCredentialsTypeSecret,
+					TenantID:              "tenant_a",
+					ClientID:              "client_id",
+					ClientSecret:          "secret",
 				},
 			},
 			authProviderInitFn: func(m *MockAzureAuthProviderAPI) {
@@ -68,10 +69,11 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			name: "Should return a UsernamePasswordCredential",
 			config: config.AzureConfig{
 				Credentials: config.AzureClientOpt{
-					TenantID:       "tenant_a",
-					ClientID:       "client_id",
-					ClientUsername: "username",
-					ClientPassword: "password",
+					ClientCredentialsType: config.AzureClientCredentialsTypeUsernamePassword,
+					TenantID:              "tenant_a",
+					ClientID:              "client_id",
+					ClientUsername:        "username",
+					ClientPassword:        "password",
 				},
 			},
 			authProviderInitFn: func(m *MockAzureAuthProviderAPI) {
@@ -89,10 +91,11 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			name: "Should return error on incomplete Username Password Credential (missing password)",
 			config: config.AzureConfig{
 				Credentials: config.AzureClientOpt{
-					TenantID:       "tenant_a",
-					ClientID:       "client_id",
-					ClientUsername: "username",
-					ClientPassword: "",
+					ClientCredentialsType: config.AzureClientCredentialsTypeUsernamePassword,
+					TenantID:              "tenant_a",
+					ClientID:              "client_id",
+					ClientUsername:        "username",
+					ClientPassword:        "",
 				},
 			},
 			authProviderInitFn: func(m *MockAzureAuthProviderAPI) {},
@@ -103,10 +106,11 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			name: "Should return error on incomplete Username Password Credential (missing username)",
 			config: config.AzureConfig{
 				Credentials: config.AzureClientOpt{
-					TenantID:       "tenant_a",
-					ClientID:       "client_id",
-					ClientUsername: "",
-					ClientPassword: "password",
+					ClientCredentialsType: config.AzureClientCredentialsTypeUsernamePassword,
+					TenantID:              "tenant_a",
+					ClientID:              "client_id",
+					ClientUsername:        "",
+					ClientPassword:        "password",
 				},
 			},
 			authProviderInitFn: func(m *MockAzureAuthProviderAPI) {},
@@ -117,6 +121,7 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			name: "Should return a ClientCertificateCredential",
 			config: config.AzureConfig{
 				Credentials: config.AzureClientOpt{
+					ClientCredentialsType:     config.AzureClientCredentialsTypeCertificate,
 					TenantID:                  "tenant_a",
 					ClientID:                  "client_id",
 					ClientCertificatePath:     "/path/cert",

--- a/resources/providers/azurelib/auth/credentials_test.go
+++ b/resources/providers/azurelib/auth/credentials_test.go
@@ -45,16 +45,15 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "Should return a DefaultAzureCredential on unknown client credentials type",
+			name: "Should return a error on unknown client credentials type",
 			config: config.AzureConfig{
 				Credentials: config.AzureClientOpt{
 					ClientCredentialsType: "unknown",
 				},
 			},
-			authProviderInitFn: initDefaultCredentialsMock(nil),
-			want: &AzureFactoryConfig{
-				Credentials: &azidentity.DefaultAzureCredential{},
-			},
+			authProviderInitFn: func(m *MockAzureAuthProviderAPI) {},
+			want:               nil,
+			wantErr:            true,
 		},
 		{
 			name: "Should return a ClientSecretCredential",

--- a/resources/providers/azurelib/auth/credentials_test.go
+++ b/resources/providers/azurelib/auth/credentials_test.go
@@ -45,6 +45,18 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "Should return a DefaultAzureCredential on unknown client credentials type",
+			config: config.AzureConfig{
+				Credentials: config.AzureClientOpt{
+					ClientCredentialsType: "unknown",
+				},
+			},
+			authProviderInitFn: initDefaultCredentialsMock(nil),
+			want: &AzureFactoryConfig{
+				Credentials: &azidentity.DefaultAzureCredential{},
+			},
+		},
+		{
 			name: "Should return a ClientSecretCredential",
 			config: config.AzureConfig{
 				Credentials: config.AzureClientOpt{


### PR DESCRIPTION
### Summary of your changes
<!--
Please provide a detailed description of the changes introduced by this Pull Request.
Provide a description of the main changes, as well as any additional information the code reviewer should be aware of before beginning the review process.
-->
Based on the discussion in [this comment](https://github.com/elastic/integrations/pull/8376#discussion_r1390451815), this PR adds the Azure credentials type in the config and uses it to identify which Azure `TokenCredential` to use.

Enumerator values are on par with [this PR](https://github.com/elastic/kibana/pull/171069).

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
