### PR TITLE
Azure Assets Enricher

### DIFF
--- a/resources/fetching/fetchers/azure/assets_enricher.go
+++ b/resources/fetching/fetchers/azure/assets_enricher.go
@@ -29,12 +29,12 @@ import (
 	"github.com/elastic/cloudbeat/resources/utils/strings"
 )
 
-type AssetsEnricherAPI interface {
+type AssetsEnricher interface {
 	Enrich(ctx context.Context, cycleMetadata cycle.Metadata, assets []inventory.AzureAsset) error
 }
 
-func initEnrichers(provider azurelib.ProviderAPI) []AssetsEnricherAPI {
-	var enrichers []AssetsEnricherAPI
+func initEnrichers(provider azurelib.ProviderAPI) []AssetsEnricher {
+	var enrichers []AssetsEnricher
 
 	enrichers = append(enrichers, storageAccountEnricher{provider: provider})
 

--- a/resources/fetching/fetchers/azure/assets_enricher.go
+++ b/resources/fetching/fetchers/azure/assets_enricher.go
@@ -1,0 +1,88 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fetchers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
+	"github.com/elastic/cloudbeat/resources/providers/azurelib"
+	"github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
+	"github.com/elastic/cloudbeat/resources/utils/strings"
+)
+
+type AssetsEnricherAPI interface {
+	Enrich(ctx context.Context, cycleMetadata cycle.Metadata, assets []inventory.AzureAsset) error
+}
+
+func initEnrichers(provider azurelib.ProviderAPI) []AssetsEnricherAPI {
+	var enrichers []AssetsEnricherAPI
+
+	enrichers = append(enrichers, storageAccountEnricher{provider: provider})
+
+	return enrichers
+}
+
+type storageAccountEnricher struct {
+	provider azurelib.ProviderAPI
+}
+
+func (e storageAccountEnricher) Enrich(ctx context.Context, cycleMetadata cycle.Metadata, assets []inventory.AzureAsset) error {
+	subscriptions, err := e.provider.GetSubscriptions(ctx, cycleMetadata)
+	if err != nil {
+		return fmt.Errorf("storageAccountEnricher: error while getting subscription: %w", err)
+	}
+
+	diagSettings, err := e.provider.ListDiagnosticSettingsAssetTypes(ctx, cycleMetadata, lo.Keys(subscriptions))
+	if err != nil {
+		return fmt.Errorf("storageAccountEnricher: error while getting diagnostic settings: %w", err)
+	}
+	e.addUsedForActivityLogsFlag(assets, diagSettings)
+
+	return nil
+}
+
+func (*storageAccountEnricher) addUsedForActivityLogsFlag(assets []inventory.AzureAsset, diagSettings []inventory.AzureAsset) {
+	usedStorageAccountIDs := map[string]struct{}{}
+	for _, d := range diagSettings {
+		storageAccountID := strings.FromMap(d.Properties, "storageAccountId")
+		if storageAccountID == "" {
+			continue
+		}
+		usedStorageAccountIDs[storageAccountID] = struct{}{}
+	}
+
+	for i, a := range assets {
+		if a.Type != inventory.StorageAccountAssetType {
+			continue
+		}
+
+		if _, exists := usedStorageAccountIDs[a.Id]; !exists {
+			continue
+		}
+
+		if a.Extension == nil {
+			a.Extension = make(map[string]any)
+		}
+		a.Extension["usedForActivityLogs"] = true
+		assets[i] = a
+	}
+}

--- a/resources/fetching/fetchers/azure/assets_enricher_storage_account.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_storage_account.go
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fetchers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
+	"github.com/elastic/cloudbeat/resources/providers/azurelib"
+	"github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
+	"github.com/elastic/cloudbeat/resources/utils/strings"
+)
+
+type storageAccountEnricher struct {
+	provider azurelib.ProviderAPI
+}
+
+func (e storageAccountEnricher) Enrich(ctx context.Context, cycleMetadata cycle.Metadata, assets []inventory.AzureAsset) error {
+	subscriptions, err := e.provider.GetSubscriptions(ctx, cycleMetadata)
+	if err != nil {
+		return fmt.Errorf("storageAccountEnricher: error while getting subscription: %w", err)
+	}
+
+	diagSettings, err := e.provider.ListDiagnosticSettingsAssetTypes(ctx, cycleMetadata, lo.Keys(subscriptions))
+	if err != nil {
+		return fmt.Errorf("storageAccountEnricher: error while getting diagnostic settings: %w", err)
+	}
+	e.addUsedForActivityLogsFlag(assets, diagSettings)
+
+	return nil
+}
+
+func (*storageAccountEnricher) addUsedForActivityLogsFlag(assets []inventory.AzureAsset, diagSettings []inventory.AzureAsset) {
+	usedStorageAccountIDs := map[string]struct{}{}
+	for _, d := range diagSettings {
+		storageAccountID := strings.FromMap(d.Properties, "storageAccountId")
+		if storageAccountID == "" {
+			continue
+		}
+		usedStorageAccountIDs[storageAccountID] = struct{}{}
+	}
+
+	for i, a := range assets {
+		if a.Type != inventory.StorageAccountAssetType {
+			continue
+		}
+
+		if _, exists := usedStorageAccountIDs[a.Id]; !exists {
+			continue
+		}
+
+		if a.Extension == nil {
+			a.Extension = make(map[string]any)
+		}
+		a.Extension["usedForActivityLogs"] = true
+		assets[i] = a
+	}
+}

--- a/resources/fetching/fetchers/azure/assets_enricher_storage_account_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_storage_account_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
 )
 
-func TestAddUsedForActivityLogsFlag(t *testing.T) {
+func TestStorageAccountEnricher(t *testing.T) {
 	tests := map[string]struct {
 		inputAssets       []inventory.AzureAsset
 		inputDiagSettings []inventory.AzureAsset

--- a/resources/fetching/fetchers/azure/assets_enricher_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_test.go
@@ -1,0 +1,102 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fetchers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/cloudbeat/resources/fetching/cycle"
+	"github.com/elastic/cloudbeat/resources/providers/azurelib"
+	"github.com/elastic/cloudbeat/resources/providers/azurelib/governance"
+	"github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
+)
+
+func TestAddUsedForActivityLogsFlag(t *testing.T) {
+	tests := map[string]struct {
+		inputAssets       []inventory.AzureAsset
+		inputDiagSettings []inventory.AzureAsset
+		expected          []inventory.AzureAsset
+	}{
+		"no storage account asset": {
+			inputAssets:       []inventory.AzureAsset{{Id: "id_1", Type: inventory.DiskAssetType}},
+			inputDiagSettings: []inventory.AzureAsset{{Properties: map[string]any{}}},
+			expected:          []inventory.AzureAsset{{Id: "id_1", Type: inventory.DiskAssetType}},
+		},
+		"storage account asset not used for activity log": {
+			inputAssets:       []inventory.AzureAsset{{Id: "id_1", Type: inventory.StorageAccountAssetType}},
+			inputDiagSettings: []inventory.AzureAsset{{Properties: map[string]any{}}},
+			expected:          []inventory.AzureAsset{{Id: "id_1", Type: inventory.StorageAccountAssetType}},
+		},
+		"storage account asset used for activity log": {
+			inputAssets:       []inventory.AzureAsset{{Id: "id_1", Type: inventory.StorageAccountAssetType}},
+			inputDiagSettings: []inventory.AzureAsset{{Properties: map[string]any{"storageAccountId": "id_1"}}},
+			expected:          []inventory.AzureAsset{{Id: "id_1", Type: inventory.StorageAccountAssetType, Extension: map[string]any{"usedForActivityLogs": true}}},
+		},
+		"multiple storage account asset, one used for activity log": {
+			inputAssets: []inventory.AzureAsset{
+				{Id: "id_1", Type: inventory.StorageAccountAssetType},
+				{Id: "id_2", Type: inventory.StorageAccountAssetType},
+				{Id: "id_3", Type: inventory.StorageAccountAssetType},
+			},
+			inputDiagSettings: []inventory.AzureAsset{{Properties: map[string]any{"storageAccountId": "id_2"}}},
+			expected: []inventory.AzureAsset{
+				{Id: "id_1", Type: inventory.StorageAccountAssetType},
+				{Id: "id_2", Type: inventory.StorageAccountAssetType, Extension: map[string]any{"usedForActivityLogs": true}},
+				{Id: "id_3", Type: inventory.StorageAccountAssetType},
+			},
+		},
+		"multiple storage account asset, two used for activity log": {
+			inputAssets: []inventory.AzureAsset{
+				{Id: "id_1", Type: inventory.StorageAccountAssetType},
+				{Id: "id_2", Type: inventory.StorageAccountAssetType},
+				{Id: "id_3", Type: inventory.StorageAccountAssetType},
+			},
+			inputDiagSettings: []inventory.AzureAsset{
+				{Properties: map[string]any{"storageAccountId": "id_2"}},
+				{Properties: map[string]any{"storageAccountId": "id_3"}},
+			},
+			expected: []inventory.AzureAsset{
+				{Id: "id_1", Type: inventory.StorageAccountAssetType},
+				{Id: "id_2", Type: inventory.StorageAccountAssetType, Extension: map[string]any{"usedForActivityLogs": true}},
+				{Id: "id_3", Type: inventory.StorageAccountAssetType, Extension: map[string]any{"usedForActivityLogs": true}},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			cmd := cycle.Metadata{}
+
+			provider := azurelib.NewMockProviderAPI(t)
+			provider.EXPECT().GetSubscriptions(mock.Anything, cmd).Return(map[string]governance.Subscription{"sub1": {}}, nil).Once()
+			provider.EXPECT().ListDiagnosticSettingsAssetTypes(mock.Anything, cmd, []string{"sub1"}).Return(tc.inputDiagSettings, nil)
+
+			e := storageAccountEnricher{provider: provider}
+			err := e.Enrich(context.Background(), cmd, tc.inputAssets)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expected, tc.inputAssets)
+		})
+	}
+}

--- a/resources/fetching/fetchers/azure/assets_fetcher.go
+++ b/resources/fetching/fetchers/azure/assets_fetcher.go
@@ -36,7 +36,7 @@ type AzureAssetsFetcher struct {
 	log        *logp.Logger
 	resourceCh chan fetching.ResourceInfo
 	provider   azurelib.ProviderAPI
-	enrichers  []AssetsEnricherAPI
+	enrichers  []AssetsEnricher
 }
 
 type AzureResource struct {

--- a/resources/fetching/fetchers/azure/assets_fetcher_test.go
+++ b/resources/fetching/fetchers/azure/assets_fetcher_test.go
@@ -97,10 +97,11 @@ func (s *AzureAssetsFetcherTestSuite) TestFetcher_Fetch() {
 				},
 			},
 		}, nil,
-	).Once()
+	).Twice()
 	mockProvider.EXPECT().
 		ListDiagnosticSettingsAssetTypes(mock.Anything, cycle.Metadata{}, []string{"subId"}).
-		Return(nil, nil)
+		Return(nil, nil).
+		Once()
 
 	results, err := s.fetch(mockProvider, totalMockAssets)
 	s.Require().NoError(err)
@@ -151,10 +152,10 @@ func (s *AzureAssetsFetcherTestSuite) TestFetcher_Fetch_Errors() {
 			}
 			return nil, errors.New("some list asset error")
 		})
-	mockProvider.EXPECT().GetSubscriptions(mock.Anything, mock.Anything).Return(nil, errors.New("some get subscription error")).Once()
 	mockProvider.EXPECT().
-		ListDiagnosticSettingsAssetTypes(mock.Anything, cycle.Metadata{}, []string{}).
-		Return(nil, nil)
+		GetSubscriptions(mock.Anything, mock.Anything).
+		Return(nil, errors.New("some get subscription error")).
+		Twice()
 
 	results, err := s.fetch(mockProvider, 1)
 	s.Require().ErrorContains(err, "some list asset error")


### PR DESCRIPTION
### Summary of your changes
This PR introduces Azure asset "enricher" interface and creates a slice of enrichers in Azure asset fetcher.

After the assets are fetched from the provider, azure assset fetcher runs all enrichers serially and enriches the assets. 

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
