### PR TITLE
revive: Enable early-return

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -96,8 +96,6 @@ linters-settings:
         disabled: true
       - name: cyclomatic
         disabled: true
-      - name: early-return
-        disabled: true
       - name: exported
         disabled: true
       - name: function-length

--- a/resources/providers/azurelib/inventory/provider.go
+++ b/resources/providers/azurelib/inventory/provider.go
@@ -133,13 +133,11 @@ func (p *provider) runPaginatedQuery(ctx context.Context, query armresourcegraph
 			resourceAssets = append(resourceAssets, structuredAsset)
 		}
 
-		if *response.ResultTruncated == *to.Ptr(armresourcegraph.ResultTruncatedTrue) &&
-			response.SkipToken != nil &&
-			*response.SkipToken != "" {
-			query.Options.SkipToken = response.SkipToken
-		} else {
+		if *response.ResultTruncated == armresourcegraph.ResultTruncatedFalse ||
+			strings.Dereference(response.SkipToken) == "" {
 			break
 		}
+		query.Options.SkipToken = response.SkipToken
 	}
 
 	return resourceAssets, nil

--- a/resources/providers/gcplib/auth/credentials.go
+++ b/resources/providers/gcplib/auth/credentials.go
@@ -85,20 +85,18 @@ func (p *ConfigProvider) getCustomCredentials(ctx context.Context, cfg config.Gc
 
 	var opts []option.ClientOption
 	if cfg.CredentialsFilePath != "" {
-		if err := validateJSONFromFile(cfg.CredentialsFilePath); err == nil {
-			log.Infof("Appending credentials file path to gcp client options: %s", cfg.CredentialsFilePath)
-			opts = append(opts, option.WithCredentialsFile(cfg.CredentialsFilePath))
-		} else {
+		if err := validateJSONFromFile(cfg.CredentialsFilePath); err != nil {
 			return nil, err
 		}
+		log.Infof("Appending credentials file path to gcp client options: %s", cfg.CredentialsFilePath)
+		opts = append(opts, option.WithCredentialsFile(cfg.CredentialsFilePath))
 	}
 	if cfg.CredentialsJSON != "" {
-		if json.Valid([]byte(cfg.CredentialsJSON)) {
-			log.Info("Appending credentials JSON to client options")
-			opts = append(opts, option.WithCredentialsJSON([]byte(cfg.CredentialsJSON)))
-		} else {
+		if !json.Valid([]byte(cfg.CredentialsJSON)) {
 			return nil, ErrInvalidCredentialsJSON
 		}
+		log.Info("Appending credentials JSON to client options")
+		opts = append(opts, option.WithCredentialsJSON([]byte(cfg.CredentialsJSON)))
 	}
 
 	return p.getGcpFactoryConfig(ctx, cfg, opts)


### PR DESCRIPTION
### Summary of your changes

Description: In Go it is idiomatic to minimize nesting statements, a typical example is to avoid if-then-else constructions. This rule spots constructions like
```go
if cond {
  // do something
} else {
  // do other thing
  return ...
}
```
where the `if` condition may be inverted in order to reduce nesting:
```go
if !cond {
  // do other thing
  return ...
}

// do something
```

### Related Issues
Related: #1669