### PR TITLE
Remove role deployment from deletion of env

### DIFF
--- a/deploy/test-environments/delete_env.sh
+++ b/deploy/test-environments/delete_env.sh
@@ -202,7 +202,7 @@ FAILED_AZURE_GROUPS=()
 deployment_names=('cloudbeat-vm-deployment' 'elastic-agent-deployment')
 groups=$(az group list --query "[?starts_with(name, '$ENV_PREFIX')].name" -o tsv | awk -v prefix="$IGNORE_PREFIX" '{if (prefix == "") print $0; else if (!($0 ~ "^" prefix)) print $0}')
 for group in $groups; do
-    for dep_name in ${deployment_names[@]}; do
+    for dep_name in "${deployment_names[@]}"; do
         resource_ids=$(az deployment group show --name "$dep_name" --resource-group "$group" --query "properties.outputResources[].id" --output tsv)
         if [ -z "$resource_ids" ]; then
             echo "No resources found for deployment $dep_name."
@@ -216,9 +216,9 @@ for group in $groups; do
                 elif [[ $resource_id == *"Microsoft.Compute/virtualMachines"* ]]; then
                     disk_ids=$(az disk list --resource-group "$group" --query "[?managedBy=='$resource_id')].id" --output tsv)
                     for disk_id in $disk_ids; do
-                        az resource delete --ids "$resource_id" || {
-                            echo "Failed to delete resource: $resource_id"
-                            FAILED_AZURE_RESOURCES+=("$resource_id")
+                        az resource delete --ids "$disk_id" || {
+                            echo "Failed to delete resource: $disk_id"
+                            FAILED_AZURE_RESOURCES+=("$disk_id")
                             continue
                         }
                     done

--- a/deploy/test-environments/delete_env.sh
+++ b/deploy/test-environments/delete_env.sh
@@ -199,16 +199,30 @@ printf "%s\n" "${FAILED_DEPLOYMENTS[@]}"
 FAILED_AZURE_DEPLOYMENTS=()
 FAILED_AZURE_RESOURCES=()
 FAILED_AZURE_GROUPS=()
-deployment_names=('cloudbeat-vm-deployment' 'role-assignment-deployment' 'elastic-agent-deployment')
+deployment_names=('cloudbeat-vm-deployment' 'elastic-agent-deployment')
 groups=$(az group list --query "[?starts_with(name, '$ENV_PREFIX')].name" -o tsv | awk -v prefix="$IGNORE_PREFIX" '{if (prefix == "") print $0; else if (!($0 ~ "^" prefix)) print $0}')
 for group in $groups; do
-    for dep_name in ${#deployment_names[@]}; do
+    for dep_name in ${deployment_names[@]}; do
         resource_ids=$(az deployment group show --name "$dep_name" --resource-group "$group" --query "properties.outputResources[].id" --output tsv)
         if [ -z "$resource_ids" ]; then
             echo "No resources found for deployment $dep_name."
         else
             echo "Deleting resources deployed by $dep_name:"
             for resource_id in $resource_ids; do
+                # Skip deleting the MSI extension resource because it will be deleted with the VM
+                # Removing this condition will cause failure when VM is deleted prior to the extension
+                if [[ $resource_id == *"extensions/EnableMSIExtension"* ]]; then
+                    continue
+                elif [[ $resource_id == *"Microsoft.Compute/virtualMachines"* ]]; then
+                    disk_ids=$(az disk list --resource-group "$group" --query "[?managedBy=='$resource_id')].id" --output tsv)
+                    for disk_id in $disk_ids; do
+                        az resource delete --ids "$resource_id" || {
+                            echo "Failed to delete resource: $resource_id"
+                            FAILED_AZURE_RESOURCES+=("$resource_id")
+                            continue
+                        }
+                    done
+                fi
                 az resource delete --ids "$resource_id" || {
                     echo "Failed to delete resource: $resource_id"
                     FAILED_AZURE_RESOURCES+=("$resource_id")


### PR DESCRIPTION
### Summary of your changes
Removed `role-assignment-deployment` from the deployment lists because it is not being deployed on resource group level.
This is deployed at the subscription level.
There are no resources that it creates and it just maps the role.
As part of the deletion of `cloudbeat-vm` this mapping should get purged as well.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
