### PR TITLE
Update updatecli workflow to also apply changes to latest active branch

### DIFF
--- a/.ci/updatecli/updatecli.d/update-beats.yml
+++ b/.ci/updatecli/updatecli.d/update-beats.yml
@@ -1,6 +1,6 @@
 ---
 name: Update Elastic Beats go.mod Version
-pipelineid: 'updatecli-beats-{{ .github.branch }}'
+pipelineid: 'updatecli-beats-{{ requiredEnv "GIT_BRANCH" }}'
 
 scms:
   default:
@@ -12,7 +12,7 @@ scms:
       repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
-      branch: "{{ .github.branch }}"
+      branch: '{{ requiredEnv "GIT_BRANCH" }}'
 
 actions:
   default:
@@ -39,7 +39,7 @@ sources:
   beats:
     kind: json
     spec:
-      file: 'https://api.github.com/repos/elastic/beats/commits?sha={{ .github.branch }}&per_page=1'
+      file: 'https://api.github.com/repos/elastic/beats/commits?sha={{ requiredEnv "GIT_BRANCH" }}&per_page=1'
       key: '.[0].sha'
     transformers:
       # substring 12 chars so it works for the condition

--- a/.ci/updatecli/updatecli.d/update-golang.yml
+++ b/.ci/updatecli/updatecli.d/update-golang.yml
@@ -1,6 +1,6 @@
 ---
 name: Update Go Version
-pipelineid: 'updatecli-golang-{{ .github.branch }}'
+pipelineid: 'updatecli-golang-{{ requiredEnv "GIT_BRANCH" }}'
 
 scms:
   default:
@@ -12,7 +12,7 @@ scms:
       repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
-      branch: "{{ .github.branch }}"
+      branch: '{{ requiredEnv "GIT_BRANCH" }}'
 
 actions:
   cloudbeat:

--- a/.ci/updatecli/updatecli.d/update-hermit.yml
+++ b/.ci/updatecli/updatecli.d/update-hermit.yml
@@ -1,6 +1,6 @@
 ---
 name: Update Hermit and Pre-commit Dependencies
-pipelineid: 'updatecli-hermit-{{ .github.branch }}'
+pipelineid: 'updatecli-hermit-{{ requiredEnv "GIT_BRANCH" }}'
 
 scms:
   default:
@@ -12,7 +12,7 @@ scms:
       repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
-      branch: "{{ .github.branch }}"
+      branch: '{{ requiredEnv "GIT_BRANCH" }}'
 
 actions:
   default:

--- a/.ci/updatecli/values.yml
+++ b/.ci/updatecli/values.yml
@@ -1,4 +1,3 @@
 github:
   owner: "elastic"
   repository: "cloudbeat"
-  branch: "main"

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pipeline-name: [ golang, beat ]
+        pipeline-name: [ golang, beats ]
     steps:
       - uses: actions/checkout@v4
       - name: Init Hermit

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -53,8 +53,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Init Hermit
         run: ./bin/hermit env -r >> $GITHUB_ENV
-      - name: Set Branch
-        run: echo "GIT_BRANCH=main" >> $GITHUB_ENV
       - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
@@ -63,6 +61,8 @@ jobs:
           pipeline: ./.ci/updatecli/updatecli.d/update-${{ matrix.pipeline-name }}.yml
           values: ./.ci/updatecli/values.yml
           notifyIfFailure: false
+        env:
+          GIT_BRANCH: main
 
   updatecli-backport:
     name: Update ${{ matrix.pipeline-name }} dependencies - backport
@@ -78,7 +78,7 @@ jobs:
       - name: Set Branch
         run: |
           branchName=$(git branch -r \
-            | grep 'origin/[0-9]\+\.[0-9]\+' \
+            | grep -E 'origin/[0-9]+\.[0-9]+' \
             | awk -F/ '{print $2}' \
             | sort -Vr \
             | head -n 1)

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -27,8 +27,8 @@ name: Update Dependencies with Updatecli
 #       schedule
 #       ```
 #
-# TEST ON YOUR LOCAL FORK:
-# It doesn't work in local forks because of lacking vault permissions
+# TEST ON YOUR FORK:
+# It doesn't work in forks because of lacking vault permissions
 
 on:
   workflow_dispatch:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,6 +1,35 @@
 ---
 name: Update Dependencies with Updatecli
 
+# TESTING
+# This workflow depends on elastic/apm-pipeline-library/.github/actions/updatecli, which is tricky to test
+#
+# TEST LOCALLY (with act):
+# 1. Logging to github with `gh auth`
+#
+# 2. Configure the job you want to run by replacing the step `elastic/apm-pipeline-library/.github/actions/updatecli` by
+#       ```
+#      - name: Install Updatecli in the runner
+#        uses: updatecli/updatecli-action@v2
+#      - name: Run Updatecli in apply mode
+#        run: "updatecli apply --debug --config .ci/updatecli/updatecli.d/update-beats.yml --values .ci/updatecli/values.yml"
+#        env:
+#          GITHUB_TOKEN: "${{ secrets.MY_GITHUB_TOKEN }}"
+#          GIT_USER: foo
+#          GIT_EMAIL: bar@elastic.co
+#       ```
+#
+# 3. Pass the secret `MY_GITHUB_TOKEN` in the act command. e.g:
+#       ```
+#       act --container-architecture linux/amd64 \
+#       -s MY_GITHUB_TOKEN="$(gh auth token)" \
+#       --workflows ./.github/workflows/updatecli.yml \
+#       schedule
+#       ```
+#
+# TEST ON YOUR LOCAL FORK:
+# It doesn't work in local forks because of lacking vault permissions
+
 on:
   workflow_dispatch:
   schedule:
@@ -19,11 +48,42 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pipeline-name: [beats, golang, hermit]
+        pipeline-name: [ beats, golang, hermit ]
     steps:
       - uses: actions/checkout@v4
       - name: Init Hermit
         run: ./bin/hermit env -r >> $GITHUB_ENV
+      - name: Set Branch
+        run: echo "GIT_BRANCH=main" >> $GITHUB_ENV
+      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.ci/updatecli/updatecli.d/update-${{ matrix.pipeline-name }}.yml
+          values: ./.ci/updatecli/values.yml
+          notifyIfFailure: false
+
+  updatecli-backport:
+    name: Update ${{ matrix.pipeline-name }} dependencies - backport
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        pipeline-name: [ golang, beat ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Init Hermit
+        run: ./bin/hermit env -r >> $GITHUB_ENV
+      - name: Set Branch
+        run: |
+          branchName=$(git branch -r \
+            | grep 'origin/[0-9]\+\.[0-9]\+' \
+            | awk -F/ '{print $2}' \
+            | sort -Vr \
+            | head -n 1)
+
+          echo "GIT_BRANCH=$branchName" >> $GITHUB_ENV
       - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
### Summary of your changes
Extended the [updatecli](https://github.com/elastic/cloudbeat/actions/workflows/updatecli.yml) workflow to check and update Go and Beat versions on latest active branches too.

The identification of what is the latest active branch was made fetching all remote branches, filtering what matches `MAJOR.MINOR` pattern, [sort by version](https://man7.org/linux/man-pages/man1/sort.1.html) (`sort -V`) and selecting the highest version.


### Related Issues
- Fixes https://github.com/elastic/cloudbeat/issues/1550

### Checklist
- [x] I have added the necessary README/documentation (if appropriate)