### PR TITLE
Fixing replacement for account type to single account

### DIFF
--- a/deploy/test-environments/fleet_api/src/package_policy.py
+++ b/deploy/test-environments/fleet_api/src/package_policy.py
@@ -322,4 +322,4 @@ def extract_arm_template_url(url_string: str) -> str:
 
     """
     parsed_url = urlparse(url_string, allow_fragments=False)
-    return unquote(parsed_url.path.split("/")[-1])
+    return unquote(parsed_url.path.split("/")[-1]).replace("ACCOUNT_TYPE", "single-account")


### PR DESCRIPTION
### Summary of your changes
Taking new template requires replacement for single account template
This will support older and newer versions of the template

### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
