### PR TITLE
revive: Enable unhandled-error

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -117,7 +117,8 @@ linters-settings:
       - name: unexported-return
         disabled: true
       - name: unhandled-error
-        disabled: true
+        arguments:
+          - "bytes.Buffer.WriteString"
       - name: unused-receiver
         disabled: true
       - name: use-any


### PR DESCRIPTION
### Summary of your changes
I've skipped `bytes.Buffer.WriteString` since it always returns a `nil` error.

Description: This rule warns when errors returned by a function are not explicitly handled on the caller side.

Configuration: function names regexp patterns to ignore

### Related Issues
Related: #1669 