### PR TITLE
Data Provider: Always insert cloudAccountIdField

### DIFF
--- a/dataprovider/providers/cloud/data_provider.go
+++ b/dataprovider/providers/cloud/data_provider.go
@@ -62,13 +62,19 @@ func NewDataProvider(options ...Option) DataProvider {
 
 func (a DataProvider) EnrichEvent(event *beat.Event, resMetadata fetching.ResourceMetadata) error {
 	return errors.Join(
-		insertIfNotEmpty(cloudAccountIdField, strings.FirstNonEmpty(resMetadata.AccountId, a.accountId), event),
+		// always insert cloud.account.id as missing fields can crash the dashboard
+		insert(cloudAccountIdField, strings.FirstNonEmpty(resMetadata.AccountId, a.accountId), event),
 		insertIfNotEmpty(cloudAccountNameField, strings.FirstNonEmpty(resMetadata.AccountName, a.accountName), event),
 		insertIfNotEmpty(cloudProviderField, a.providerName, event),
 		insertIfNotEmpty(cloudRegionField, resMetadata.Region, event),
 		insertIfNotEmpty(cloudOrganizationIdField, resMetadata.OrganisationId, event),
 		insertIfNotEmpty(cloudOrganizationNameField, resMetadata.OrganizationName, event),
 	)
+}
+
+func insert(field string, value string, event *beat.Event) error {
+	_, err := event.Fields.Put(field, value)
+	return err
 }
 
 func insertIfNotEmpty(field string, value string, event *beat.Event) error {

--- a/dataprovider/providers/cloud/data_provider_test.go
+++ b/dataprovider/providers/cloud/data_provider_test.go
@@ -122,6 +122,19 @@ func TestDataProvider_EnrichEvent(t *testing.T) {
 				cloudAccountNameField: gcpProjectName,
 			},
 		},
+		{
+			name: "missing fields",
+			resMetadata: fetching.ResourceMetadata{
+				Region: someRegion,
+			},
+			identity: Identity{
+				Provider: awsProvider,
+			},
+			expectedFields: map[string]string{
+				cloudProviderField:  awsProvider,
+				cloudAccountIdField: "",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Summary of your changes
Makes the `cloud.account.id` field mandatory even if empty. This is preferable behavior since this field missing can cause the Kibana dashboard crash.

### Screenshot/Data
#### Before
![screenshot-2023-12-07T17:23:52 CET](https://github.com/elastic/cloudbeat/assets/5778622/b7de7f3f-d233-4044-9058-c57af3aae117)
![screenshot-2023-12-07T17:23:27 CET](https://github.com/elastic/cloudbeat/assets/5778622/951f0ac7-06e4-49ef-820f-0a257dfe7205)
#### After
![screenshot-2023-12-07T17:14:16 CET](https://github.com/elastic/cloudbeat/assets/5778622/b420e4ac-7ac4-4aaf-b3c1-33cdfecce1d1)
![screenshot-2023-12-07T17:10:45 CET](https://github.com/elastic/cloudbeat/assets/5778622/5111b253-2831-45d6-bd00-e656430ea7c0)


### Related Issues
Fixes #1631

### Checklist
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary README/documentation (if appropriate)