### PR TITLE
Adding workflow dispatch to Azure CI due to Azure CI retrigger bugs

### DIFF
--- a/.github/workflows/azure-ci.yml
+++ b/.github/workflows/azure-ci.yml
@@ -1,6 +1,8 @@
 name: CIS-AZURE-CI
 
 on:
+  worflow_dispatch:
+    inputs:
   pull_request_target:
     branches:
       - main

--- a/.github/workflows/azure-ci.yml
+++ b/.github/workflows/azure-ci.yml
@@ -1,7 +1,7 @@
 name: CIS-AZURE-CI
 
 on:
-  worflow_dispatch:
+  workflow_dispatch:
     inputs:
   pull_request_target:
     branches:


### PR DESCRIPTION
### Summary of your changes
In order to test and run Azure CI, I would need to trigger it manually because it doesn't run the CI via pull requests and pulls the new workflow file

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
