### PR TITLE
updatecli: Run cron job earlier

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -33,7 +33,7 @@ name: Update Dependencies with Updatecli
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 13 * * 1'
+    - cron: '0 7 * * 1'
 
 permissions:
   contents: read

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -33,6 +33,7 @@ name: Update Dependencies with Updatecli
 on:
   workflow_dispatch:
   schedule:
+    # Run all jobs weekly at 07:00 UTC on Monday.
     - cron: '0 7 * * 1'
 
 permissions:


### PR DESCRIPTION
### Summary of your changes
Run the jobs earlier so that they ready to merge on Monday morning.