### PR TITLE
IGNORE_PREFIX fix in delete_env

### DIFF
--- a/deploy/test-environments/delete_env.sh
+++ b/deploy/test-environments/delete_env.sh
@@ -200,7 +200,7 @@ FAILED_AZURE_DEPLOYMENTS=()
 FAILED_AZURE_RESOURCES=()
 FAILED_AZURE_GROUPS=()
 deployment_names=('cloudbeat-vm-deployment' 'role-assignment-deployment' 'elastic-agent-deployment')
-groups=$(az group list --query "[?starts_with(name, '$ENV_PREFIX')].name" -o tsv | grep -v "^$IGNORE_PREFIX")
+groups=$(az group list --query "[?starts_with(name, '$ENV_PREFIX')].name" -o tsv | awk -v prefix="$IGNORE_PREFIX" '{if (prefix == "") print $0; else if (!($0 ~ "^" prefix)) print $0}')
 for group in $groups; do
     for dep_name in ${#deployment_names[@]}; do
         resource_ids=$(az deployment group show --name "$dep_name" --resource-group "$group" --query "properties.outputResources[].id" --output tsv)


### PR DESCRIPTION
### Summary of your changes
Fixing a case when IGNORE_PREFIX equals to an empty string and we remove groups with grep -v

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
