### PR TITLE
revive: Enable indent-error-flow rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -102,8 +102,6 @@ linters-settings:
         disabled: true
       - name: import-shadowing
         disabled: true
-      - name: indent-error-flow
-        disabled: true
       - name: line-length-limit
         disabled: true
       - name: max-public-structs

--- a/resources/providers/awslib/iam/access_analyzer_test.go
+++ b/resources/providers/awslib/iam/access_analyzer_test.go
@@ -115,9 +115,8 @@ func TestProvider_GetAccessAnalyzers(t *testing.T) {
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 				return
-			} else {
-				require.NoError(t, err)
 			}
+			require.NoError(t, err)
 
 			allAnalyzersTyped, ok := allAnalyzers.(AccessAnalyzers)
 			require.True(t, ok)

--- a/resources/providers/azurelib/inventory/provider_test.go
+++ b/resources/providers/azurelib/inventory/provider_test.go
@@ -103,11 +103,10 @@ func (s *ProviderTestSuite) SetupTest() {
 				return armresourcegraph.ClientResourcesResponse{
 					QueryResponse: nonTruncatedResponse,
 				}, nil
-			} else {
-				return armresourcegraph.ClientResourcesResponse{
-					QueryResponse: truncatedResponse,
-				}, nil
 			}
+			return armresourcegraph.ClientResourcesResponse{
+				QueryResponse: truncatedResponse,
+			}, nil
 		},
 	}
 }


### PR DESCRIPTION
### Summary of your changes
Description: To improve the readability of code, it is recommended to reduce the indentation as much as possible. This rule highlights redundant else-blocks that can be eliminated from the code.

More information:
https://go.dev/wiki/CodeReviewComments#indent-error-flow

### Related Issues
Related: #1669