### PR TITLE
Azure credentials config: Add missing type `arm_template`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -101,6 +101,7 @@ type AzureClientOpt struct {
 }
 
 const (
+	AzureClientCredentialsTypeARMTemplate      = "arm_template"
 	AzureClientCredentialsTypeManagedIdentity  = "managed_identity"
 	AzureClientCredentialsTypeSecret           = "service_principal_with_client_secret"
 	AzureClientCredentialsTypeCertificate      = "service_principal_with_client_certificate"

--- a/resources/providers/azurelib/auth/credentials.go
+++ b/resources/providers/azurelib/auth/credentials.go
@@ -49,7 +49,7 @@ func (p *ConfigProvider) GetAzureClientConfig(cfg config.AzureConfig) (*AzureFac
 			return nil, ErrIncompleteUsernamePassword
 		}
 		return p.getUsernamePasswordCredentialsConfig(cfg)
-	case "", config.AzureClientCredentialsTypeManagedIdentity:
+	case "", config.AzureClientCredentialsTypeManagedIdentity, config.AzureClientCredentialsTypeARMTemplate:
 		return p.getDefaultCredentialsConfig()
 	}
 

--- a/resources/providers/azurelib/auth/credentials_test.go
+++ b/resources/providers/azurelib/auth/credentials_test.go
@@ -45,6 +45,30 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "Should return a DefaultAzureCredential using managed_identity type",
+			config: config.AzureConfig{
+				Credentials: config.AzureClientOpt{
+					ClientCredentialsType: config.AzureClientCredentialsTypeManagedIdentity,
+				},
+			},
+			authProviderInitFn: initDefaultCredentialsMock(nil),
+			want: &AzureFactoryConfig{
+				Credentials: &azidentity.DefaultAzureCredential{},
+			},
+		},
+		{
+			name: "Should return a DefaultAzureCredential using arm_template type",
+			config: config.AzureConfig{
+				Credentials: config.AzureClientOpt{
+					ClientCredentialsType: config.AzureClientCredentialsTypeARMTemplate,
+				},
+			},
+			authProviderInitFn: initDefaultCredentialsMock(nil),
+			want: &AzureFactoryConfig{
+				Credentials: &azidentity.DefaultAzureCredential{},
+			},
+		},
+		{
 			name: "Should return a error on unknown client credentials type",
 			config: config.AzureConfig{
 				Credentials: config.AzureClientOpt{


### PR DESCRIPTION
### Summary of your changes
Add the missing `arm_template` azure credential type, which is the value is used on ARM Template deployments.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
Fixes: https://github.com/elastic/cloudbeat/issues/1563

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
