### PR TITLE
update-mods.sh: Break after 5 hours

### DIFF
--- a/.ci/updatecli/scripts/update-mods.sh
+++ b/.ci/updatecli/scripts/update-mods.sh
@@ -13,9 +13,11 @@ function update_deps() {
     return 0
 }
 
+SECONDS=0
 go list -m -f '{{if not (or .Indirect .Main)}}{{.Path}}{{end}}' all | # List all direct dependencies
     grep -v 'github.com/elastic/beats/v7' |                           # Updated separately
     sort --random-sort |                                              # Avoid always having the same update order
     while read -r line; do
+        ((SECONDS > 18000)) && break         # Break after 5 hours, GitHub Actions has a 6 hour limit
         update_deps "$line" || git restore . # Reset state if update fails to build and pass tests
     done


### PR DESCRIPTION
### Summary of your changes
On the last run, the job timed-out after 6 hours because of the amount of work it had to do. We can do the updates in 5-hour batches in these cases.

For the $SECONDS variable see https://stackoverflow.com/a/31663949