### PR TITLE
Azure ARM: Use resource group deployment schema

### DIFF
--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -311,7 +311,7 @@ jobs:
         id: cspm-azure-agent
         working-directory: deploy/azure
         run: |
-          az deployment sub create --location EastUS --template-file azureARMTemplate.json --parameters @arm_parameters.json
+          az deployment sub create --location EastUS --template-file ARM-for-single-account.json --parameters @arm_parameters.json
 
       - name: Install D4C integration
         id: kspm-d4c

--- a/deploy/azure/ARM-for-single-account.json
+++ b/deploy/azure/ARM-for-single-account.json
@@ -3,14 +3,6 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "Location": {
-            "type": "string",
-            "minLength": 6,
-            "metadata": {
-                "description": "The location to deploy the resource group with the virtual machine on"
-            },
-            "defaultValue": "[resourceGroup().location]"
-        },
         "ElasticArtifactServer": {
             "type": "string",
             "defaultValue": "https://artifacts.elastic.co/downloads/beats/elastic-agent",

--- a/deploy/azure/ARM-for-single-account.json
+++ b/deploy/azure/ARM-for-single-account.json
@@ -1,4 +1,3 @@
-
 {
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
@@ -30,11 +29,14 @@
             }
         }
     },
+    "variables": {
+        "roleAssignmentDeployment": "[concat('role-assignment-deployment-', resourceGroup().location)]"
+    },
     "resources": [
         {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
-            "name": "role-assignment-deployment",
+            "name": "[variables('roleAssignmentDeployment')]",
             "location": "[resourceGroup().location]",
             "subscriptionId": "[subscription().subscriptionId]",
             "properties": {
@@ -279,7 +281,7 @@
             },
             "dependsOn": [
                 "cloudbeat-vm-deployment",
-                "role-assignment-deployment"
+                "[variables('roleAssignmentDeployment')]"
             ]
         }
     ]

--- a/deploy/azure/ARM-for-single-account.json
+++ b/deploy/azure/ARM-for-single-account.json
@@ -1,21 +1,15 @@
+
 {
-    "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "ResourceGroupName": {
-            "type": "string",
-            "defaultValue": "[concat('cloudbeat-resource-group-', dateTimeToEpoch(utcNow('u')))]",
-            "metadata": {
-                "description": "The resource group name where the virtual machine with the Elastic Agent is running on"
-            }
-        },
         "Location": {
             "type": "string",
             "minLength": 6,
             "metadata": {
                 "description": "The location to deploy the resource group with the virtual machine on"
             },
-            "defaultValue": "[deployment().location]"
+            "defaultValue": "[resourceGroup().location]"
         },
         "ElasticArtifactServer": {
             "type": "string",
@@ -46,16 +40,10 @@
     },
     "resources": [
         {
-            "type": "Microsoft.Resources/resourceGroups",
-            "apiVersion": "2022-09-01",
-            "name": "[parameters('ResourceGroupName')]",
-            "location": "[parameters('Location')]"
-        },
-        {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "role-assignment-deployment",
-            "location": "[deployment().location]",
+            "location": "[resourceGroup().location]",
             "subscriptionId": "[subscription().subscriptionId]",
             "properties": {
                 "expressionEvaluationOptions": {
@@ -64,7 +52,7 @@
                 "mode": "Incremental",
                 "parameters": {
                     "ResourceGroupName": {
-                        "value": "[parameters('ResourceGroupName')]"
+                        "value": "[resourceGroup().name]"
                     }
                 },
                 "template": {
@@ -90,7 +78,6 @@
                 }
             },
             "dependsOn": [
-                "[parameters('ResourceGroupName')]",
                 "cloudbeat-vm-deployment"
             ]
         },
@@ -98,7 +85,6 @@
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "cloudbeat-vm-deployment",
-            "resourceGroup": "[parameters('ResourceGroupName')]",
             "properties": {
                 "expressionEvaluationOptions": {
                     "scope": "inner"
@@ -236,16 +222,12 @@
                         }
                     ]
                 }
-            },
-            "dependsOn": [
-                "[parameters('ResourceGroupName')]"
-            ]
+            }
         },
         {
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2022-09-01",
             "name": "elastic-agent-deployment",
-            "resourceGroup": "[parameters('ResourceGroupName')]",
             "properties": {
                 "expressionEvaluationOptions": {
                     "scope": "inner"

--- a/deploy/test-environments/fleet_api/src/install_cspm_azure_integration.py
+++ b/deploy/test-environments/fleet_api/src/install_cspm_azure_integration.py
@@ -42,7 +42,7 @@ CSPM_AZURE_AGENT_POLICY = "../../../cloud/data/agent_policy_cspm_azure.json"
 CSPM_AZURE_PACKAGE_POLICY = "../../../cloud/data/package_policy_cspm_azure.json"
 CSPM_AZURE_EXPECTED_AGENTS = 1
 AZURE_ARM_PARAMETERS = "../../../azure/arm_parameters.json"
-AZURE_ARM_TEMPLATE = "../../../azure/azureARMTemplate.json"
+AZURE_ARM_TEMPLATE = "../../../azure/ARM-for-single-account.json"
 
 cspm_azure_agent_policy_data = Path(__file__).parent / CSPM_AZURE_AGENT_POLICY
 cspm_azure_pkg_policy_data = Path(__file__).parent / CSPM_AZURE_PACKAGE_POLICY


### PR DESCRIPTION
### Summary of your changes
This uses the "default" deployment template which includes a better UI for selecting resource group to deploy to. This also removes one sub-deployment for the resource group as the user can select/create one from the UI.

Previously, it was thought that we need the subscription deployment template schema to deploy role assignments to the subscription level.

Removes the location parameter and use the native Azure selector.
Additionally, fixes an issue with the deployment not working across different regions (#1619). Fix is just to include the location in the name for the role assignment deployment. This one is the only sub-deployment that needs to be fixed because the rest deploy at the resource group level. The subscription level sub-deployment requires the `location` property, otherwise you get an error:
```
The 'location' property must be specified for 'role-assignment-deployment-eastus'. Please see https://aka.ms/arm-deployment-subscription for usage details. (Code: InvalidDeployment)
```

Finally, I've fixed ci commands that were using the old filename for the template.

### Screenshot/Data
#### Before
![image](https://github.com/elastic/cloudbeat/assets/5778622/3569ef69-5ad5-423b-a1cd-bffae4103af7)
#### After
![image](https://github.com/elastic/cloudbeat/assets/5778622/ad226d32-9c27-47a3-b11f-98e71d493576)
#### Result 1 (Sweden)
![image](https://github.com/elastic/cloudbeat/assets/5778622/92588af6-eb97-4948-a44f-0286b58f06d8)
#### Result 2 (Sweden)
![image](https://github.com/elastic/cloudbeat/assets/5778622/43e1aee3-8864-43c6-b9e6-3256aa277457)
#### Result 3 (US East)
![image](https://github.com/elastic/cloudbeat/assets/5778622/265fbec3-728d-49b3-8e15-1adfe82396bc)

Fixes https://github.com/elastic/cloudbeat/issues/1619
