### PR TITLE
Lock Azure agent installation script for 8.12

### DIFF
--- a/deploy/azure/ARM-for-organization-account.json
+++ b/deploy/azure/ARM-for-organization-account.json
@@ -342,7 +342,7 @@
                                 "typeHandlerVersion": "2.1",
                                 "settings": {
                                     "fileUris": [
-                                        "https://raw.githubusercontent.com/elastic/cloudbeat/main/deploy/azure/install-agent.sh"
+                                        "https://raw.githubusercontent.com/elastic/cloudbeat/8.12/deploy/azure/install-agent.sh"
                                     ],
                                     "commandToExecute": "[concat('bash install-agent.sh ', parameters('ElasticAgentVersion'), ' ', parameters('ElasticArtifactServer'), ' ', parameters('FleetUrl'), ' ', parameters('EnrollmentToken'))]"
                                 }

--- a/deploy/azure/ARM-for-single-account.json
+++ b/deploy/azure/ARM-for-single-account.json
@@ -294,7 +294,7 @@
                                 "typeHandlerVersion": "2.1",
                                 "settings": {
                                     "fileUris": [
-                                        "https://raw.githubusercontent.com/elastic/cloudbeat/main/deploy/azure/install-agent.sh"
+                                        "https://raw.githubusercontent.com/elastic/cloudbeat/8.12/deploy/azure/install-agent.sh"
                                     ],
                                     "commandToExecute": "[concat('bash install-agent.sh ', parameters('ElasticAgentVersion'), ' ', parameters('ElasticArtifactServer'), ' ', parameters('FleetUrl'), ' ', parameters('EnrollmentToken'))]"
                                 }


### PR DESCRIPTION
### Summary of your changes
Lock Azure agent installation script to `8.12` branch for released version

### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/1603

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
