### PR TITLE
revive: Enable confusing-results and function-result-limit

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -92,15 +92,11 @@ linters-settings:
         arguments: [30]
       - name: confusing-naming
         disabled: true
-      - name: confusing-results
-        disabled: true
       - name: cyclomatic
         arguments: [15]
       - name: exported
         disabled: true
       - name: function-length
-        disabled: true
-      - name: function-result-limit
         disabled: true
       - name: get-return
         disabled: true

--- a/flavors/benchmark/aws.go
+++ b/flavors/benchmark/aws.go
@@ -53,6 +53,7 @@ func (a *AWS) NewBenchmark(ctx context.Context, log *logp.Logger, cfg *config.Co
 	).Build(ctx, log, cfg, resourceCh, reg)
 }
 
+//revive:disable-next-line:function-result-limit
 func (a *AWS) initialize(ctx context.Context, log *logp.Logger, cfg *config.Config, ch chan fetching.ResourceInfo) (registry.Registry, dataprovider.CommonDataProvider, dataprovider.IdProvider, error) {
 	if err := a.checkDependencies(); err != nil {
 		return nil, nil, nil, err

--- a/flavors/benchmark/aws_org.go
+++ b/flavors/benchmark/aws_org.go
@@ -55,6 +55,7 @@ func (a *AWSOrg) NewBenchmark(ctx context.Context, log *logp.Logger, cfg *config
 	).Build(ctx, log, cfg, resourceCh, reg)
 }
 
+//revive:disable-next-line:function-result-limit
 func (a *AWSOrg) initialize(ctx context.Context, log *logp.Logger, cfg *config.Config, ch chan fetching.ResourceInfo) (registry.Registry, dataprovider.CommonDataProvider, dataprovider.IdProvider, error) {
 	if err := a.checkDependencies(); err != nil {
 		return nil, nil, nil, err

--- a/flavors/benchmark/azure.go
+++ b/flavors/benchmark/azure.go
@@ -52,6 +52,7 @@ func (a *Azure) NewBenchmark(ctx context.Context, log *logp.Logger, cfg *config.
 	).Build(ctx, log, cfg, resourceCh, reg)
 }
 
+//revive:disable-next-line:function-result-limit
 func (a *Azure) initialize(_ context.Context, log *logp.Logger, cfg *config.Config, ch chan fetching.ResourceInfo) (registry.Registry, dataprovider.CommonDataProvider, dataprovider.IdProvider, error) {
 	if err := a.checkDependencies(); err != nil {
 		return nil, nil, nil, err

--- a/flavors/benchmark/eks.go
+++ b/flavors/benchmark/eks.go
@@ -61,6 +61,7 @@ func (k *EKS) NewBenchmark(ctx context.Context, log *logp.Logger, cfg *config.Co
 	).BuildK8s(ctx, log, cfg, resourceCh, reg, k.leaderElector)
 }
 
+//revive:disable-next-line:function-result-limit
 func (k *EKS) initialize(ctx context.Context, log *logp.Logger, cfg *config.Config, ch chan fetching.ResourceInfo) (registry.Registry, dataprovider.CommonDataProvider, dataprovider.IdProvider, error) {
 	if err := k.checkDependencies(); err != nil {
 		return nil, nil, nil, err

--- a/flavors/benchmark/gcp.go
+++ b/flavors/benchmark/gcp.go
@@ -52,6 +52,7 @@ func (g *GCP) NewBenchmark(ctx context.Context, log *logp.Logger, cfg *config.Co
 	).Build(ctx, log, cfg, resourceCh, reg)
 }
 
+//revive:disable-next-line:function-result-limit
 func (g *GCP) initialize(ctx context.Context, log *logp.Logger, cfg *config.Config, ch chan fetching.ResourceInfo) (registry.Registry, dataprovider.CommonDataProvider, dataprovider.IdProvider, error) {
 	if err := g.checkDependencies(); err != nil {
 		return nil, nil, nil, err

--- a/flavors/benchmark/k8s.go
+++ b/flavors/benchmark/k8s.go
@@ -54,6 +54,7 @@ func (k *K8S) NewBenchmark(ctx context.Context, log *logp.Logger, cfg *config.Co
 	).BuildK8s(ctx, log, cfg, resourceCh, reg, k.leaderElector)
 }
 
+//revive:disable-next-line:function-result-limit
 func (k *K8S) initialize(ctx context.Context, log *logp.Logger, cfg *config.Config, ch chan fetching.ResourceInfo) (registry.Registry, dataprovider.CommonDataProvider, dataprovider.IdProvider, error) {
 	if err := k.checkDependencies(); err != nil {
 		return nil, nil, nil, err

--- a/vulnerability/fetcher_test.go
+++ b/vulnerability/fetcher_test.go
@@ -68,6 +68,7 @@ func generateTestInstances() (*ec2.Ec2Instance, *ec2.Ec2Instance, *ec2.Ec2Instan
 		generateInstance(instanceId3, instanceId3RootDevice)
 }
 
+//revive:disable-next-line:function-result-limit
 func generateTestVolumes() (*ec2.Volume, *ec2.Volume, *ec2.Volume, *ec2.Volume, *ec2.Volume, *ec2.Volume) {
 	return gernerateVolume(instanceId1, "some-vol-id-1", "some-device-1", 1),
 		gernerateVolume(instanceId1, instanceId1RootVolumeId, instanceId1RootDevice, 10),


### PR DESCRIPTION
### Summary of your changes
confusing-results

Description: Function or methods that return multiple, no named, values of the same type could induce error.

function-result-limit

Description: Functions returning too many results can be hard to understand/use.

Configuration: (int) the maximum allowed return values

### Related Issues
Related: #1669 