### PR TITLE
Add wait step to avoid too tight publishing period

### DIFF
--- a/flavors/publisher_test.go
+++ b/flavors/publisher_test.go
@@ -33,13 +33,14 @@ func TestPublisher_HandleEvents(t *testing.T) {
 	testhelper.SkipLong(t)
 
 	type testCase struct {
-		name              string
-		interval          time.Duration
-		threshold         int
-		ctxTimeout        time.Duration
-		eventCount        int
-		expectedEventSize []int
-		closeChannel      bool
+		name                  string
+		interval              time.Duration
+		threshold             int
+		ctxTimeout            time.Duration
+		eventCount            int
+		expectedEventSize     []int
+		closeChannel          bool
+		expectedEventsInCycle int
 	}
 	testCases := []testCase{
 		{
@@ -115,14 +116,6 @@ func TestPublisher_HandleEvents(t *testing.T) {
 			eventCount:        4,
 			expectedEventSize: []int{6},
 		},
-		// {
-		//	name:              "Publish events on interval reached 2 times",
-		//	interval:          45 * time.Millisecond,
-		//	threshold:         100,
-		//	ctxTimeout:        200 * time.Millisecond,
-		//	eventCount:        10,
-		//	expectedEventSize: []int{10, 26, 9},
-		// },
 		{
 			name:              "Publish events on closed channel",
 			interval:          time.Minute,
@@ -131,6 +124,15 @@ func TestPublisher_HandleEvents(t *testing.T) {
 			eventCount:        4,
 			expectedEventSize: []int{6},
 			closeChannel:      true,
+		},
+		{
+			name:                  "Publish events on interval reached 2 times",
+			interval:              55 * time.Millisecond,
+			threshold:             100,
+			ctxTimeout:            250 * time.Millisecond,
+			eventCount:            10,
+			expectedEventSize:     []int{10, 26, 9},
+			expectedEventsInCycle: 4,
 		},
 	}
 
@@ -150,12 +152,13 @@ func TestPublisher_HandleEvents(t *testing.T) {
 			eventsChannel := make(chan []beat.Event)
 
 			go func(tc testCase) {
+				start := time.Now()
 				for i := 0; i < tc.eventCount; i++ {
 					select {
 					case <-ctx.Done():
 						return
 					// Simulate events being sent to the channel
-					case eventsChannel <- generateEvents(i):
+					case eventsChannel <- generateEvents(t, i, tc.expectedEventsInCycle, tc.interval, start):
 					}
 					time.Sleep(10 * time.Millisecond)
 				}
@@ -175,10 +178,26 @@ func lengthMatcher(length int) func(events []beat.Event) bool {
 	}
 }
 
-func generateEvents(size int) []beat.Event {
+func generateEvents(t *testing.T, size int, expectedEventsInCycle int, interval time.Duration, start time.Time) []beat.Event {
+	sleepOnCycleEnd(t, size, expectedEventsInCycle, interval, start)
+	t.Logf(" %d events at %dms", size, time.Since(start).Milliseconds())
 	results := make([]beat.Event, size)
 	for i := 0; i < size; i++ {
 		results[i] = beat.Event{}
 	}
 	return results
+}
+
+const gracePeriod = 10 * time.Millisecond
+
+// sleepOnCycleEnd once the expected amount of events to be published is reached,
+// wait the rest of the interval + grace period. The grace periods exists to avoid delays on the tick
+func sleepOnCycleEnd(t *testing.T, size int, eventCount int, interval time.Duration, start time.Time) {
+	if eventCount > 0 && size > 1 && size%eventCount == 1 {
+		cycle := size / eventCount
+		cycleInterval := interval * time.Duration(cycle)
+		waitPeriod := cycleInterval - time.Since(start) + gracePeriod
+		t.Logf("--- Waiting %s (cycle %d interval %s)", waitPeriod.String(), cycle, cycleInterval.String())
+		time.Sleep(waitPeriod)
+	}
 }


### PR DESCRIPTION
### Summary of your changes

*this is an alternative solution to https://github.com/elastic/cloudbeat/pull/1678*

TestPublisher_HandleEvents tests the events batching functionality of `flavors.Publisher`. This is a tricky test because it spawns multiple goroutines and want to verify that x events were published in Y period. With litlle external interference the tests work great. But if for any reason multiple go routines run 1ms or 2ms later, or 1 go routine delays 10ms, the test will fail. 

For example, in a 45ms period, it's expected:

```
1 event at 10ms
2 event at 20ms
3 event at 30ms
4 event at 40ms
------- Publish 10 events
5 event at 50ms
6 event at 60ms
7 event at 70ms
8 event at 80ms
------- Publish 26 events
9 event at 90ms
------- Publish 9 events
```

But what happens sometimes is:
```
1 event at 11ms
2 event at 23ms
3 event at 35ms
------- Publish 6 events
4 event at 47ms
5 event at 50ms
6 event at 60ms
7 event at 70ms
8 event at 80ms
------- Publish 26 events
9 event at 90ms
------- Publish 9 events
```


The idea behind this PR is to wait until the interval is finished + a grace period so we make sure that the flush was finished before publishing new events. I also increased the interval. So the expectation is:

```
1 event at 11ms
2 event at 23ms
3 event at 35ms
4 event at 47ms
  ------- Wait 18ms (55ms of interval - 47ms current span + 10ms for gracePeriod)
  ------- Publish 10 events at 55ms
5 event at 65ms
6 event at 75ms
7 event at 85ms
8 event at 95ms
    ------- Wait 25ms (110ms of interval - 5ms current span + 10ms for gracePeriod)
    ------- Publish 26 events at 120
9 event at 90ms
     ------- Publish 9 events
```


This doesn't prevent long pauses, like the below on (seen locally), or long tick delays:
```
0 events at 0ms
1 events at 10ms
2 events at 20ms
3 events at 63ms   
```

Essentially, I think we can make this less probable, but a complete fix, I couldn't think of one. We are always prone to have long pauses.


### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/1661