### PR TITLE
revive: Enable unexported-naming and unexported-return

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -112,10 +112,6 @@ linters-settings:
         disabled: true
       - name: unchecked-type-assertion
         disabled: true
-      - name: unexported-naming
-        disabled: true
-      - name: unexported-return
-        disabled: true
       - name: unhandled-error
         disabled: true
       - name: unused-receiver

--- a/dataprovider/enrich.go
+++ b/dataprovider/enrich.go
@@ -23,17 +23,17 @@ type ElasticCommonDataProvider interface {
 	GetElasticCommonData() (map[string]any, error)
 }
 
-type enricher struct {
+type Enricher struct {
 	dataprovider ElasticCommonDataProvider
 }
 
-func NewEnricher(dataprovider ElasticCommonDataProvider) *enricher {
-	return &enricher{
+func NewEnricher(dataprovider ElasticCommonDataProvider) *Enricher {
+	return &Enricher{
 		dataprovider: dataprovider,
 	}
 }
 
-func (e *enricher) EnrichEvent(event *beat.Event) error {
+func (e *Enricher) EnrichEvent(event *beat.Event) error {
 	ecsData, err := e.dataprovider.GetElasticCommonData()
 	if err != nil {
 		return err

--- a/dataprovider/providers/k8s/id_provider.go
+++ b/dataprovider/providers/k8s/id_provider.go
@@ -20,6 +20,7 @@ package k8s
 import (
 	"github.com/gofrs/uuid"
 
+	"github.com/elastic/cloudbeat/dataprovider"
 	"github.com/elastic/cloudbeat/resources/fetching"
 	fetchers "github.com/elastic/cloudbeat/resources/fetching/fetchers/k8s"
 )
@@ -32,7 +33,7 @@ type idProvider struct {
 	nodeID    string
 }
 
-func NewIdProvider(clusterID, nodeID string) *idProvider {
+func NewIdProvider(clusterID, nodeID string) dataprovider.IdProvider {
 	return &idProvider{
 		namespace: uuidNamespace,
 		clusterID: clusterID,

--- a/dataprovider/providers/k8s/id_provider_test.go
+++ b/dataprovider/providers/k8s/id_provider_test.go
@@ -54,7 +54,7 @@ func Test_k8sIdProvider_GetIdInCluster(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewIdProvider("cluster_id", "node_id")
+			p := NewIdProvider("cluster_id", "node_id").(*idProvider)
 			data := p.getIdInCluster(tt.resource, tt.id)
 			assert.Equal(t, tt.want, data)
 		})

--- a/flavors/benchmark/aws_org_test.go
+++ b/flavors/benchmark/aws_org_test.go
@@ -145,11 +145,11 @@ func Test_getAwsAccounts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			A := AWSOrg{
+			a := AWSOrg{
 				IdentityProvider: nil,
 				AccountProvider:  tt.accountProvider,
 			}
-			got, err := A.getAwsAccounts(context.Background(), nil, aws.Config{}, &tt.rootIdentity)
+			got, err := a.getAwsAccounts(context.Background(), nil, aws.Config{}, &tt.rootIdentity)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return

--- a/flavors/benchmark/k8s_helper.go
+++ b/flavors/benchmark/k8s_helper.go
@@ -31,21 +31,21 @@ import (
 	"github.com/elastic/cloudbeat/dataprovider/providers/k8s"
 )
 
-type k8sBenchmarkHelper struct {
+type K8SBenchmarkHelper struct {
 	log    *logp.Logger
 	cfg    *config.Config
 	client client_gokubernetes.Interface
 }
 
-func NewK8sBenchmarkHelper(log *logp.Logger, cfg *config.Config, client client_gokubernetes.Interface) *k8sBenchmarkHelper {
-	return &k8sBenchmarkHelper{
+func NewK8sBenchmarkHelper(log *logp.Logger, cfg *config.Config, client client_gokubernetes.Interface) *K8SBenchmarkHelper {
+	return &K8SBenchmarkHelper{
 		log:    log,
 		cfg:    cfg,
 		client: client,
 	}
 }
 
-func (h *k8sBenchmarkHelper) GetK8sDataProvider(ctx context.Context, clusterNameProvider k8s.ClusterNameProviderAPI) (dataprovider.CommonDataProvider, error) {
+func (h *K8SBenchmarkHelper) GetK8sDataProvider(ctx context.Context, clusterNameProvider k8s.ClusterNameProviderAPI) (dataprovider.CommonDataProvider, error) {
 	clusterName, err := clusterNameProvider.GetClusterName(ctx, h.cfg)
 	if err != nil {
 		h.log.Errorf("failed to get cluster name: %v", err)
@@ -69,7 +69,7 @@ func (h *k8sBenchmarkHelper) GetK8sDataProvider(ctx context.Context, clusterName
 	return k8s.New(options...), nil
 }
 
-func (h *k8sBenchmarkHelper) GetK8sIdProvider(ctx context.Context) (dataprovider.IdProvider, error) {
+func (h *K8SBenchmarkHelper) GetK8sIdProvider(ctx context.Context) (dataprovider.IdProvider, error) {
 	nodeId, err := h.getK8sNodeId(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get node id: %w", err)
@@ -83,7 +83,7 @@ func (h *k8sBenchmarkHelper) GetK8sIdProvider(ctx context.Context) (dataprovider
 	return k8s.NewIdProvider(clusterId, nodeId), nil
 }
 
-func (h *k8sBenchmarkHelper) getK8sClusterId(ctx context.Context) (string, error) {
+func (h *K8SBenchmarkHelper) getK8sClusterId(ctx context.Context) (string, error) {
 	namespace, err := h.client.CoreV1().Namespaces().Get(ctx, "kube-system", v1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to get namespace data: %w", err)
@@ -92,7 +92,7 @@ func (h *k8sBenchmarkHelper) getK8sClusterId(ctx context.Context) (string, error
 	return string(namespace.ObjectMeta.UID), nil
 }
 
-func (h *k8sBenchmarkHelper) getK8sNodeId(ctx context.Context) (string, error) {
+func (h *K8SBenchmarkHelper) getK8sNodeId(ctx context.Context) (string, error) {
 	nodeName, err := kubernetes.DiscoverKubernetesNode(h.log, &kubernetes.DiscoverKubernetesNodeParams{
 		ConfigHost:  "",
 		Client:      h.client,

--- a/resources/fetching/fetchers/k8s/file_system_fetcher_test.go
+++ b/resources/fetching/fetchers/k8s/file_system_fetcher_test.go
@@ -154,12 +154,12 @@ func (s *FSFetcherTestSuite) TestFileFetcherFetchTwoPatterns() {
 	s.Equal("etcd", secEvalResource.Owner)
 	s.Equal("etcd", secEvalResource.Group)
 
-	SecResMetadata, err := secFSResource.GetMetadata()
+	secResMetadata, err := secFSResource.GetMetadata()
 	s.Require().NoError(err)
-	s.NotNil(SecResMetadata.ID)
-	s.Equal(paths[1], SecResMetadata.Name)
-	s.Equal(FileSubType, SecResMetadata.SubType)
-	s.Equal(FSResourceType, SecResMetadata.Type)
+	s.NotNil(secResMetadata.ID)
+	s.Equal(paths[1], secResMetadata.Name)
+	s.Equal(FileSubType, secResMetadata.SubType)
+	s.Equal(FSResourceType, secResMetadata.Type)
 }
 
 func (s *FSFetcherTestSuite) TestFileFetcherFetchDirectoryOnly() {


### PR DESCRIPTION
### Summary of your changes
These are also flagged by Goland so it's nice to have

unexported-naming

Description: this rule warns on wrongly named un-exported symbols, i.e. un-exported symbols whose name start with a capital letter.

Configuration: N/A

unexported-return

Description: This rule warns when an exported function or method returns a value of an un-exported type.

Configuration: N/A

### Related Issues
Related: #1669