### PR TITLE
Add cycle-based cache

### DIFF
--- a/evaluator/opa_test.go
+++ b/evaluator/opa_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/elastic/cloudbeat/config"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
@@ -129,7 +130,7 @@ func (s *OpaTestSuite) TestOpaEvaluatorWithDecisionLogs() {
 			for i := 0; i < tt.evals; i++ {
 				_, err = e.Eval(ctx, fetching.ResourceInfo{
 					Resource:      &DummyResource{},
-					CycleMetadata: fetching.CycleMetadata{},
+					CycleMetadata: cycle.Metadata{},
 				})
 				s.Require().NoError(err)
 			}

--- a/resources/fetching/cycle/cache.go
+++ b/resources/fetching/cycle/cache.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cycle
+
+// TODO: test
+
+import (
+	"context"
+	"sync"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+// Cache is a thread-safe generic struct that you can use to cache values for the current cycle. On a new cycle,
+// determined by cycle metadata, the callback function is called and a new value is initialized. If the callback fails
+// and an old value exists, it is re-used.
+type Cache[T any] struct {
+	log         *logp.Logger
+	lastCycle   Metadata
+	cb          func(context.Context) (T, error)
+	cachedValue T
+	mu          sync.RWMutex
+}
+
+func NewCache[T any](log *logp.Logger, cb func(context.Context) (T, error)) Cache[T] {
+	return Cache[T]{
+		log:       log.Named("cycle.cache"),
+		cb:        cb,
+		lastCycle: Metadata{Sequence: -1},
+	}
+}
+
+func (c *Cache[T]) GetValue(ctx context.Context, cycle Metadata) (T, error) {
+	if !c.needsUpdate(cycle) {
+		return c.cachedValue, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.needsUpdateLocked(cycle) { // check again with write lock.
+		return c.cachedValue, nil
+	}
+
+	result, err := c.cb(ctx)
+	if err != nil {
+		if c.lastCycle.Sequence < 0 {
+			return result, err
+		}
+		c.log.Errorf("Failed to renew, using cached value: %v", err)
+	} else {
+		c.cachedValue = result
+		c.lastCycle = cycle
+	}
+	return c.cachedValue, nil
+}
+
+func (c *Cache[T]) needsUpdate(cycle Metadata) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.needsUpdateLocked(cycle)
+}
+
+func (c *Cache[T]) needsUpdateLocked(cycle Metadata) bool {
+	return c.lastCycle.Sequence < 0 || c.lastCycle.Sequence < cycle.Sequence
+}

--- a/resources/fetching/cycle/cache_test.go
+++ b/resources/fetching/cycle/cache_test.go
@@ -1,0 +1,183 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cycle
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/atomic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/cloudbeat/resources/utils/testhelper"
+)
+
+type helper struct {
+	value  int
+	err    error
+	called atomic.Int
+}
+
+func (h *helper) cb(_ context.Context) (int, error) {
+	h.called.Inc()
+	return h.value, h.err
+}
+
+func TestCache(t *testing.T) {
+	h := helper{}
+	cache := NewCache(testhelper.NewLogger(t), h.cb)
+
+	tests := []struct {
+		name string
+
+		sequence int64
+		setValue int
+		setError bool
+
+		want       int
+		wantErr    bool
+		wantCalled bool
+	}{
+		{
+			name:       "error first",
+			sequence:   10,
+			setError:   true,
+			want:       0,
+			wantErr:    true,
+			wantCalled: true,
+		},
+		{
+			name:       "called with error again",
+			sequence:   0,
+			setError:   true,
+			want:       0,
+			wantErr:    true,
+			wantCalled: true,
+		},
+		{
+			name:       "success",
+			sequence:   0,
+			setValue:   1,
+			setError:   false,
+			want:       1,
+			wantErr:    false,
+			wantCalled: true,
+		},
+		{
+			name:       "success call skipped",
+			sequence:   0,
+			setValue:   100,  // not used
+			setError:   true, // not used
+			want:       1,    // previous value
+			wantErr:    false,
+			wantCalled: false,
+		},
+		{
+			name:       "new cycle error",
+			sequence:   1,
+			setError:   true,
+			want:       1, // previous value
+			wantErr:    false,
+			wantCalled: true,
+		},
+		{
+			name:       "same cycle but with success",
+			sequence:   1,
+			setValue:   2,
+			setError:   false,
+			want:       2,
+			wantErr:    false,
+			wantCalled: true,
+		},
+		{
+			name:       "old cycle",
+			sequence:   0,
+			want:       2, // previous value
+			wantErr:    false,
+			wantCalled: false,
+		},
+		{
+			name:       "new cycle",
+			sequence:   5,
+			setValue:   3,
+			setError:   false,
+			want:       3,
+			wantErr:    false,
+			wantCalled: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h.value = tt.setValue
+			if tt.setError {
+				h.err = errors.New("some error")
+			} else {
+				h.err = nil
+			}
+			h.called.Store(0)
+			got, err := cache.GetValue(context.Background(), Metadata{Sequence: tt.sequence})
+			if tt.wantErr {
+				require.ErrorContains(t, err, "some error")
+			} else {
+				require.NoError(t, err)
+			}
+			expectedCalls := 0
+			if tt.wantCalled {
+				expectedCalls = 1
+			}
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, expectedCalls, h.called.Load())
+		})
+	}
+}
+
+func TestCache_Lock(t *testing.T) {
+	ctx := context.Background()
+	count := 0
+	ch := make(chan struct{})
+	cache := NewCache(testhelper.NewLogger(t), func(_ context.Context) (int, error) {
+		count++
+		if count == 1 {
+			close(ch)
+			time.Sleep(50 * time.Millisecond)
+			return 1, nil
+		}
+		return -1, errors.New("some error")
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	defer wg.Wait() // wait for tests in goroutine
+	go func() {
+		defer wg.Done()
+
+		got, err := cache.GetValue(ctx, Metadata{Sequence: 1})
+		require.NoError(t, err)
+		assert.Equal(t, 1, got)
+	}()
+
+	<-ch // wait until callback is blocked
+	got, err := cache.GetValue(ctx, Metadata{Sequence: 1})
+	require.NoError(t, err)
+	assert.Equal(t, 1, got)
+	assert.Equal(t, 1, count)
+}

--- a/resources/fetching/cycle/metadata.go
+++ b/resources/fetching/cycle/metadata.go
@@ -15,13 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package transformer
+package cycle
 
-import (
-	"github.com/elastic/cloudbeat/resources/fetching/cycle"
-)
-
-type ResourceTypeMetadata struct {
-	cycle.Metadata
-	Type string
+type Metadata struct {
+	Sequence int64
 }

--- a/resources/fetching/fetcher.go
+++ b/resources/fetching/fetcher.go
@@ -21,6 +21,8 @@ import (
 	"context"
 
 	awssdk "github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
+
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 )
 
 const (
@@ -100,7 +102,7 @@ const (
 
 // Fetcher represents a data fetcher.
 type Fetcher interface {
-	Fetch(context.Context, CycleMetadata) error
+	Fetch(context.Context, cycle.Metadata) error
 	Stop()
 }
 
@@ -111,11 +113,7 @@ type Condition interface {
 
 type ResourceInfo struct {
 	Resource
-	CycleMetadata
-}
-
-type CycleMetadata struct {
-	Sequence int64
+	CycleMetadata cycle.Metadata
 }
 
 type EcsGcp struct {

--- a/resources/fetching/fetchers/aws/ecr_fetcher.go
+++ b/resources/fetching/fetchers/aws/ecr_fetcher.go
@@ -29,6 +29,7 @@ import (
 	k8s "k8s.io/client-go/kubernetes"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ecr"
 )
 
@@ -67,7 +68,7 @@ func NewEcrFetcher(log *logp.Logger, ch chan fetching.ResourceInfo, kubeProvider
 
 func (f *EcrFetcher) Stop() {}
 
-func (f *EcrFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *EcrFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Debug("Starting EcrFetcher.Fetch")
 
 	podsList, err := f.kubeClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{})

--- a/resources/fetching/fetchers/aws/ecr_fetcher_test.go
+++ b/resources/fetching/fetchers/aws/ecr_fetcher_test.go
@@ -34,6 +34,7 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ecr"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
@@ -245,7 +246,7 @@ func (s *EcrFetcherTestSuite) TestCreateFetcher() {
 		}
 
 		ctx := context.Background()
-		err = ecrFetcher.Fetch(ctx, fetching.CycleMetadata{})
+		err = ecrFetcher.Fetch(ctx, cycle.Metadata{})
 		results := testhelper.CollectResources(s.resourceCh)
 
 		s.Equal(len(test.expectedRepositoriesNames), len(results))
@@ -328,7 +329,7 @@ func (s *EcrFetcherTestSuite) TestCreateFetcherErrorCases() {
 		}
 
 		ctx := context.Background()
-		err = ecrFetcher.Fetch(ctx, fetching.CycleMetadata{})
+		err = ecrFetcher.Fetch(ctx, cycle.Metadata{})
 		s.Require().NoError(err)
 		results := testhelper.CollectResources(s.resourceCh)
 		s.Empty(results)

--- a/resources/fetching/fetchers/aws/elb_fetcher.go
+++ b/resources/fetching/fetchers/aws/elb_fetcher.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/elb"
 )
 
@@ -58,7 +59,7 @@ func NewElbFetcher(log *logp.Logger, ch chan fetching.ResourceInfo, kubeProvider
 	}
 }
 
-func (f *ElbFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *ElbFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Debug("Starting ElbFetcher.Fetch")
 
 	balancers, err := f.GetLoadBalancers(ctx)

--- a/resources/fetching/fetchers/aws/elb_fetcher_test.go
+++ b/resources/fetching/fetchers/aws/elb_fetcher_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/elb"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
@@ -137,7 +138,7 @@ func (s *ElbFetcherTestSuite) TestCreateFetcher() {
 			cloudIdentity:   &identity,
 		}
 
-		err = elbFetcher.Fetch(context.Background(), fetching.CycleMetadata{})
+		err = elbFetcher.Fetch(context.Background(), cycle.Metadata{})
 		results := testhelper.CollectResources(s.resourceCh)
 
 		s.Equal(len(test.expectedlbNames), len(results))
@@ -208,7 +209,7 @@ func (s *ElbFetcherTestSuite) TestCreateFetcherErrorCases() {
 
 		ctx := context.Background()
 
-		err = elbFetcher.Fetch(ctx, fetching.CycleMetadata{})
+		err = elbFetcher.Fetch(ctx, cycle.Metadata{})
 		results := testhelper.CollectResources(s.resourceCh)
 
 		s.Nil(results)

--- a/resources/fetching/fetchers/aws/iam_fetcher.go
+++ b/resources/fetching/fetchers/aws/iam_fetcher.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/iam"
 )
@@ -56,7 +57,7 @@ func NewIAMFetcher(log *logp.Logger, provider iam.AccessManagement, ch chan fetc
 
 // Fetch collects IAM resources, such as password-policy and IAM users.
 // The resources are enriched by the provider and being send to evaluation.
-func (f IAMFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f IAMFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Debug("Starting IAMFetcher.Fetch")
 	iamResources := make([]awslib.AwsResource, 0)
 

--- a/resources/fetching/fetchers/aws/iam_fetcher_test.go
+++ b/resources/fetching/fetchers/aws/iam_fetcher_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/iam"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
@@ -226,7 +227,7 @@ func (s *IamFetcherTestSuite) TestIamFetcher_Fetch() {
 				},
 			}
 
-			err := iamFetcher.Fetch(ctx, fetching.CycleMetadata{})
+			err := iamFetcher.Fetch(ctx, cycle.Metadata{})
 			s.Require().NoError(err)
 
 			results := testhelper.CollectResources(s.resourceCh)

--- a/resources/fetching/fetchers/aws/kms_fetcher.go
+++ b/resources/fetching/fetchers/aws/kms_fetcher.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/kms"
 )
@@ -46,7 +47,7 @@ func NewKMSFetcher(log *logp.Logger, provider kms.KMS, ch chan fetching.Resource
 	}
 }
 
-func (f *KmsFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *KmsFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Info("Starting KMSFetcher.Fetch")
 
 	keys, err := f.kms.DescribeSymmetricKeys(ctx)

--- a/resources/fetching/fetchers/aws/kms_fetcher_test.go
+++ b/resources/fetching/fetchers/aws/kms_fetcher_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/kms"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
@@ -91,7 +92,7 @@ func (s *KmsFetcherTestSuite) TestFetcher_Fetch() {
 				resourceCh: s.resourceCh,
 			}
 
-			err := kmsFetcher.Fetch(ctx, fetching.CycleMetadata{})
+			err := kmsFetcher.Fetch(ctx, cycle.Metadata{})
 			s.Require().NoError(err)
 
 			results := testhelper.CollectResources(s.resourceCh)

--- a/resources/fetching/fetchers/aws/logging_fetcher.go
+++ b/resources/fetching/fetchers/aws/logging_fetcher.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/aws_cis/logging"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/configservice"
@@ -63,7 +64,7 @@ func NewLoggingFetcher(
 	}
 }
 
-func (f LoggingFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f LoggingFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Debug("Starting LoggingFetcher.Fetch")
 	trails, err := f.loggingProvider.DescribeTrails(ctx)
 	if err != nil {

--- a/resources/fetching/fetchers/aws/logging_fetcher_test.go
+++ b/resources/fetching/fetchers/aws/logging_fetcher_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/aws_cis/logging"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/cloudtrail"
@@ -125,7 +126,7 @@ func TestLoggingFetcher_Fetch(t *testing.T) {
 				},
 			}
 
-			err := f.Fetch(ctx, fetching.CycleMetadata{})
+			err := f.Fetch(ctx, cycle.Metadata{})
 			resources := testhelper.CollectResources(ch)
 			require.NoError(t, err)
 			assert.Len(t, resources, tt.expectedResources)

--- a/resources/fetching/fetchers/aws/monitoring_fetcher.go
+++ b/resources/fetching/fetchers/aws/monitoring_fetcher.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/aws_cis/monitoring"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/securityhub"
@@ -57,7 +58,7 @@ func NewMonitoringFetcher(log *logp.Logger, provider monitoring.Client, security
 	}
 }
 
-func (m MonitoringFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (m MonitoringFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	m.log.Debug("Starting MonitoringFetcher.Fetch")
 	out, err := m.provider.AggregateResources(ctx)
 	if err != nil {

--- a/resources/fetching/fetchers/aws/monitoring_fetcher_test.go
+++ b/resources/fetching/fetchers/aws/monitoring_fetcher_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/aws_cis/monitoring"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/securityhub"
@@ -125,7 +126,7 @@ func TestMonitoringFetcher_Fetch(t *testing.T) {
 				cloudIdentity: &cloud.Identity{Account: "account"},
 			}
 
-			err := m.Fetch(ctx, fetching.CycleMetadata{})
+			err := m.Fetch(ctx, cycle.Metadata{})
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/resources/fetching/fetchers/aws/network_fetcher.go
+++ b/resources/fetching/fetchers/aws/network_fetcher.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
 )
@@ -54,7 +55,7 @@ func NewNetworkFetcher(log *logp.Logger, ec2Client ec2.ElasticCompute, ch chan f
 }
 
 // Fetch collects network resource such as network acl and security groups
-func (f NetworkFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f NetworkFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Debug("Starting NetworkFetcher.Fetch")
 	resources := f.aggregateResources(ctx, f.ec2Client)
 

--- a/resources/fetching/fetchers/aws/network_fetcher_test.go
+++ b/resources/fetching/fetchers/aws/network_fetcher_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/ec2"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
@@ -138,7 +139,7 @@ func TestNetworkFetcher_Fetch(t *testing.T) {
 				cloudIdentity: &cloud.Identity{Account: tt.name},
 			}
 
-			err := f.Fetch(ctx, fetching.CycleMetadata{})
+			err := f.Fetch(ctx, cycle.Metadata{})
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/resources/fetching/fetchers/aws/rds_fetcher.go
+++ b/resources/fetching/fetchers/aws/rds_fetcher.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/rds"
 )
@@ -49,7 +50,7 @@ func NewRdsFetcher(log *logp.Logger, provider rds.Rds, ch chan fetching.Resource
 	}
 }
 
-func (f *RdsFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *RdsFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Info("Starting RdsFetcher.Fetch")
 	dbInstances, err := f.provider.DescribeDBInstances(ctx)
 	if err != nil {

--- a/resources/fetching/fetchers/aws/rds_fetcher_test.go
+++ b/resources/fetching/fetchers/aws/rds_fetcher_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/rds"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
@@ -77,10 +78,10 @@ func (s *RdsFetcherTestSuite) TestFetcher_Fetch() {
 			},
 			expected: []fetching.ResourceInfo{{
 				Resource:      RdsResource{dbInstance: dbInstance1},
-				CycleMetadata: fetching.CycleMetadata{},
+				CycleMetadata: cycle.Metadata{},
 			}, {
 				Resource:      RdsResource{dbInstance: dbInstance2},
-				CycleMetadata: fetching.CycleMetadata{},
+				CycleMetadata: cycle.Metadata{},
 			}},
 		},
 	}
@@ -100,7 +101,7 @@ func (s *RdsFetcherTestSuite) TestFetcher_Fetch() {
 
 			ctx := context.Background()
 
-			err := rdsFetcher.Fetch(ctx, fetching.CycleMetadata{})
+			err := rdsFetcher.Fetch(ctx, cycle.Metadata{})
 			s.Require().NoError(err)
 
 			results := testhelper.CollectResources(s.resourceCh)

--- a/resources/fetching/fetchers/aws/s3_fetcher.go
+++ b/resources/fetching/fetchers/aws/s3_fetcher.go
@@ -23,6 +23,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/s3"
 )
@@ -45,7 +46,7 @@ func NewS3Fetcher(log *logp.Logger, s3 s3.S3, ch chan fetching.ResourceInfo) *S3
 	}
 }
 
-func (f *S3Fetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *S3Fetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Info("Starting S3Fetcher.Fetch")
 	buckets, err := f.s3.DescribeBuckets(ctx)
 	if err != nil {

--- a/resources/fetching/fetchers/aws/s3_fetcher_test.go
+++ b/resources/fetching/fetchers/aws/s3_fetcher_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/resources/providers/awslib/s3"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
@@ -88,7 +89,7 @@ func (s *S3FetcherTestSuite) TestFetcher_Fetch() {
 				resourceCh: s.resourceCh,
 			}
 
-			err := s3Fetcher.Fetch(ctx, fetching.CycleMetadata{})
+			err := s3Fetcher.Fetch(ctx, cycle.Metadata{})
 			s.Require().NoError(err)
 
 			results := testhelper.CollectResources(s.resourceCh)

--- a/resources/fetching/fetchers/azure/assets_fetcher.go
+++ b/resources/fetching/fetchers/azure/assets_fetcher.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/governance"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
@@ -84,7 +85,7 @@ func NewAzureAssetsFetcher(log *logp.Logger, ch chan fetching.ResourceInfo, prov
 	}
 }
 
-func (f *AzureAssetsFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *AzureAssetsFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Info("Starting AzureAssetsFetcher.Fetch")
 	var errAgg error
 	// This might be relevant if we'd like to fetch assets in parallel in order to evaluate a rule that uses multiple resources
@@ -118,7 +119,7 @@ func (f *AzureAssetsFetcher) Fetch(ctx context.Context, cMetadata fetching.Cycle
 	return errAgg
 }
 
-func resourceFromAsset(asset inventory.AzureAsset, cMetadata fetching.CycleMetadata, subscriptions map[string]governance.Subscription) fetching.ResourceInfo {
+func resourceFromAsset(asset inventory.AzureAsset, cMetadata cycle.Metadata, subscriptions map[string]governance.Subscription) fetching.ResourceInfo {
 	pair := AzureAssetTypeToTypePair[asset.Type]
 	subscription, ok := subscriptions[asset.SubscriptionId]
 	if !ok {

--- a/resources/fetching/fetchers/azure/assets_fetcher_test.go
+++ b/resources/fetching/fetchers/azure/assets_fetcher_test.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/governance"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
@@ -178,7 +179,7 @@ func (s *AzureAssetsFetcherTestSuite) fetch(provider *azurelib.MockProviderAPI, 
 		resourceCh: s.resourceCh,
 		provider:   provider,
 	}
-	err := fetcher.Fetch(context.Background(), fetching.CycleMetadata{})
+	err := fetcher.Fetch(context.Background(), cycle.Metadata{})
 	results := testhelper.CollectResources(s.resourceCh)
 	s.Require().Len(results, expectedLength)
 	return results, err

--- a/resources/fetching/fetchers/azure/batch_fetcher.go
+++ b/resources/fetching/fetchers/azure/batch_fetcher.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/governance"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
@@ -56,7 +57,7 @@ func NewAzureBatchAssetFetcher(log *logp.Logger, ch chan fetching.ResourceInfo, 
 	}
 }
 
-func (f *AzureBatchAssetFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *AzureBatchAssetFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Info("Starting AzureBatchAssetFetcher.Fetch")
 	subscriptions, err := f.provider.GetSubscriptions(ctx, cMetadata)
 	if err != nil {

--- a/resources/fetching/fetchers/azure/batch_fetcher_test.go
+++ b/resources/fetching/fetchers/azure/batch_fetcher_test.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/exp/maps"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/governance"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
@@ -105,7 +106,7 @@ func (s *AzureBatchAssetFetcherTestSuite) TestFetcher_Fetch() {
 		resourceCh: s.resourceCh,
 		provider:   mockProvider,
 	}
-	err := fetcher.Fetch(context.Background(), fetching.CycleMetadata{})
+	err := fetcher.Fetch(context.Background(), cycle.Metadata{})
 	s.Require().NoError(err)
 	results := testhelper.CollectResources(s.resourceCh)
 
@@ -205,7 +206,7 @@ func (s *AzureBatchAssetFetcherTestSuite) TestFetcher_Fetch_Subscriptions() {
 		resourceCh: s.resourceCh,
 		provider:   mockProvider,
 	}
-	err := fetcher.Fetch(context.Background(), fetching.CycleMetadata{})
+	err := fetcher.Fetch(context.Background(), cycle.Metadata{})
 	s.Require().NoError(err)
 	results := testhelper.CollectResources(s.resourceCh)
 

--- a/resources/fetching/fetchers/gcp/assets_fetcher.go
+++ b/resources/fetching/fetchers/gcp/assets_fetcher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/huandu/xstrings"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib/inventory"
 )
 
@@ -91,7 +92,7 @@ func NewGcpAssetsFetcher(_ context.Context, log *logp.Logger, ch chan fetching.R
 	}
 }
 
-func (f *GcpAssetsFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *GcpAssetsFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Info("Starting GcpAssetsFetcher.Fetch")
 
 	for typeName, assetTypes := range GcpAssetTypes {

--- a/resources/fetching/fetchers/gcp/assets_fetcher_test.go
+++ b/resources/fetching/fetchers/gcp/assets_fetcher_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib/inventory"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
@@ -79,7 +80,7 @@ func (s *GcpAssetsFetcherTestSuite) TestFetcher_Fetch() {
 		}, nil,
 	)
 
-	err := fetcher.Fetch(ctx, fetching.CycleMetadata{})
+	err := fetcher.Fetch(ctx, cycle.Metadata{})
 	s.Require().NoError(err)
 	results := testhelper.CollectResources(s.resourceCh)
 

--- a/resources/fetching/fetchers/gcp/log_sink_fetcher.go
+++ b/resources/fetching/fetchers/gcp/log_sink_fetcher.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib/inventory"
 )
@@ -49,7 +50,7 @@ func NewGcpLogSinkFetcher(_ context.Context, log *logp.Logger, ch chan fetching.
 	}
 }
 
-func (f *GcpLogSinkFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *GcpLogSinkFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Info("Starting GcpLogSinkFetcher.Fetch")
 
 	loggingAssets, err := f.provider.ListLoggingAssets(ctx)

--- a/resources/fetching/fetchers/gcp/log_sink_fetcher_test.go
+++ b/resources/fetching/fetchers/gcp/log_sink_fetcher_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib/inventory"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
@@ -81,7 +82,7 @@ func (s *GcpLogSinkFetcherTestSuite) TestFetcher_Fetch_Success() {
 		}, nil,
 	)
 
-	err := fetcher.Fetch(ctx, fetching.CycleMetadata{})
+	err := fetcher.Fetch(ctx, cycle.Metadata{})
 	s.Require().NoError(err)
 	results := testhelper.CollectResources(s.resourceCh)
 
@@ -100,7 +101,7 @@ func (s *GcpLogSinkFetcherTestSuite) TestFetcher_Fetch_Error() {
 
 	mockInventoryService.On("ListLoggingAssets", mock.Anything).Return(nil, errors.New("api call error"))
 
-	err := fetcher.Fetch(ctx, fetching.CycleMetadata{})
+	err := fetcher.Fetch(ctx, cycle.Metadata{})
 	s.Require().Error(err)
 }
 

--- a/resources/fetching/fetchers/gcp/monitoring_fetcher.go
+++ b/resources/fetching/fetchers/gcp/monitoring_fetcher.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib/inventory"
 )
@@ -54,7 +55,7 @@ var monitoringAssetTypes = map[string][]string{
 	"AlertPolicy": {inventory.MonitoringAlertPolicyAssetType},
 }
 
-func (f *GcpMonitoringFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *GcpMonitoringFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Info("Starting GcpMonitoringFetcher.Fetch")
 
 	monitoringAssets, err := f.provider.ListMonitoringAssets(ctx, monitoringAssetTypes)

--- a/resources/fetching/fetchers/gcp/monitoring_fetcher_test.go
+++ b/resources/fetching/fetchers/gcp/monitoring_fetcher_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib/inventory"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
@@ -86,7 +87,7 @@ func (s *GcpMonitoringFetcherTestSuite) TestFetcher_Fetch_Success() {
 		}, nil,
 	)
 
-	err := fetcher.Fetch(ctx, fetching.CycleMetadata{})
+	err := fetcher.Fetch(ctx, cycle.Metadata{})
 	s.Require().NoError(err)
 	results := testhelper.CollectResources(s.resourceCh)
 
@@ -105,7 +106,7 @@ func (s *GcpMonitoringFetcherTestSuite) TestFetcher_Fetch_Error() {
 
 	mockInventoryService.EXPECT().ListMonitoringAssets(mock.Anything, mock.Anything).Return(nil, errors.New("api call error"))
 
-	err := fetcher.Fetch(ctx, fetching.CycleMetadata{})
+	err := fetcher.Fetch(ctx, cycle.Metadata{})
 	s.Require().ErrorContains(err, "api call error")
 }
 

--- a/resources/fetching/fetchers/gcp/policies_fetcher.go
+++ b/resources/fetching/fetchers/gcp/policies_fetcher.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib/inventory"
 )
@@ -49,7 +50,7 @@ func NewGcpPoliciesFetcher(_ context.Context, log *logp.Logger, ch chan fetching
 	}
 }
 
-func (f *GcpPoliciesFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *GcpPoliciesFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Info("Starting GcpPoliciesFetcher.Fetch")
 
 	projectsAssets, err := f.provider.ListProjectsAncestorsPolicies(ctx)

--- a/resources/fetching/fetchers/gcp/policies_fetcher_test.go
+++ b/resources/fetching/fetchers/gcp/policies_fetcher_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib/inventory"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
@@ -81,7 +82,7 @@ func (s *GcpPoliciesFetcherTestSuite) TestFetcher_Fetch_Success() {
 		}, nil,
 	)
 
-	err := fetcher.Fetch(ctx, fetching.CycleMetadata{})
+	err := fetcher.Fetch(ctx, cycle.Metadata{})
 	s.Require().NoError(err)
 	results := testhelper.CollectResources(s.resourceCh)
 
@@ -99,7 +100,7 @@ func (s *GcpPoliciesFetcherTestSuite) TestFetcher_Fetch_Error() {
 
 	mockInventoryService.On("ListProjectsAncestorsPolicies", mock.Anything).Return(nil, errors.New("api call error"))
 
-	err := fetcher.Fetch(ctx, fetching.CycleMetadata{})
+	err := fetcher.Fetch(ctx, cycle.Metadata{})
 	s.Require().Error(err)
 }
 

--- a/resources/fetching/fetchers/gcp/service_usage_fetcher.go
+++ b/resources/fetching/fetchers/gcp/service_usage_fetcher.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib/inventory"
 )
@@ -49,7 +50,7 @@ func NewGcpServiceUsageFetcher(_ context.Context, log *logp.Logger, ch chan fetc
 	}
 }
 
-func (f *GcpServiceUsageFetcher) Fetch(ctx context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *GcpServiceUsageFetcher) Fetch(ctx context.Context, cMetadata cycle.Metadata) error {
 	f.log.Info("Starting GcpServiceUsageFetcher.Fetch")
 
 	serviceUsageAssets, err := f.provider.ListServiceUsageAssets(ctx)

--- a/resources/fetching/fetchers/gcp/service_usage_fetcher_test.go
+++ b/resources/fetching/fetchers/gcp/service_usage_fetcher_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib"
 	"github.com/elastic/cloudbeat/resources/providers/gcplib/inventory"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
@@ -81,7 +82,7 @@ func (s *GcpServiceUsageFetcherTestSuite) TestFetcher_Fetch_Success() {
 		}, nil,
 	)
 
-	err := fetcher.Fetch(ctx, fetching.CycleMetadata{})
+	err := fetcher.Fetch(ctx, cycle.Metadata{})
 	s.Require().NoError(err)
 	results := testhelper.CollectResources(s.resourceCh)
 
@@ -100,7 +101,7 @@ func (s *GcpServiceUsageFetcherTestSuite) TestFetcher_Fetch_Error() {
 
 	mockInventoryService.On("ListServiceUsageAssets", mock.Anything).Return(nil, errors.New("api call error"))
 
-	err := fetcher.Fetch(ctx, fetching.CycleMetadata{})
+	err := fetcher.Fetch(ctx, cycle.Metadata{})
 	s.Require().Error(err)
 }
 

--- a/resources/fetching/fetchers/k8s/file_system_fetcher.go
+++ b/resources/fetching/fetchers/k8s/file_system_fetcher.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/utils/user"
 )
 
@@ -97,7 +98,7 @@ func NewFsFetcher(log *logp.Logger, ch chan fetching.ResourceInfo, patterns []st
 	}
 }
 
-func (f *FileSystemFetcher) Fetch(_ context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *FileSystemFetcher) Fetch(_ context.Context, cMetadata cycle.Metadata) error {
 	f.log.Debug("Starting FileSystemFetcher.Fetch")
 
 	// Input files might contain glob pattern

--- a/resources/fetching/fetchers/k8s/file_system_fetcher_test.go
+++ b/resources/fetching/fetchers/k8s/file_system_fetcher_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 	"github.com/elastic/cloudbeat/resources/utils/user"
 )
@@ -77,7 +78,7 @@ func (s *FSFetcherTestSuite) TestFileFetcherFetchASingleFile() {
 	}
 
 	var results []fetching.ResourceInfo
-	err := fileFetcher.Fetch(context.TODO(), fetching.CycleMetadata{})
+	err := fileFetcher.Fetch(context.TODO(), cycle.Metadata{})
 	results = testhelper.CollectResources(s.resourceCh)
 
 	s.Require().NoError(err, "Fetcher was not able to fetch files from FS")
@@ -126,7 +127,7 @@ func (s *FSFetcherTestSuite) TestFileFetcherFetchTwoPatterns() {
 		patterns:   paths,
 	}
 
-	err := fileFetcher.Fetch(context.TODO(), fetching.CycleMetadata{})
+	err := fileFetcher.Fetch(context.TODO(), cycle.Metadata{})
 	results := testhelper.CollectResources(s.resourceCh)
 
 	s.Require().NoError(err, "Fetcher was not able to fetch files from FS")
@@ -183,7 +184,7 @@ func (s *FSFetcherTestSuite) TestFileFetcherFetchDirectoryOnly() {
 		osUser:     osUserMock,
 		resourceCh: s.resourceCh,
 	}
-	err := fileFetcher.Fetch(context.TODO(), fetching.CycleMetadata{})
+	err := fileFetcher.Fetch(context.TODO(), cycle.Metadata{})
 	results := testhelper.CollectResources(s.resourceCh)
 
 	s.Require().NoError(err, "Fetcher was not able to fetch files from FS")
@@ -234,7 +235,7 @@ func (s *FSFetcherTestSuite) TestFileFetcherFetchOuterDirectoryOnly() {
 		resourceCh: s.resourceCh,
 	}
 
-	err := fileFetcher.Fetch(context.TODO(), fetching.CycleMetadata{})
+	err := fileFetcher.Fetch(context.TODO(), cycle.Metadata{})
 	results := testhelper.CollectResources(s.resourceCh)
 
 	s.Require().NoError(err, "Fetcher was not able to fetch files from FS")
@@ -291,7 +292,7 @@ func (s *FSFetcherTestSuite) TestFileFetcherFetchDirectoryRecursively() {
 		resourceCh: s.resourceCh,
 	}
 
-	err := fileFetcher.Fetch(context.TODO(), fetching.CycleMetadata{})
+	err := fileFetcher.Fetch(context.TODO(), cycle.Metadata{})
 	results := testhelper.CollectResources(s.resourceCh)
 
 	s.Require().NoError(err, "Fetcher was not able to fetch files from FS")
@@ -344,7 +345,7 @@ func (s *FSFetcherTestSuite) TestElasticCommonData() {
 	}
 
 	var results []fetching.ResourceInfo
-	err := fileFetcher.Fetch(context.TODO(), fetching.CycleMetadata{})
+	err := fileFetcher.Fetch(context.TODO(), cycle.Metadata{})
 	results = testhelper.CollectResources(s.resourceCh)
 
 	s.Require().NoError(err, "Fetcher was not able to fetch files from FS")

--- a/resources/fetching/fetchers/k8s/kube_fetcher.go
+++ b/resources/fetching/fetchers/k8s/kube_fetcher.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 )
 
 const (
@@ -153,7 +154,7 @@ func (f *KubeFetcher) initWatchers() error {
 	return nil
 }
 
-func (f *KubeFetcher) Fetch(_ context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *KubeFetcher) Fetch(_ context.Context, cMetadata cycle.Metadata) error {
 	f.log.Debug("Starting KubeFetcher.Fetch")
 
 	var err error

--- a/resources/fetching/fetchers/k8s/kube_fetcher_test.go
+++ b/resources/fetching/fetchers/k8s/kube_fetcher_test.go
@@ -31,6 +31,7 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
@@ -186,7 +187,7 @@ func (s *KubeFetcherTestSuite) TestKubeFetcher_TestFetch() {
 			client := k8sfake.NewSimpleClientset(tt)
 			kubeFetcher := NewKubeFetcher(testhelper.NewLogger(s.T()), s.resourceCh, client)
 
-			err := kubeFetcher.Fetch(context.TODO(), fetching.CycleMetadata{})
+			err := kubeFetcher.Fetch(context.TODO(), cycle.Metadata{})
 			results := testhelper.CollectResources(s.resourceCh)
 
 			s.Require().NoError(err, "Fetcher was not able to fetch resources from kube api")

--- a/resources/fetching/fetchers/k8s/kube_provider.go
+++ b/resources/fetching/fetchers/k8s/kube_provider.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 )
 
 type K8sResource struct {
@@ -38,7 +39,7 @@ const (
 	K8sObjType           = "k8s_object"
 )
 
-func getKubeData(log *logp.Logger, watchers []kubernetes.Watcher, resCh chan fetching.ResourceInfo, cMetadata fetching.CycleMetadata) {
+func getKubeData(log *logp.Logger, watchers []kubernetes.Watcher, resCh chan fetching.ResourceInfo, cMetadata cycle.Metadata) {
 	log.Debug("Starting getKubeData")
 
 	for _, watcher := range watchers {

--- a/resources/fetching/fetchers/k8s/process_fetcher.go
+++ b/resources/fetching/fetchers/k8s/process_fetcher.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 )
 
 const (
@@ -127,7 +128,7 @@ func NewProcessFetcher(log *logp.Logger, ch chan fetching.ResourceInfo, processe
 	}
 }
 
-func (f *ProcessesFetcher) Fetch(_ context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *ProcessesFetcher) Fetch(_ context.Context, cMetadata cycle.Metadata) error {
 	f.log.Debug("Starting ProcessesFetcher.Fetch")
 
 	pids, err := proc.ListFS(f.Fs)

--- a/resources/fetching/fetchers/k8s/process_fetcher_test.go
+++ b/resources/fetching/fetchers/k8s/process_fetcher_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
@@ -88,7 +89,7 @@ func (s *ProcessFetcherTestSuite) TestFetchWhenFlagExistsButNoFile() {
 	}
 	processesFetcher := &ProcessesFetcher{log: testhelper.NewLogger(s.T()), Fs: sysfs, resourceCh: s.resourceCh, processes: procCfg}
 
-	err := processesFetcher.Fetch(context.TODO(), fetching.CycleMetadata{})
+	err := processesFetcher.Fetch(context.TODO(), cycle.Metadata{})
 	results := testhelper.CollectResources(s.resourceCh)
 
 	s.Len(results, 1)
@@ -121,7 +122,7 @@ func (s *ProcessFetcherTestSuite) TestFetchWhenProcessDoesNotExist() {
 		processes:  procCfg,
 	}
 
-	err := processesFetcher.Fetch(context.TODO(), fetching.CycleMetadata{})
+	err := processesFetcher.Fetch(context.TODO(), cycle.Metadata{})
 	results := testhelper.CollectResources(s.resourceCh)
 
 	s.Empty(results)
@@ -139,7 +140,7 @@ func (s *ProcessFetcherTestSuite) TestFetchWhenNoFlagRequired() {
 	var procCfg = ProcessesConfigMap{
 		"kubelet": {ConfigFileArguments: []string{}}}
 	processesFetcher := &ProcessesFetcher{log: testhelper.NewLogger(s.T()), Fs: fsys, resourceCh: s.resourceCh, processes: procCfg}
-	err := processesFetcher.Fetch(context.TODO(), fetching.CycleMetadata{})
+	err := processesFetcher.Fetch(context.TODO(), cycle.Metadata{})
 
 	results := testhelper.CollectResources(s.resourceCh)
 	s.Len(results, 1)
@@ -191,7 +192,7 @@ func (s *ProcessFetcherTestSuite) TestFetchWhenFlagExistsWithConfigFile() {
 			testProcess.Name: {ConfigFileArguments: []string{"fetcherConfig"}},
 		}
 		processesFetcher := &ProcessesFetcher{log: testhelper.NewLogger(s.T()), Fs: sysfs, resourceCh: s.resourceCh, processes: procCfg}
-		err = processesFetcher.Fetch(context.TODO(), fetching.CycleMetadata{})
+		err = processesFetcher.Fetch(context.TODO(), cycle.Metadata{})
 		results := testhelper.CollectResources(s.resourceCh)
 
 		s.Len(results, 1)

--- a/resources/fetching/manager/manager.go
+++ b/resources/fetching/manager/manager.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/logp"
 
-	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/fetching/registry"
 )
 
@@ -102,7 +102,7 @@ func (m *Manager) fetchIteration(ctx context.Context) {
 		wg.Add(1)
 		go func(k string) {
 			defer wg.Done()
-			err := m.fetchSingle(ctx, k, fetching.CycleMetadata{Sequence: seq})
+			err := m.fetchSingle(ctx, k, cycle.Metadata{Sequence: seq})
 			if err != nil {
 				m.log.Errorf("Error running fetcher for key %s: %v", k, err)
 			}
@@ -114,7 +114,7 @@ func (m *Manager) fetchIteration(ctx context.Context) {
 	m.log.Infof("Cycle %d resource fetching has ended", seq)
 }
 
-func (m *Manager) fetchSingle(ctx context.Context, k string, cycleMetadata fetching.CycleMetadata) error {
+func (m *Manager) fetchSingle(ctx context.Context, k string, cycleMetadata cycle.Metadata) error {
 	if !m.fetcherRegistry.ShouldRun(k) {
 		return nil
 	}
@@ -147,7 +147,7 @@ func (m *Manager) fetchSingle(ctx context.Context, k string, cycleMetadata fetch
 }
 
 // fetchProtected protect the fetching goroutine from getting panic
-func (m *Manager) fetchProtected(ctx context.Context, k string, metadata fetching.CycleMetadata) (err error) {
+func (m *Manager) fetchProtected(ctx context.Context, k string, metadata cycle.Metadata) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("fetcher %s recovered from panic: %v", k, r)

--- a/resources/fetching/manager/manager_test.go
+++ b/resources/fetching/manager/manager_test.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/fetching/registry"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
@@ -130,7 +131,7 @@ func (s *ManagerTestSuite) TestManagerFetchSingleTimeout() {
 	fetcherName := "timeout_fetcher"
 
 	s.registry.EXPECT().ShouldRun(mock.Anything).Return(true).Once()
-	s.registry.EXPECT().Run(mock.Anything, mock.Anything, mock.Anything).Call.Return(func(ctx context.Context, key string, metadata fetching.CycleMetadata) {
+	s.registry.EXPECT().Run(mock.Anything, mock.Anything, mock.Anything).Call.Return(func(ctx context.Context, key string, metadata cycle.Metadata) {
 		select {
 		case <-ctx.Done():
 			return
@@ -142,7 +143,7 @@ func (s *ManagerTestSuite) TestManagerFetchSingleTimeout() {
 	m, err := NewManager(context.Background(), testhelper.NewLogger(s.T()), interval, timeout, s.registry)
 	s.Require().NoError(err)
 
-	err = m.fetchSingle(context.Background(), fetcherName, fetching.CycleMetadata{})
+	err = m.fetchSingle(context.Background(), fetcherName, cycle.Metadata{})
 	s.Require().Error(err)
 	s.registry.AssertExpectations(s.T())
 }

--- a/resources/fetching/mock_fetcher.go
+++ b/resources/fetching/mock_fetcher.go
@@ -22,6 +22,7 @@ package fetching
 import (
 	context "context"
 
+	cycle "github.com/elastic/cloudbeat/resources/fetching/cycle"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -39,11 +40,11 @@ func (_m *MockFetcher) EXPECT() *MockFetcher_Expecter {
 }
 
 // Fetch provides a mock function with given fields: _a0, _a1
-func (_m *MockFetcher) Fetch(_a0 context.Context, _a1 CycleMetadata) error {
+func (_m *MockFetcher) Fetch(_a0 context.Context, _a1 cycle.Metadata) error {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, CycleMetadata) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, cycle.Metadata) error); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Error(0)
@@ -59,14 +60,14 @@ type MockFetcher_Fetch_Call struct {
 
 // Fetch is a helper method to define mock.On call
 //   - _a0 context.Context
-//   - _a1 CycleMetadata
+//   - _a1 cycle.Metadata
 func (_e *MockFetcher_Expecter) Fetch(_a0 interface{}, _a1 interface{}) *MockFetcher_Fetch_Call {
 	return &MockFetcher_Fetch_Call{Call: _e.mock.On("Fetch", _a0, _a1)}
 }
 
-func (_c *MockFetcher_Fetch_Call) Run(run func(_a0 context.Context, _a1 CycleMetadata)) *MockFetcher_Fetch_Call {
+func (_c *MockFetcher_Fetch_Call) Run(run func(_a0 context.Context, _a1 cycle.Metadata)) *MockFetcher_Fetch_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(CycleMetadata))
+		run(args[0].(context.Context), args[1].(cycle.Metadata))
 	})
 	return _c
 }
@@ -76,7 +77,7 @@ func (_c *MockFetcher_Fetch_Call) Return(_a0 error) *MockFetcher_Fetch_Call {
 	return _c
 }
 
-func (_c *MockFetcher_Fetch_Call) RunAndReturn(run func(context.Context, CycleMetadata) error) *MockFetcher_Fetch_Call {
+func (_c *MockFetcher_Fetch_Call) RunAndReturn(run func(context.Context, cycle.Metadata) error) *MockFetcher_Fetch_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/resources/fetching/preset/aws_org_preset_test.go
+++ b/resources/fetching/preset/aws_org_preset_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/fetching/registry"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
@@ -74,7 +75,7 @@ func subtest(t *testing.T, drain bool) {
 					for i := 0; i < resourcesPerAccount; i++ {
 						ch <- fetching.ResourceInfo{
 							Resource:      mockResource(),
-							CycleMetadata: fetching.CycleMetadata{Sequence: int64(i)},
+							CycleMetadata: cycle.Metadata{Sequence: int64(i)},
 						}
 					}
 				}()
@@ -152,7 +153,7 @@ func TestNewCisAwsOrganizationFetchers_LeakContextDone(t *testing.T) {
 			func(_ *logp.Logger, _ aws.Config, ch chan fetching.ResourceInfo, _ *cloud.Identity) registry.FetchersMap {
 				ch <- fetching.ResourceInfo{
 					Resource:      mockResource(),
-					CycleMetadata: fetching.CycleMetadata{Sequence: 1},
+					CycleMetadata: cycle.Metadata{Sequence: 1},
 				}
 
 				return registry.FetchersMap{"fetcher": registry.RegisteredFetcher{}}

--- a/resources/fetching/registry/mock_registry.go
+++ b/resources/fetching/registry/mock_registry.go
@@ -22,7 +22,7 @@ package registry
 import (
 	context "context"
 
-	fetching "github.com/elastic/cloudbeat/resources/fetching"
+	cycle "github.com/elastic/cloudbeat/resources/fetching/cycle"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -83,11 +83,11 @@ func (_c *MockRegistry_Keys_Call) RunAndReturn(run func() []string) *MockRegistr
 }
 
 // Run provides a mock function with given fields: ctx, key, metadata
-func (_m *MockRegistry) Run(ctx context.Context, key string, metadata fetching.CycleMetadata) error {
+func (_m *MockRegistry) Run(ctx context.Context, key string, metadata cycle.Metadata) error {
 	ret := _m.Called(ctx, key, metadata)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, fetching.CycleMetadata) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, cycle.Metadata) error); ok {
 		r0 = rf(ctx, key, metadata)
 	} else {
 		r0 = ret.Error(0)
@@ -104,14 +104,14 @@ type MockRegistry_Run_Call struct {
 // Run is a helper method to define mock.On call
 //   - ctx context.Context
 //   - key string
-//   - metadata fetching.CycleMetadata
+//   - metadata cycle.Metadata
 func (_e *MockRegistry_Expecter) Run(ctx interface{}, key interface{}, metadata interface{}) *MockRegistry_Run_Call {
 	return &MockRegistry_Run_Call{Call: _e.mock.On("Run", ctx, key, metadata)}
 }
 
-func (_c *MockRegistry_Run_Call) Run(run func(ctx context.Context, key string, metadata fetching.CycleMetadata)) *MockRegistry_Run_Call {
+func (_c *MockRegistry_Run_Call) Run(run func(ctx context.Context, key string, metadata cycle.Metadata)) *MockRegistry_Run_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(fetching.CycleMetadata))
+		run(args[0].(context.Context), args[1].(string), args[2].(cycle.Metadata))
 	})
 	return _c
 }
@@ -121,7 +121,7 @@ func (_c *MockRegistry_Run_Call) Return(_a0 error) *MockRegistry_Run_Call {
 	return _c
 }
 
-func (_c *MockRegistry_Run_Call) RunAndReturn(run func(context.Context, string, fetching.CycleMetadata) error) *MockRegistry_Run_Call {
+func (_c *MockRegistry_Run_Call) RunAndReturn(run func(context.Context, string, cycle.Metadata) error) *MockRegistry_Run_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/resources/fetching/registry/registry.go
+++ b/resources/fetching/registry/registry.go
@@ -23,13 +23,13 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/logp"
 
-	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 )
 
 type Registry interface {
 	Keys() []string
 	ShouldRun(key string) bool
-	Run(ctx context.Context, key string, metadata fetching.CycleMetadata) error
+	Run(ctx context.Context, key string, metadata cycle.Metadata) error
 	Update()
 	Stop()
 }
@@ -91,7 +91,7 @@ func (r *registry) ShouldRun(key string) bool {
 	return true
 }
 
-func (r *registry) Run(ctx context.Context, key string, metadata fetching.CycleMetadata) error {
+func (r *registry) Run(ctx context.Context, key string, metadata cycle.Metadata) error {
 	registered, ok := r.reg[key]
 	if !ok {
 		return fmt.Errorf("fetcher %v not found", key)

--- a/resources/fetching/registry/registry_test.go
+++ b/resources/fetching/registry/registry_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
@@ -92,7 +93,7 @@ func (s *registryTestSuite) TestRunNotRegistered() {
 	f := newNumberFetcher(1, s.wg)
 	s.registerFetcher(f, "some-key")
 
-	err := s.registry.Run(context.TODO(), "unknown", fetching.CycleMetadata{})
+	err := s.registry.Run(context.TODO(), "unknown", cycle.Metadata{})
 	s.Require().Error(err)
 }
 
@@ -122,7 +123,7 @@ func (s *registryTestSuite) TestRunRegistered() {
 	}
 
 	for _, test := range tests {
-		err := s.registry.Run(context.TODO(), test.key, fetching.CycleMetadata{})
+		err := s.registry.Run(context.TODO(), test.key, cycle.Metadata{})
 		results := testhelper.CollectResources(s.resourceCh)
 
 		s.Require().NoError(err)
@@ -186,7 +187,7 @@ type syncNumberFetcher struct {
 	resourceCh chan fetching.ResourceInfo
 }
 
-func (f *syncNumberFetcher) Fetch(_ context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *syncNumberFetcher) Fetch(_ context.Context, cMetadata cycle.Metadata) error {
 	f.resourceCh <- fetching.ResourceInfo{
 		Resource:      numberResource{f.num},
 		CycleMetadata: cMetadata,
@@ -228,7 +229,7 @@ func newNumberFetcher(num int, wg *sync.WaitGroup) fetching.Fetcher {
 	return &numberFetcher{num, false, nil, wg}
 }
 
-func (f *numberFetcher) Fetch(_ context.Context, cMetadata fetching.CycleMetadata) error {
+func (f *numberFetcher) Fetch(_ context.Context, cMetadata cycle.Metadata) error {
 	defer f.wg.Done()
 
 	f.resourceCh <- fetching.ResourceInfo{
@@ -303,7 +304,7 @@ func Test_registry_Update(t *testing.T) {
 				emptyFn(t, r) // empty at beginning because of error
 				r.Update()
 				assert.Len(t, r.Keys(), 1)
-				require.NoError(t, r.Run(context.Background(), "fetcher", fetching.CycleMetadata{}))
+				require.NoError(t, r.Run(context.Background(), "fetcher", cycle.Metadata{}))
 				assert.Panics(t, r.Update)
 			},
 		},
@@ -323,11 +324,11 @@ func Test_registry_Update(t *testing.T) {
 			},
 			testFn: func(t *testing.T, r Registry) {
 				assert.Len(t, r.Keys(), 1)
-				require.NoError(t, r.Run(context.Background(), "fetcher", fetching.CycleMetadata{}))
+				require.NoError(t, r.Run(context.Background(), "fetcher", cycle.Metadata{}))
 
 				r.Update() // update fails, registry remains as is
 				assert.Len(t, r.Keys(), 1)
-				require.NoError(t, r.Run(context.Background(), "fetcher", fetching.CycleMetadata{}))
+				require.NoError(t, r.Run(context.Background(), "fetcher", cycle.Metadata{}))
 
 				assert.Panics(t, r.Update)
 			},

--- a/resources/providers/azurelib/governance/management_group_test.go
+++ b/resources/providers/azurelib/governance/management_group_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
@@ -67,38 +67,38 @@ func Test_provider_GetSubscriptions(t *testing.T) {
 
 	t.Run("no assets", func(t *testing.T) {
 		p := NewProvider(testhelper.NewLogger(t), mockClient(t, nil, nil))
-		subs, err := p.GetSubscriptions(ctx, fetching.CycleMetadata{Sequence: 1})
+		subs, err := p.GetSubscriptions(ctx, cycle.Metadata{Sequence: 1})
 		require.NoError(t, err)
 		assert.Equal(t, map[string]Subscription{}, subs)
 
-		subsSame, err := p.GetSubscriptions(ctx, fetching.CycleMetadata{Sequence: 1})
+		subsSame, err := p.GetSubscriptions(ctx, cycle.Metadata{Sequence: 1})
 		require.NoError(t, err)
 		assert.Equal(t, subs, subsSame)
 	})
 
 	t.Run("error on first call", func(t *testing.T) {
 		p := NewProvider(testhelper.NewLogger(t), mockClient(t, nil, err1))
-		_, err := p.GetSubscriptions(ctx, fetching.CycleMetadata{Sequence: 10})
+		_, err := p.GetSubscriptions(ctx, cycle.Metadata{Sequence: 10})
 		require.ErrorIs(t, err, err1)
 
 		p.(*provider).client = mockClient(t, nil, err2)
-		_, err = p.GetSubscriptions(ctx, fetching.CycleMetadata{Sequence: 1})
+		_, err = p.GetSubscriptions(ctx, cycle.Metadata{Sequence: 1})
 		require.ErrorIs(t, err, err2)
 
 		p.(*provider).client = mockClient(t, assets, nil)
-		got, err := p.GetSubscriptions(ctx, fetching.CycleMetadata{Sequence: 1})
+		got, err := p.GetSubscriptions(ctx, cycle.Metadata{Sequence: 1})
 		require.NoError(t, err)
 		assert.Equal(t, expectedSubscriptions, got)
 	})
 
 	t.Run("error on later call", func(t *testing.T) {
 		p := NewProvider(testhelper.NewLogger(t), mockClient(t, assets, nil))
-		got, err := p.GetSubscriptions(ctx, fetching.CycleMetadata{Sequence: 1})
+		got, err := p.GetSubscriptions(ctx, cycle.Metadata{Sequence: 1})
 		require.NoError(t, err)
 		assert.Equal(t, expectedSubscriptions, got)
 
 		p.(*provider).client = mockClient(t, nil, err1)
-		got, err = p.GetSubscriptions(ctx, fetching.CycleMetadata{Sequence: 10})
+		got, err = p.GetSubscriptions(ctx, cycle.Metadata{Sequence: 10})
 		require.NoError(t, err)
 		assert.Equal(t, expectedSubscriptions, got)
 	})
@@ -123,12 +123,12 @@ func Test_provider_GetSubscriptions(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			got, err := p.GetSubscriptions(ctx, fetching.CycleMetadata{Sequence: 1})
+			got, err := p.GetSubscriptions(ctx, cycle.Metadata{Sequence: 1})
 			require.NoError(t, err)
 			assert.Equal(t, expectedSubscriptions, got)
 		}()
 
-		got, err := p.GetSubscriptions(ctx, fetching.CycleMetadata{Sequence: 1})
+		got, err := p.GetSubscriptions(ctx, cycle.Metadata{Sequence: 1})
 		require.NoError(t, err)
 		assert.Equal(t, expectedSubscriptions, got)
 	})

--- a/resources/providers/azurelib/governance/mock_provider_api.go
+++ b/resources/providers/azurelib/governance/mock_provider_api.go
@@ -22,7 +22,7 @@ package governance
 import (
 	context "context"
 
-	fetching "github.com/elastic/cloudbeat/resources/fetching"
+	cycle "github.com/elastic/cloudbeat/resources/fetching/cycle"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -39,25 +39,25 @@ func (_m *MockProviderAPI) EXPECT() *MockProviderAPI_Expecter {
 	return &MockProviderAPI_Expecter{mock: &_m.Mock}
 }
 
-// GetSubscriptions provides a mock function with given fields: ctx, cycle
-func (_m *MockProviderAPI) GetSubscriptions(ctx context.Context, cycle fetching.CycleMetadata) (map[string]Subscription, error) {
-	ret := _m.Called(ctx, cycle)
+// GetSubscriptions provides a mock function with given fields: ctx, _a1
+func (_m *MockProviderAPI) GetSubscriptions(ctx context.Context, _a1 cycle.Metadata) (map[string]Subscription, error) {
+	ret := _m.Called(ctx, _a1)
 
 	var r0 map[string]Subscription
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, fetching.CycleMetadata) (map[string]Subscription, error)); ok {
-		return rf(ctx, cycle)
+	if rf, ok := ret.Get(0).(func(context.Context, cycle.Metadata) (map[string]Subscription, error)); ok {
+		return rf(ctx, _a1)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, fetching.CycleMetadata) map[string]Subscription); ok {
-		r0 = rf(ctx, cycle)
+	if rf, ok := ret.Get(0).(func(context.Context, cycle.Metadata) map[string]Subscription); ok {
+		r0 = rf(ctx, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]Subscription)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, fetching.CycleMetadata) error); ok {
-		r1 = rf(ctx, cycle)
+	if rf, ok := ret.Get(1).(func(context.Context, cycle.Metadata) error); ok {
+		r1 = rf(ctx, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -72,14 +72,14 @@ type MockProviderAPI_GetSubscriptions_Call struct {
 
 // GetSubscriptions is a helper method to define mock.On call
 //   - ctx context.Context
-//   - cycle fetching.CycleMetadata
-func (_e *MockProviderAPI_Expecter) GetSubscriptions(ctx interface{}, cycle interface{}) *MockProviderAPI_GetSubscriptions_Call {
-	return &MockProviderAPI_GetSubscriptions_Call{Call: _e.mock.On("GetSubscriptions", ctx, cycle)}
+//   - _a1 cycle.Metadata
+func (_e *MockProviderAPI_Expecter) GetSubscriptions(ctx interface{}, _a1 interface{}) *MockProviderAPI_GetSubscriptions_Call {
+	return &MockProviderAPI_GetSubscriptions_Call{Call: _e.mock.On("GetSubscriptions", ctx, _a1)}
 }
 
-func (_c *MockProviderAPI_GetSubscriptions_Call) Run(run func(ctx context.Context, cycle fetching.CycleMetadata)) *MockProviderAPI_GetSubscriptions_Call {
+func (_c *MockProviderAPI_GetSubscriptions_Call) Run(run func(ctx context.Context, _a1 cycle.Metadata)) *MockProviderAPI_GetSubscriptions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(fetching.CycleMetadata))
+		run(args[0].(context.Context), args[1].(cycle.Metadata))
 	})
 	return _c
 }
@@ -89,7 +89,7 @@ func (_c *MockProviderAPI_GetSubscriptions_Call) Return(_a0 map[string]Subscript
 	return _c
 }
 
-func (_c *MockProviderAPI_GetSubscriptions_Call) RunAndReturn(run func(context.Context, fetching.CycleMetadata) (map[string]Subscription, error)) *MockProviderAPI_GetSubscriptions_Call {
+func (_c *MockProviderAPI_GetSubscriptions_Call) RunAndReturn(run func(context.Context, cycle.Metadata) (map[string]Subscription, error)) *MockProviderAPI_GetSubscriptions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/resources/providers/azurelib/mock_provider_api.go
+++ b/resources/providers/azurelib/mock_provider_api.go
@@ -22,7 +22,7 @@ package azurelib
 import (
 	context "context"
 
-	fetching "github.com/elastic/cloudbeat/resources/fetching"
+	cycle "github.com/elastic/cloudbeat/resources/fetching/cycle"
 	governance "github.com/elastic/cloudbeat/resources/providers/azurelib/governance"
 
 	inventory "github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
@@ -43,25 +43,25 @@ func (_m *MockProviderAPI) EXPECT() *MockProviderAPI_Expecter {
 	return &MockProviderAPI_Expecter{mock: &_m.Mock}
 }
 
-// GetSubscriptions provides a mock function with given fields: ctx, cycle
-func (_m *MockProviderAPI) GetSubscriptions(ctx context.Context, cycle fetching.CycleMetadata) (map[string]governance.Subscription, error) {
-	ret := _m.Called(ctx, cycle)
+// GetSubscriptions provides a mock function with given fields: ctx, _a1
+func (_m *MockProviderAPI) GetSubscriptions(ctx context.Context, _a1 cycle.Metadata) (map[string]governance.Subscription, error) {
+	ret := _m.Called(ctx, _a1)
 
 	var r0 map[string]governance.Subscription
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, fetching.CycleMetadata) (map[string]governance.Subscription, error)); ok {
-		return rf(ctx, cycle)
+	if rf, ok := ret.Get(0).(func(context.Context, cycle.Metadata) (map[string]governance.Subscription, error)); ok {
+		return rf(ctx, _a1)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, fetching.CycleMetadata) map[string]governance.Subscription); ok {
-		r0 = rf(ctx, cycle)
+	if rf, ok := ret.Get(0).(func(context.Context, cycle.Metadata) map[string]governance.Subscription); ok {
+		r0 = rf(ctx, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]governance.Subscription)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, fetching.CycleMetadata) error); ok {
-		r1 = rf(ctx, cycle)
+	if rf, ok := ret.Get(1).(func(context.Context, cycle.Metadata) error); ok {
+		r1 = rf(ctx, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -76,14 +76,14 @@ type MockProviderAPI_GetSubscriptions_Call struct {
 
 // GetSubscriptions is a helper method to define mock.On call
 //   - ctx context.Context
-//   - cycle fetching.CycleMetadata
-func (_e *MockProviderAPI_Expecter) GetSubscriptions(ctx interface{}, cycle interface{}) *MockProviderAPI_GetSubscriptions_Call {
-	return &MockProviderAPI_GetSubscriptions_Call{Call: _e.mock.On("GetSubscriptions", ctx, cycle)}
+//   - _a1 cycle.Metadata
+func (_e *MockProviderAPI_Expecter) GetSubscriptions(ctx interface{}, _a1 interface{}) *MockProviderAPI_GetSubscriptions_Call {
+	return &MockProviderAPI_GetSubscriptions_Call{Call: _e.mock.On("GetSubscriptions", ctx, _a1)}
 }
 
-func (_c *MockProviderAPI_GetSubscriptions_Call) Run(run func(ctx context.Context, cycle fetching.CycleMetadata)) *MockProviderAPI_GetSubscriptions_Call {
+func (_c *MockProviderAPI_GetSubscriptions_Call) Run(run func(ctx context.Context, _a1 cycle.Metadata)) *MockProviderAPI_GetSubscriptions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(fetching.CycleMetadata))
+		run(args[0].(context.Context), args[1].(cycle.Metadata))
 	})
 	return _c
 }
@@ -93,7 +93,7 @@ func (_c *MockProviderAPI_GetSubscriptions_Call) Return(_a0 map[string]governanc
 	return _c
 }
 
-func (_c *MockProviderAPI_GetSubscriptions_Call) RunAndReturn(run func(context.Context, fetching.CycleMetadata) (map[string]governance.Subscription, error)) *MockProviderAPI_GetSubscriptions_Call {
+func (_c *MockProviderAPI_GetSubscriptions_Call) RunAndReturn(run func(context.Context, cycle.Metadata) (map[string]governance.Subscription, error)) *MockProviderAPI_GetSubscriptions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/resources/providers/azurelib/provider.go
+++ b/resources/providers/azurelib/provider.go
@@ -24,7 +24,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resourcegraph/armresourcegraph"
 	"github.com/elastic/elastic-agent-libs/logp"
 
-	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/auth"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/governance"
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
@@ -67,6 +67,6 @@ func (p provider) ListAllAssetTypesByName(ctx context.Context, assetGroup string
 	return p.inventory.ListAllAssetTypesByName(ctx, assetGroup, assets)
 }
 
-func (p provider) GetSubscriptions(ctx context.Context, cycle fetching.CycleMetadata) (map[string]governance.Subscription, error) {
+func (p provider) GetSubscriptions(ctx context.Context, cycle cycle.Metadata) (map[string]governance.Subscription, error) {
 	return p.governance.GetSubscriptions(ctx, cycle)
 }

--- a/transformer/events_creator_test.go
+++ b/transformer/events_creator_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/cloudbeat/dataprovider"
 	"github.com/elastic/cloudbeat/evaluator"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
 	fetchers "github.com/elastic/cloudbeat/resources/fetching/fetchers/k8s"
 	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 	"github.com/elastic/cloudbeat/version"
@@ -109,7 +110,7 @@ func (s *EventsCreatorTestSuite) TestTransformer_ProcessAggregatedResources() {
 				RuleResult: opaResults,
 				ResourceInfo: fetching.ResourceInfo{
 					Resource:      fetcherResult,
-					CycleMetadata: fetching.CycleMetadata{},
+					CycleMetadata: cycle.Metadata{},
 				},
 			},
 			bdpp: func() dataprovider.CommonDataProvider {
@@ -145,7 +146,7 @@ func (s *EventsCreatorTestSuite) TestTransformer_ProcessAggregatedResources() {
 				},
 				ResourceInfo: fetching.ResourceInfo{
 					Resource:      fetcherResult,
-					CycleMetadata: fetching.CycleMetadata{},
+					CycleMetadata: cycle.Metadata{},
 				},
 			},
 			bdpp: func() dataprovider.CommonDataProvider {


### PR DESCRIPTION
### Summary of your changes
Generalizes the cache used in https://github.com/elastic/cloudbeat/pull/1559 to be re-used for future tasks.

Big diff is because `CycleMetadata` is moved into a `cycle` package to simplify its name and be used together with other cycle-specific code.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
- Related to 5.1.3: https://github.com/elastic/cloudbeat/issues/1418

### Checklist
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary README/documentation (if appropriate)