### PR TITLE
add workflow for version bumps

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,41 @@
+name: Bump Cloudbeat version
+
+on:
+  workflow_dispatch:
+    inputs:
+      cloudbeat_version:
+        description: "New cloudbeat major.minor version (e.g. 8.13)"
+        required: true
+
+env:
+  GITHUB_TOKEN: ${{ secrets.CLOUDSEC_MACHINE_TOKEN }}
+  NEXT_CLOUDBEAT_VERSION: ${{ inputs.cloudbeat_version }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.CSPM_CFT_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.CSPM_CFT_SECRET_ACCESS_KEY }}
+
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Cloudbeat Repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CLOUDSEC_MACHINE_TOKEN }}
+
+      - name: Setup Cloudbeat Versions
+        run: |
+          echo "CURRENT_CLOUDBEAT_VERSION=$(grep defaultBeatVersion version/version.go | cut -f2 -d "\"")" >> $GITHUB_ENV
+          echo "NEXT_CLOUDBEAT_VERSION=$NEXT_CLOUDBEAT_VERSION.0" >> $GITHUB_ENV
+          echo "Bumping $CURRENT_CLOUDBEAT_VERSION to $NEXT_CLOUDBEAT_VERSION"
+
+      - name: Setup Git User
+        run: |
+          git config --global user.email "cloudsecmachine@users.noreply.github.com"
+          git config --global user.name "Cloud Security Machine"
+
+      - name: Bump Cloudbeat
+        run: scripts/bump_cloudbeat.sh
+
+      - name: Bump Cloud Security Posture Integration
+        run: scripts/bump_integration.sh

--- a/scripts/bump_cloudbeat.sh
+++ b/scripts/bump_cloudbeat.sh
@@ -61,7 +61,7 @@ create_cloudbeat_versions_pr() {
     cat <<EOF >cloudbeat_pr_body
 Bump cloudbeat version - \`$NEXT_CLOUDBEAT_VERSION\`
 
-> [!NOTE]  
+> [!NOTE]
 > This is an automated PR
 EOF
 
@@ -95,10 +95,10 @@ bump_hermit() {
     cat <<EOF >hermit_pr_body
 Bump cloudbeat version - \`$NEXT_CLOUDBEAT_VERSION\`
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > to be merged after snapshot build for $NEXT_CLOUDBEAT_VERSION is available
 
-> [!NOTE]  
+> [!NOTE]
 > This is an automated PR
 EOF
 

--- a/scripts/bump_cloudbeat.sh
+++ b/scripts/bump_cloudbeat.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+set -euo pipefail
+
+export NEXT_CLOUDBEAT_BRANCH="bump-to-$NEXT_CLOUDBEAT_VERSION"
+export NEXT_MINOR_VERSION=$(echo $NEXT_CLOUDBEAT_VERSION | cut -d '.' -f1,2)
+export CURRENT_MINOR_VERSION=$(echo $CURRENT_CLOUDBEAT_VERSION | cut -d '.' -f1,2)
+
+echo "NEXT_CLOUDBEAT_VERSION: $NEXT_CLOUDBEAT_VERSION"
+echo "NEXT_MINOR_VERSION: $NEXT_MINOR_VERSION"
+echo "CURRENT_CLOUDBEAT_VERSION: $CURRENT_CLOUDBEAT_VERSION"
+echo "CURRENT_MINOR_VERSION: $CURRENT_MINOR_VERSION"
+
+update_version_mergify() {
+    echo "• Add a new entry to .mergify.yml"
+    cat <<EOF >>.mergify.yml
+  - name: backport patches to $CURRENT_MINOR_VERSION branch
+    conditions:
+      - merged
+      - label=backport-v$CURRENT_CLOUDBEAT_VERSION
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "$CURRENT_MINOR_VERSION"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+EOF
+}
+
+update_version_arm_template() {
+    echo "• Update ARM templates with new version"
+    local single_account_file="deploy/azure/ARM-for-single-account.json"
+    local organization_account_file="deploy/azure/ARM-for-organization-account.json"
+
+    echo "• Replace defaultValue for ElasticAgentVersion in ARM templates"
+    jq --indent 4 ".parameters.ElasticAgentVersion.defaultValue = \"$NEXT_CLOUDBEAT_VERSION\"" $single_account_file >tmp.json && mv tmp.json $single_account_file
+    jq --indent 4 ".parameters.ElasticAgentVersion.defaultValue = \"$NEXT_CLOUDBEAT_VERSION\"" $organization_account_file >tmp.json && mv tmp.json $organization_account_file
+
+    echo "• Replace cloudbeat/main with cloudbeat/$NEXT_MINOR_VERSION in ARM templates"
+    sed -i'' -E "s/cloudbeat\/main/cloudbeat\/$NEXT_MINOR_VERSION/g" $single_account_file
+    sed -i'' -E "s/cloudbeat\/main/cloudbeat\/$NEXT_MINOR_VERSION/g" $organization_account_file
+
+    echo "• Generate dev ARM templates"
+    ./deploy/azure/generate_dev_template.py --template-type single-account
+    ./deploy/azure/generate_dev_template.py --template-type organization-account
+}
+
+update_version_beat() {
+    echo "• Update version/version.go with new version"
+    sed -i'' -E "s/const defaultBeatVersion = .*/const defaultBeatVersion = \"$NEXT_CLOUDBEAT_VERSION\"/g" version/version.go
+}
+
+create_cloudbeat_versions_pr() {
+    echo "• Create PR for cloudbeat versions"
+    git add .
+    git commit -m "Bump cloudbeat to $NEXT_CLOUDBEAT_VERSION"
+    git push origin "$NEXT_CLOUDBEAT_BRANCH"
+
+    cat <<EOF >cloudbeat_pr_body
+Bump cloudbeat version - \`$NEXT_CLOUDBEAT_VERSION\`
+
+> [!NOTE]  
+> This is an automated PR
+EOF
+
+    gh pr create --title "Bump cloudbeat version" \
+        --body-file cloudbeat_pr_body \
+        --base "main" \
+        --head "$NEXT_CLOUDBEAT_BRANCH" \
+        --label "backport-skip"
+}
+
+bump_cloudbeat() {
+    git fetch origin main
+    git checkout -b "$NEXT_CLOUDBEAT_BRANCH" origin/main
+    update_version_mergify
+    update_version_arm_template
+    update_version_beat
+    create_cloudbeat_versions_pr
+}
+
+# We need to bump hermit seperately because we need to wait for the snapshot build to be available
+bump_hermit() {
+    echo "• Bump hermit cloudbeat version"
+    local BRANCH="bump-hermit-to-$NEXT_CLOUDBEAT_VERSION"
+    git checkout -b "$BRANCH" origin/main
+
+    sed -i'' -E "s/\"CLOUDBEAT_VERSION\": .*/\"CLOUDBEAT_VERSION\": \"$NEXT_CLOUDBEAT_VERSION\",/g" bin/hermit.hcl
+    git add bin/hermit.hcl
+    git commit -m "Bump cloudbeat to $NEXT_CLOUDBEAT_VERSION"
+    git push origin "$BRANCH"
+
+    cat <<EOF >hermit_pr_body
+Bump cloudbeat version - \`$NEXT_CLOUDBEAT_VERSION\`
+
+> [!IMPORTANT]  
+> to be merged after snapshot build for $NEXT_CLOUDBEAT_VERSION is available
+
+> [!NOTE]  
+> This is an automated PR
+EOF
+
+    echo "• Create a PR for cloudbeat hermit version"
+    gh pr create --title "Bump hermit cloudbeat version" \
+        --body-file hermit_pr_body \
+        --base "main" \
+        --head "$BRANCH" \
+        --label "backport-skip"
+}
+
+upload_cloud_formation_templates() {
+    echo "• Upload cloud formation templates for $CURRENT_CLOUDBEAT_VERSION"
+    aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+    aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+    aws configure set region us-east-2
+    scripts/publish_cft.sh
+}
+
+bump_cloudbeat
+bump_hermit
+upload_cloud_formation_templates

--- a/scripts/bump_cloudbeat.sh
+++ b/scripts/bump_cloudbeat.sh
@@ -2,8 +2,11 @@
 set -euo pipefail
 
 export NEXT_CLOUDBEAT_BRANCH="bump-to-$NEXT_CLOUDBEAT_VERSION"
-export NEXT_MINOR_VERSION=$(echo $NEXT_CLOUDBEAT_VERSION | cut -d '.' -f1,2)
-export CURRENT_MINOR_VERSION=$(echo $CURRENT_CLOUDBEAT_VERSION | cut -d '.' -f1,2)
+NEXT_MINOR_VERSION=$(echo "$NEXT_CLOUDBEAT_VERSION" | cut -d '.' -f1,2)
+CURRENT_MINOR_VERSION=$(echo "$CURRENT_CLOUDBEAT_VERSION" | cut -d '.' -f1,2)
+
+export NEXT_MINOR_VERSION
+export CURRENT_MINOR_VERSION
 
 echo "NEXT_CLOUDBEAT_VERSION: $NEXT_CLOUDBEAT_VERSION"
 echo "NEXT_MINOR_VERSION: $NEXT_MINOR_VERSION"
@@ -112,8 +115,8 @@ EOF
 
 upload_cloud_formation_templates() {
     echo "• Upload cloud formation templates for $CURRENT_CLOUDBEAT_VERSION"
-    aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
-    aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+    aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
+    aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
     aws configure set region us-east-2
     scripts/publish_cft.sh
 }

--- a/scripts/bump_integration.sh
+++ b/scripts/bump_integration.sh
@@ -52,7 +52,7 @@ create_integrations_pr() {
     cat <<EOF >pr_body
 Bump integration version - \`$NEXT_INTEGRATION_VERSION\`
 
-> [!NOTE]  
+> [!NOTE]
 > This is an automated PR
 EOF
 

--- a/scripts/bump_integration.sh
+++ b/scripts/bump_integration.sh
@@ -5,7 +5,9 @@ export MANIFEST_PATH="packages/cloud_security_posture/manifest.yml"
 export CHANGELOG_PATH="packages/cloud_security_posture/changelog.yml"
 export INTEGRATION_REPO="elastic/integrations"
 export BRANCH="bump-to-$NEXT_CLOUDBEAT_VERSION"
-export MAJOR_MINOR_CLOUDBEAT=$(echo "$NEXT_CLOUDBEAT_VERSION" | cut -d. -f1,2)
+MAJOR_MINOR_CLOUDBEAT=$(echo "$NEXT_CLOUDBEAT_VERSION" | cut -d. -f1,2)
+
+export MAJOR_MINOR_CLOUDBEAT
 
 checkout_integration_repo() {
     echo "• Checkout integration repo"
@@ -20,10 +22,10 @@ checkout_integration_repo() {
 get_next_integration_version() {
     echo "• Get next integration version"
     input_line=$(sed -n '3p' $CHANGELOG_PATH) # last version is always on line 3
-    first_version=$(echo $input_line | cut -d' ' -f2)
-    major_minor=$(echo $first_version | cut -d'.' -f1-2)
-    major=$(echo $major_minor | cut -d'.' -f1)
-    minor=$(echo $major_minor | cut -d'.' -f2)
+    first_version=$(echo "$input_line" | cut -d' ' -f2)
+    major_minor=$(echo "$first_version" | cut -d'.' -f1-2)
+    major=$(echo "$major_minor" | cut -d'.' -f1)
+    minor=$(echo "$major_minor" | cut -d'.' -f2)
     next_minor=$((minor + 1))
     export NEXT_INTEGRATION_VERSION="$major.$next_minor.0"
     echo "NEXT_INTEGRATION_VERSION: $NEXT_INTEGRATION_VERSION"
@@ -45,7 +47,7 @@ update_manifest_version_vars() {
 
     git add $MANIFEST_PATH
     git commit -m "Update manifest template vars"
-    git push origin $BRANCH
+    git push origin "$BRANCH"
 }
 
 create_integrations_pr() {
@@ -64,7 +66,7 @@ EOF
         --label "enhancement" \
         --label "Team:Cloud Security" \
         --repo "$INTEGRATION_REPO")"
-    echo $PR_URL
+    echo "$PR_URL"
 }
 
 update_manifest_version() {
@@ -72,7 +74,7 @@ update_manifest_version() {
     yq -i ".version = \"$NEXT_INTEGRATION_VERSION\"" $MANIFEST_PATH
     git add $MANIFEST_PATH
     git commit -m "Update manifest version"
-    git push origin $BRANCH
+    git push origin "$BRANCH"
 }
 
 update_changelog_version() {
@@ -83,20 +85,19 @@ update_changelog_version() {
     yq -i '.[0].changes += [{"description": "Bump version", "type": "enhancement", "link": env(PR_URL) }]' $CHANGELOG_PATH
     git add $CHANGELOG_PATH
     git commit -m "Update changelog version"
-    git push origin $BRANCH
+    git push origin "$BRANCH"
 }
 
 update_changelog_version_map() {
     echo "• Update changelog version map"
     next_minor=$(echo "$NEXT_INTEGRATION_VERSION" | cut -d'.' -f1,2)
     new_comment="# ${next_minor}.x - ${MAJOR_MINOR_CLOUDBEAT}.x"
-    file_content=$(<"$CHANGELOG_PATH")
     new_file_content=$(awk -v var="$new_comment" 'NR==3 {print var} {print}' "$CHANGELOG_PATH")
     echo -e "$new_file_content" >temp.yaml
     mv temp.yaml "$CHANGELOG_PATH"
     git add $CHANGELOG_PATH
     git commit -m "Update changelog version map"
-    git push origin $BRANCH
+    git push origin "$BRANCH"
 }
 
 checkout_integration_repo

--- a/scripts/bump_integration.sh
+++ b/scripts/bump_integration.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -euo pipefail
+
+export MANIFEST_PATH="packages/cloud_security_posture/manifest.yml"
+export CHANGELOG_PATH="packages/cloud_security_posture/changelog.yml"
+export INTEGRATION_REPO="elastic/integrations"
+export BRANCH="bump-to-$NEXT_CLOUDBEAT_VERSION"
+export MAJOR_MINOR_CLOUDBEAT=$(echo "$NEXT_CLOUDBEAT_VERSION" | cut -d. -f1,2)
+
+checkout_integration_repo() {
+    echo "• Checkout integration repo"
+    gh auth setup-git
+    gh repo clone $INTEGRATION_REPO
+    cd integrations
+    git checkout -b "$BRANCH" origin/main
+}
+
+# reads the last version from changelog.yml version map
+# and increments the minor version
+get_next_integration_version() {
+    echo "• Get next integration version"
+    input_line=$(sed -n '3p' $CHANGELOG_PATH) # last version is always on line 3
+    first_version=$(echo $input_line | cut -d' ' -f2)
+    major_minor=$(echo $first_version | cut -d'.' -f1-2)
+    major=$(echo $major_minor | cut -d'.' -f1)
+    minor=$(echo $major_minor | cut -d'.' -f2)
+    next_minor=$((minor + 1))
+    export NEXT_INTEGRATION_VERSION="$major.$next_minor.0"
+    echo "NEXT_INTEGRATION_VERSION: $NEXT_INTEGRATION_VERSION"
+}
+
+update_manifest_version_vars() {
+    # cis_gcp
+    echo "• Update cloudshell_git_branch in manifest.yml"
+    sed -i'' -E "s/cloudshell_git_branch=[0-9]+\.[0-9]+/cloudshell_git_branch=$MAJOR_MINOR_CLOUDBEAT/g" $MANIFEST_PATH
+
+    # cis_aws + vuln_mgmt_aws
+    echo "• Update cloudformation-* in manifest.yml"
+    sed -i'' -E "s/cloudformation-cnvm-[0-9]+\.[0-9]+\.[0-9]+/cloudformation-cnvm-$NEXT_CLOUDBEAT_VERSION/g" $MANIFEST_PATH
+    sed -i'' -E "s/cloudformation-cspm-ACCOUNT_TYPE-[0-9]+\.[0-9]+\.[0-9]+/cloudformation-cspm-ACCOUNT_TYPE-$NEXT_CLOUDBEAT_VERSION/g" $MANIFEST_PATH
+
+    # cis_azure
+    echo "• Update cloudshell_git_branch in manifest.yml"
+    sed -i'' -E "s/cloudbeat%2F[0-9]+\.[0-9]+/cloudbeat%2F$MAJOR_MINOR_CLOUDBEAT/g" $MANIFEST_PATH
+
+    git add $MANIFEST_PATH
+    git commit -m "Update manifest template vars"
+    git push origin $BRANCH
+}
+
+create_integrations_pr() {
+    cat <<EOF >pr_body
+Bump integration version - \`$NEXT_INTEGRATION_VERSION\`
+
+> [!NOTE]  
+> This is an automated PR
+EOF
+
+    echo '• Create a PR to update integration'
+    PR_URL="$(gh pr create --title "[Cloud Security] Bump integration" \
+        --body-file pr_body \
+        --base "main" \
+        --head "$BRANCH" \
+        --label "enhancement" \
+        --label "Team:Cloud Security" \
+        --repo "$INTEGRATION_REPO")"
+    echo $PR_URL
+}
+
+update_manifest_version() {
+    echo "• Update manifest version"
+    yq -i ".version = \"$NEXT_INTEGRATION_VERSION\"" $MANIFEST_PATH
+    git add $MANIFEST_PATH
+    git commit -m "Update manifest version"
+    git push origin $BRANCH
+}
+
+update_changelog_version() {
+    local PR_URL="$1"
+    echo "• Update changelog version"
+    yq -i ".[0].version = \"$NEXT_INTEGRATION_VERSION\"" $CHANGELOG_PATH
+    # this line below requires single quotes and env(PR) to interpolate this env var
+    yq -i '.[0].changes += [{"description": "Bump version", "type": "enhancement", "link": env(PR_URL) }]' $CHANGELOG_PATH
+    git add $CHANGELOG_PATH
+    git commit -m "Update changelog version"
+    git push origin $BRANCH
+}
+
+update_changelog_version_map() {
+    echo "• Update changelog version map"
+    next_minor=$(echo "$NEXT_INTEGRATION_VERSION" | cut -d'.' -f1,2)
+    new_comment="# ${next_minor}.x - ${MAJOR_MINOR_CLOUDBEAT}.x"
+    file_content=$(<"$CHANGELOG_PATH")
+    new_file_content=$(awk -v var="$new_comment" 'NR==3 {print var} {print}' "$CHANGELOG_PATH")
+    echo -e "$new_file_content" >temp.yaml
+    mv temp.yaml "$CHANGELOG_PATH"
+    git add $CHANGELOG_PATH
+    git commit -m "Update changelog version map"
+    git push origin $BRANCH
+}
+
+checkout_integration_repo
+get_next_integration_version
+update_manifest_version_vars
+update_manifest_version
+update_changelog_version "$(create_integrations_pr)"
+update_changelog_version_map


### PR DESCRIPTION
### Summary of your changes

this PR adds a dispatch workflow that should be triggered manually whenever we release a new version. it takes a single input:
- next cloudbeat version (major.minor) 

then it bumps all the required files in both repos

### Screenshot/Data

for a test-run, i bumped `8.14.0` to `8.15.0` (current is actually `8.13.0` but this was just for demo purpose)
- [intergrations PR](https://github.com/elastic/integrations/pull/8958)
- [cloudbeat versions PR](https://github.com/elastic/cloudbeat/pull/1851)
- [cloudbeat hermit PR](https://github.com/elastic/cloudbeat/pull/1852)


looks like this:
![Screenshot 2024-01-24 at 18 07 19](https://github.com/elastic/cloudbeat/assets/20814186/ed2f9cfa-6ec5-4cb1-801d-9d78f31e781d)


### Related Issues
 - closes https://github.com/elastic/cloudbeat/issues/1675



