### PR TITLE
Add retry mechanism to TestPublisher_HandleEvents

### DIFF
--- a/flavors/publisher_test.go
+++ b/flavors/publisher_test.go
@@ -142,7 +142,11 @@ func TestPublisher_HandleEvents(t *testing.T) {
 		// that cpu context switches won't interfere a few milliseconds here and there.
 		// Therefore, to avoid complex solutions retry was implemented. The likelihood of
 		// events being mis-published due to cpu switches is very small in 3 retries.
+		attempt := 1
 		retry.RunWith(&retry.Counter{Count: 3, Wait: 50 * time.Millisecond}, t, func(r *retry.R) {
+			r.Logf("Test %s - %s (attempt %d)", t.Name(), tc.name, attempt)
+			attempt++
+
 			log := testhelper.NewLogger(t)
 			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 			ctx, cancel := context.WithTimeout(context.Background(), tc.ctxTimeout)

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/gocarina/gocsv v0.0.0-20170324095351-ffef3ffc77be
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/googleapis/gax-go/v2 v2.12.0
+	github.com/hashicorp/consul/sdk v0.15.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/huandu/xstrings v1.4.0
 	github.com/magefile/mage v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -1807,6 +1807,8 @@ github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBt
 github.com/hashicorp/consul/api v1.18.0/go.mod h1:owRRGJ9M5xReDC5nfT8FTJrNAPbT4NM6p/k+d03q2v4=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.13.0/go.mod h1:0hs/l5fOVhJy/VdcoaNqUSi2AUs95eF5WKtv+EYIQqE=
+github.com/hashicorp/consul/sdk v0.15.0 h1:2qK9nDrr4tiJKRoxPGhm6B7xJjLVIQqkjiab2M4aKjU=
+github.com/hashicorp/consul/sdk v0.15.0/go.mod h1:r/OmRRPbHOe0yxNahLw7G9x5WG17E1BIECMtCjcPSNo=
 github.com/hashicorp/cronexpr v1.1.0 h1:dnNsWtH0V2ReN7JccYe8m//Bj14+PjJDntR1dz0Cixk=
 github.com/hashicorp/cronexpr v1.1.0/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=


### PR DESCRIPTION
### Summary of your changes

TestPublisher_HandleEvents tests the events batching functionality of `flavors.Publisher`. This is a tricky test because it spawns multiple goroutines and want to verify that x events were published in Y period. With litlle external interference the tests work great. But if for any reason multiple go routines run 1ms or 2ms later, or 1 go routine delays 10ms, the test will fail. 

For example, in a 45ms period, it's expected:

```
1 event at 10ms
2 event at 20ms
3 event at 30ms
4 event at 40ms
------- Publish 10 events
5 event at 50ms
6 event at 60ms
7 event at 70ms
8 event at 80ms
------- Publish 26 events
9 event at 90ms
------- Publish 9 events
```

But what happens sometimes is:
```
1 event at 11ms
2 event at 23ms
3 event at 35ms
------- Publish 6 events
4 event at 47ms
5 event at 50ms
6 event at 60ms
7 event at 70ms
8 event at 80ms
------- Publish 26 events
9 event at 90ms
------- Publish 9 events
```

To try to time it correctly agnostically from external OS interferences is hard. We could also think on mocking everything, even the tick. But then, are we really testing the functionality?

I decided to add this Retry mechanism, with a backoff period in between retries. Locally, I have not seen it failed. But the chance still exists, although smaller.

If it happens again, I think we should rethink this test.

### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/1661