### PR TITLE
TestLauncherStopTimeout: Increase post-grace sleep duration

### DIFF
--- a/launcher/launcher_test.go
+++ b/launcher/launcher_test.go
@@ -489,9 +489,10 @@ func (s *LauncherTestSuite) TestLauncherStopTimeout() {
 
 	sut.wg.Add(1) // keep waiting for graceful period
 	go func() {
+		defer sut.wg.Done()
+
 		sut.Stop()
-		time.Sleep(shutdownGracePeriod + 10*time.Millisecond)
-		sut.wg.Done()
+		time.Sleep(shutdownGracePeriod + 100*time.Millisecond)
 	}()
 
 	err := sut.run()


### PR DESCRIPTION
### Summary of your changes
Since 10ms can be too little time and beater might exit gracefully in that time span.

Fixes #1703