### PR TITLE
Add permissions for rerun action

### DIFF
--- a/.github/workflows/rerun-flaky-workflows.yml
+++ b/.github/workflows/rerun-flaky-workflows.yml
@@ -9,6 +9,10 @@ jobs:
   rerun-on-failure:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure'}}
+    permissions:
+      # permission required to rerun a workflow https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-actions
+      # gh run rerun --failed requires write permission
+      actions: write
     steps:
       - name: Display Workflow Run Information
         run: |


### PR DESCRIPTION
### Summary of your changes

This PR adds permissions to the "Rerun Flaky Workflows" workflow to allow the rerun action

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
