### PR TITLE
Skipping pre-merge k8s tests

### DIFF
--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -1,11 +1,13 @@
 name: K8s-CI
 
 on:
-  pull_request:
-    branches:
-      - main
-      - "[0-9]+.[0-9]+"
-    types: [ opened, synchronize, reopened ]
+  # Skipping pre-merge K8s tests for now
+  # https://github.com/elastic/cloudbeat/issues/1623
+  # pull_request:
+  #   branches:
+  #     - main
+  #     - "[0-9]+.[0-9]+"
+  #   types: [ opened, synchronize, reopened ]
 
   push:
     branches:


### PR DESCRIPTION
### Summary of your changes

The k8s CI tests are flaky and run as pre-merge, which is a requirement for every PR. Since the feature is in the support stage, we avoid making any changes to that codebase in our PRs. This PR skips pre-merge k8s tests.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
