### PR TITLE
Add the buildkite-pipeline to the catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -32,3 +32,62 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-cloudbeat
+  description: Buildkite Pipeline for cloudbeat
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/cloudbeat
+
+spec:
+  type: buildkite-pipeline
+  owner: group:cloudbeat
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: cloudbeat
+    spec:
+      repository: elastic/cloudbeat
+      pipeline_file: ".buildkite/pipeline.yml"
+      provider_settings:
+        build_branches: true
+        build_tags: false
+        build_pull_requests: false
+        filter_enabled: true
+        filter_condition: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+$$/
+      teams:
+        cloud-security-posture:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-csp-policies-ci
+spec:
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: Rego policies ci
+      name: csp-policies-ci
+    spec:
+      pipeline_file: .buildkite/pipelines/csp-policies-ci.yml
+      provider_settings:
+        trigger_mode: none
+      repository: elastic/cloudbeat
+      teams:
+        cloud-security-posture: {}
+        everyone:
+          access_level: READ_ONLY
+  owner: group:cloud-security-posture
+  type: buildkite-pipeline


### PR DESCRIPTION
This PR converts the data in
https://github.com/elastic/ci/blob/6843857da04cc0602307ed3773ecec4c9c87f4ca/terrazzo/manifests/prod/buildkite/
 into an RRE and stores it their associated repo.