### PR TITLE
Skip long tests when -short flag is set

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,18 @@ repos:
         language: system
         files: .*.go
         pass_filenames: false
+      - id: go-test
+        name: Run short unit tests
+        entry: bash -c 'go test -short -timeout 100ms ./...'
+        language: system
+        files: .*.go
+        pass_filenames: false
+      - id: go-mod-tidy
+        name: Run go mod tidy
+        entry: bash -c 'go mod tidy'
+        language: system
+        files: (go.mod|go.sum)
+        pass_filenames: false
 
   - repo: local
     hooks:

--- a/evaluator/opa_test.go
+++ b/evaluator/opa_test.go
@@ -55,6 +55,8 @@ type OpaTestSuite struct {
 }
 
 func TestOpaTestSuite(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	s := new(OpaTestSuite)
 	s.log = testhelper.NewLogger(t)
 
@@ -112,6 +114,8 @@ func (s *OpaTestSuite) TestOpaEvaluator_decode() {
 }
 
 func (s *OpaTestSuite) TestOpaEvaluatorWithDecisionLogs() {
+	testhelper.SkipLong(s.T())
+
 	ctx := context.Background()
 	tests := []struct {
 		evals    int

--- a/flavors/benchmark/aws_org_test.go
+++ b/flavors/benchmark/aws_org_test.go
@@ -31,9 +31,12 @@ import (
 	"github.com/elastic/cloudbeat/dataprovider/providers/cloud"
 	"github.com/elastic/cloudbeat/resources/fetching"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
+	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
 func TestAWSOrg_Initialize(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	tests := []struct {
 		name             string
 		identityProvider awslib.IdentityProviderGetter

--- a/flavors/benchmark/aws_test.go
+++ b/flavors/benchmark/aws_test.go
@@ -24,9 +24,12 @@ import (
 	"github.com/elastic/cloudbeat/config"
 	"github.com/elastic/cloudbeat/resources/fetching"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
+	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
 func TestAWS_Initialize(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	tests := []struct {
 		name             string
 		identityProvider awslib.IdentityProviderGetter

--- a/flavors/benchmark/builder/benchmark_test.go
+++ b/flavors/benchmark/builder/benchmark_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 func TestRun_ReturnEvents(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	tests := []struct {
 		name           string
 		manager        func(*MockManager) *MockManager

--- a/flavors/benchmark/builder/builder_test.go
+++ b/flavors/benchmark/builder/builder_test.go
@@ -36,6 +36,8 @@ import (
 )
 
 func TestBase_Build_Success(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	tests := []struct {
 		name      string
 		opts      []Option
@@ -81,6 +83,8 @@ func TestBase_Build_Success(t *testing.T) {
 }
 
 func TestBase_BuildK8s_Success(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	tests := []struct {
 		name      string
 		opts      []Option

--- a/flavors/benchmark/builder/k8s_test.go
+++ b/flavors/benchmark/builder/k8s_test.go
@@ -35,6 +35,8 @@ import (
 )
 
 func TestK8sRun_ReturnEvents(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	tests := []struct {
 		name           string
 		manager        func(*MockManager) *MockManager

--- a/flavors/benchmark/eks_test.go
+++ b/flavors/benchmark/eks_test.go
@@ -28,9 +28,12 @@ import (
 	k8sprovider "github.com/elastic/cloudbeat/dataprovider/providers/k8s"
 	"github.com/elastic/cloudbeat/resources/fetching"
 	"github.com/elastic/cloudbeat/resources/providers/awslib"
+	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
 func TestEKS_Initialize(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	t.Setenv("NODE_NAME", "node-name")
 	awsCfg := config.Config{
 		CloudConfig: config.CloudConfig{

--- a/flavors/benchmark/k8s_test.go
+++ b/flavors/benchmark/k8s_test.go
@@ -24,9 +24,12 @@ import (
 	"github.com/elastic/cloudbeat/config"
 	k8sprovider "github.com/elastic/cloudbeat/dataprovider/providers/k8s"
 	"github.com/elastic/cloudbeat/resources/fetching"
+	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
 func TestK8S_Initialize(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	t.Setenv("NODE_NAME", "node-name")
 	tests := []struct {
 		name           string

--- a/flavors/publisher_test.go
+++ b/flavors/publisher_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestPublisher_HandleEvents(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	type testCase struct {
 		name              string
 		interval          time.Duration

--- a/flavors/repeater_test.go
+++ b/flavors/repeater_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestRepeater_Run(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	testCases := []struct {
 		name           string
 		interval       time.Duration

--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -139,6 +139,8 @@ type launcherMocks struct {
 }
 
 func TestLauncherTestSuite(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	s := new(LauncherTestSuite)
 	s.log = testhelper.NewLogger(t)
 

--- a/resources/fetching/cycle/cache_test.go
+++ b/resources/fetching/cycle/cache_test.go
@@ -151,6 +151,8 @@ func TestCache(t *testing.T) {
 }
 
 func TestCache_Lock(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	ctx := context.Background()
 	count := 0
 	ch := make(chan struct{})

--- a/resources/fetching/fetchers/k8s/kube_fetcher_test.go
+++ b/resources/fetching/fetchers/k8s/kube_fetcher_test.go
@@ -42,6 +42,8 @@ type KubeFetcherTestSuite struct {
 }
 
 func TestKubeFetcherTestSuite(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	s := new(KubeFetcherTestSuite)
 
 	suite.Run(t, s)

--- a/resources/fetching/manager/manager_test.go
+++ b/resources/fetching/manager/manager_test.go
@@ -40,6 +40,8 @@ type ManagerTestSuite struct {
 const timeout = 2 * time.Second
 
 func TestManagerTestSuite(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	s := new(ManagerTestSuite)
 
 	suite.Run(t, s)

--- a/resources/fetching/preset/aws_org_preset_test.go
+++ b/resources/fetching/preset/aws_org_preset_test.go
@@ -38,6 +38,8 @@ import (
 )
 
 func TestNewCisAwsOrganizationFetchers_Leak(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	t.Run("drain", func(t *testing.T) {
 		subtest(t, true)
 	})

--- a/resources/providers/awslib/cached_region_selector_test.go
+++ b/resources/providers/awslib/cached_region_selector_test.go
@@ -27,6 +27,8 @@ import (
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/elastic/cloudbeat/resources/utils/testhelper"
 )
 
 type CachedRegionSelectorTestSuite struct {
@@ -34,6 +36,8 @@ type CachedRegionSelectorTestSuite struct {
 }
 
 func TestCachedRegionSelectorTestSuite(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	s := new(CachedRegionSelectorTestSuite)
 
 	suite.Run(t, s)

--- a/resources/providers/azurelib/governance/management_group_test.go
+++ b/resources/providers/azurelib/governance/management_group_test.go
@@ -104,6 +104,8 @@ func Test_provider_GetSubscriptions(t *testing.T) {
 	})
 
 	t.Run("lock", func(t *testing.T) {
+		testhelper.SkipLong(t)
+
 		firstRun := atomic.NewBool(false)
 		m := inventory.NewMockProviderAPI(t)
 		m.EXPECT().

--- a/resources/utils/testhelper/helper.go
+++ b/resources/utils/testhelper/helper.go
@@ -97,3 +97,9 @@ func NewLogger(t *testing.T) *logp.Logger {
 
 	return logp.NewLogger(t.Name())
 }
+
+func SkipLong(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+}

--- a/resources/utils/testhelper/helper_test.go
+++ b/resources/utils/testhelper/helper_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 func TestCollectResources(t *testing.T) {
+	SkipLong(t)
+
 	t.Run("empty channel", func(t *testing.T) {
 		ch := make(chan struct{})
 		assert.Empty(t, CollectResources(ch))
@@ -84,6 +86,8 @@ func TestCollectResourcesBlocking(t *testing.T) {
 }
 
 func TestCollectResourcesWithTimeout(t *testing.T) {
+	SkipLong(t)
+
 	t.Run("blocks on empty channel", func(t *testing.T) {
 		ch := make(chan struct{})
 

--- a/uniqueness/leaderelection_test.go
+++ b/uniqueness/leaderelection_test.go
@@ -50,6 +50,8 @@ type LeaderElectionTestSuite struct {
 }
 
 func TestLeaderElectionTestSuite(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	s := new(LeaderElectionTestSuite)
 	suite.Run(t, s)
 }

--- a/vulnerability/events_creator_test.go
+++ b/vulnerability/events_creator_test.go
@@ -178,6 +178,8 @@ func (s *EventsCreatorTestSuite) TestCreateEvents_Success() {
 }
 
 func (s *EventsCreatorTestSuite) TestCreateEvents_Cancel() {
+	testhelper.SkipLong(s.T())
+
 	s.bdp.EXPECT().EnrichEvent(mock.Anything, mock.Anything).Return(nil).Times(10)
 	s.cdp.EXPECT().EnrichEvent(mock.Anything).Return(nil).Times(10)
 

--- a/vulnerability/fetcher_test.go
+++ b/vulnerability/fetcher_test.go
@@ -83,6 +83,8 @@ type FetcherTestSuite struct {
 }
 
 func TestFetcherTestSuite(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	s := new(FetcherTestSuite)
 	s.opts = goleak.IgnoreCurrent()
 	suite.Run(t, s)

--- a/vulnerability/replicator_test.go
+++ b/vulnerability/replicator_test.go
@@ -39,6 +39,8 @@ type ReplicatorTestSuite struct {
 }
 
 func TestReplicatorTestSuite(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	s := new(ReplicatorTestSuite)
 	s.opts = goleak.IgnoreCurrent()
 	suite.Run(t, s)

--- a/vulnerability/runner_test.go
+++ b/vulnerability/runner_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 func TestNewVulnerabilityRunner(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	log := testhelper.NewLogger(t)
 	runner, err := NewVulnerabilityRunner(log)
 	defer func() {
@@ -41,6 +43,8 @@ func TestNewVulnerabilityRunner(t *testing.T) {
 }
 
 func TestGetRunner(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	log := testhelper.NewLogger(t)
 	runner, err := NewVulnerabilityRunner(log)
 	defer func() {

--- a/vulnerability/verifier_test.go
+++ b/vulnerability/verifier_test.go
@@ -38,6 +38,8 @@ type VerifierTestSuite struct {
 }
 
 func TestVerifierTestSuite(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	s := new(VerifierTestSuite)
 	s.opts = goleak.IgnoreCurrent()
 	suite.Run(t, s)

--- a/vulnerability/worker_test.go
+++ b/vulnerability/worker_test.go
@@ -79,6 +79,8 @@ func (s runnerMock) Close(context.Context) error {
 }
 
 func TestNewVulnerabilityWorker(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	c := &config.Config{}
 	log := testhelper.NewLogger(t)
 	bdp := &dataprovider.MockCommonDataProvider{}
@@ -107,6 +109,8 @@ func TestNewVulnerabilityWorker(t *testing.T) {
 }
 
 func TestVulnerabilityWorker_Run(t *testing.T) {
+	testhelper.SkipLong(t)
+
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 	log := testhelper.NewLogger(t)


### PR DESCRIPTION
### Summary of your changes
Adds a pre-commit action for running the tests. By using the timeout flag, we ensure that all new tests that are long will be properly skipped when the short flag is used.

Fixes #1140 