### PR TITLE
updatecli: Update go mod dependencies

### DIFF
--- a/.ci/updatecli/scripts/update-mods.sh
+++ b/.ci/updatecli/scripts/update-mods.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euxo pipefail
+
+function update_deps() {
+    # Update dependencies in go.mod and go.sum
+    go get -u "$1" && go mod tidy || return 1
+    # Check if anything changed
+    git diff --exit-code &>/dev/null && return 1
+    # Build and test
+    go build && go test -failfast || return 1
+    # Add changes to git
+    git add .
+    return 0
+}
+
+go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | # List all direct dependencies
+    grep -v 'github.com/elastic/beats/v7' |                           # Updated separately
+    sort --random-sort |                                              # Avoid always having the same update order
+    while read -r line; do
+        update_deps "$line" || git restore . # Reset state if update fails to build and pass tests
+    done

--- a/.ci/updatecli/scripts/update-mods.sh
+++ b/.ci/updatecli/scripts/update-mods.sh
@@ -7,7 +7,7 @@ function update_deps() {
     # Check if anything changed
     git diff --exit-code &>/dev/null && return 1
     # Build and test
-    go build && go test -failfast || return 1
+    go build && go test -failfast ./... || return 1
     # Add changes to git
     git add .
     return 0

--- a/.ci/updatecli/updatecli.d/update-mods.yml
+++ b/.ci/updatecli/updatecli.d/update-mods.yml
@@ -1,0 +1,44 @@
+---
+name: Update Golang Mod Dependencies
+pipelineid: 'updatecli-mods-{{ requiredEnv "GIT_BRANCH" }}'
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GIT_USER" }}'
+      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      branch: '{{ requiredEnv "GIT_BRANCH" }}'
+
+actions:
+  default:
+    title: '[updatecli] Update golang mod dependencies'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      labels:
+        - automation
+        - backport-skip
+        - dependency
+        - go
+      description: |-
+        ### What
+        Run `go get -u ${module}` for each module in `go.mod`.
+
+        Generated automatically with {{ requiredEnv "JOB_URL" }}
+
+targets:
+  mods:
+    name: 'Update golang mod dependencies'
+    scmid: default
+    kind: shell
+    spec:
+      command: .ci/updatecli/scripts/update-mods.sh
+      environments:
+        - name: PATH
+        - name: HOME

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pipeline-name: [ beats, golang, hermit ]
+        pipeline-name: [ beats, golang, hermit, mods ]
     steps:
       - uses: actions/checkout@v4
       - name: Init Hermit


### PR DESCRIPTION
### Summary of your changes
Since dependabot is often encountering issues updating our go.mod, we can work-around this by updating everything with updatecli.

Since not all modules can be upgraded without failures, the script updates modules one-by-one and reverts the changes if build & test fails.