### PR TITLE
Use Cloud Trail ARN when get trail status and event selectors

### DIFF
--- a/resources/providers/awslib/cloudtrail/provider.go
+++ b/resources/providers/awslib/cloudtrail/provider.go
@@ -75,7 +75,7 @@ func (p Provider) getTrailStatus(ctx context.Context, trail types.Trail) (*cloud
 		return nil, err
 	}
 
-	return client.GetTrailStatus(ctx, &cloudtrail.GetTrailStatusInput{Name: trail.Name})
+	return client.GetTrailStatus(ctx, &cloudtrail.GetTrailStatusInput{Name: trail.TrailARN})
 }
 
 func (p Provider) getEventSelectors(ctx context.Context, trail types.Trail) ([]types.EventSelector, error) {
@@ -84,7 +84,7 @@ func (p Provider) getEventSelectors(ctx context.Context, trail types.Trail) ([]t
 		return nil, err
 	}
 
-	output, err := client.GetEventSelectors(ctx, &cloudtrail.GetEventSelectorsInput{TrailName: trail.Name})
+	output, err := client.GetEventSelectors(ctx, &cloudtrail.GetEventSelectorsInput{TrailName: trail.TrailARN})
 	if err != nil {
 		return []types.EventSelector{}, err
 	}


### PR DESCRIPTION
### Summary of your changes

Use Cloud Trail ARN when get trail status and event selectors instead of Cloud Trail name

### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/1750