### PR TITLE
Add azure credential type: manual (backwards compatibility value)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -103,6 +103,7 @@ type AzureClientOpt struct {
 const (
 	AzureClientCredentialsTypeARMTemplate      = "arm_template"
 	AzureClientCredentialsTypeManagedIdentity  = "managed_identity"
+	AzureClientCredentialsTypeManual           = "manual"
 	AzureClientCredentialsTypeSecret           = "service_principal_with_client_secret"
 	AzureClientCredentialsTypeCertificate      = "service_principal_with_client_certificate"
 	AzureClientCredentialsTypeUsernamePassword = "service_principal_with_client_username_and_password"

--- a/resources/providers/azurelib/auth/credentials.go
+++ b/resources/providers/azurelib/auth/credentials.go
@@ -49,7 +49,7 @@ func (p *ConfigProvider) GetAzureClientConfig(cfg config.AzureConfig) (*AzureFac
 			return nil, ErrIncompleteUsernamePassword
 		}
 		return p.getUsernamePasswordCredentialsConfig(cfg)
-	case "", config.AzureClientCredentialsTypeManagedIdentity, config.AzureClientCredentialsTypeARMTemplate:
+	case "", config.AzureClientCredentialsTypeManagedIdentity, config.AzureClientCredentialsTypeARMTemplate, config.AzureClientCredentialsTypeManual:
 		return p.getDefaultCredentialsConfig()
 	}
 

--- a/resources/providers/azurelib/auth/credentials_test.go
+++ b/resources/providers/azurelib/auth/credentials_test.go
@@ -18,6 +18,7 @@
 package auth
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -49,6 +50,18 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			config: config.AzureConfig{
 				Credentials: config.AzureClientOpt{
 					ClientCredentialsType: config.AzureClientCredentialsTypeManagedIdentity,
+				},
+			},
+			authProviderInitFn: initDefaultCredentialsMock(nil),
+			want: &AzureFactoryConfig{
+				Credentials: &azidentity.DefaultAzureCredential{},
+			},
+		},
+		{
+			name: "Should return a DefaultAzureCredential using manual type",
+			config: config.AzureConfig{
+				Credentials: config.AzureClientOpt{
+					ClientCredentialsType: config.AzureClientCredentialsTypeManual,
 				},
 			},
 			authProviderInitFn: initDefaultCredentialsMock(nil),
@@ -174,6 +187,17 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Should return an error on credentials error",
+			config: config.AzureConfig{
+				Credentials: config.AzureClientOpt{
+					ClientCredentialsType: config.AzureClientCredentialsTypeManagedIdentity,
+				},
+			},
+			authProviderInitFn: initDefaultCredentialsMock(errMockAzure),
+			want:               nil,
+			wantErr:            true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -209,3 +233,5 @@ func initDefaultCredentialsMock(err error) func(*MockAzureAuthProviderAPI) {
 		}
 	}
 }
+
+var errMockAzure = errors.New("mock azure error")


### PR DESCRIPTION
### Summary of your changes
<!--
Please provide a detailed description of the changes introduced by this Pull Request.
Provide a description of the main changes, as well as any additional information the code reviewer should be aware of before beginning the review process.
-->
Add Azure credential type value `manual` for backward compatibility reasons to cover upgrade while Manual setup access was selected. 


### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
- Related: https://github.com/elastic/cloudbeat/issues/1563

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
