### PR TITLE
CIS Azure 4.1.5

### DIFF
--- a/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
@@ -30,18 +30,40 @@ import (
 	"github.com/elastic/cloudbeat/resources/providers/azurelib/inventory"
 )
 
-func TestSQLServerEnricher_Enrich(t *testing.T) {
-	type enricherResponse struct {
-		assets []inventory.AzureAsset
-		err    error
-	}
+type enricherResponse struct {
+	assets []inventory.AzureAsset
+	err    error
+}
 
+func noRes() enricherResponse {
+	return enricherResponse{
+		assets: nil,
+		err:    nil,
+	}
+}
+
+func assetRes(a ...inventory.AzureAsset) enricherResponse {
+	return enricherResponse{
+		assets: a,
+		err:    nil,
+	}
+}
+
+func errorRes(err error) enricherResponse {
+	return enricherResponse{
+		assets: nil,
+		err:    err,
+	}
+}
+
+func TestSQLServerEnricher_Enrich(t *testing.T) {
 	tcs := map[string]struct {
-		input                       []inventory.AzureAsset
-		expected                    []inventory.AzureAsset
-		expectError                 bool
-		encryptionProtectorResponse map[string]enricherResponse
-		blobAuditPolicyResponse     map[string]enricherResponse
+		input       []inventory.AzureAsset
+		expected    []inventory.AzureAsset
+		expectError bool
+		epRes       map[string]enricherResponse
+		bapRes      map[string]enricherResponse
+		tdeRes      map[string]enricherResponse
 	}{
 		"Some assets have encryption protection, others don't": {
 			input: []inventory.AzureAsset{
@@ -51,97 +73,49 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			},
 			expected: []inventory.AzureAsset{
 				mockSQLServerWithEncryptionProtectorExtension("id1", "serverName1", map[string]any{
-					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{
-						{
-							"kind":                "azurekeyvault",
-							"serverKeyType":       "AzureKeyVault",
-							"autoRotationEnabled": true,
-							"serverKeyName":       "serverKey1",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						},
-					},
+					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{epProps("serverKey1", true)},
 				}),
 				mockOther("id4"),
 				mockSQLServer("id2", "serverName2"),
 			},
-			encryptionProtectorResponse: map[string]enricherResponse{
-				"serverName1": { //nolint:exhaustruct
-					assets: []inventory.AzureAsset{
-						mockEncryptionProtector("ep1", map[string]any{
-							"kind":                "azurekeyvault",
-							"serverKeyType":       "AzureKeyVault",
-							"autoRotationEnabled": true,
-							"serverKeyName":       "serverKey1",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						}),
-					},
-				},
-				"serverName2": {}, //nolint:exhaustruct
+			epRes: map[string]enricherResponse{
+				"serverName1": assetRes(mockEncryptionProtector("ep1", epProps("serverKey1", true))),
+				"serverName2": noRes(),
 			},
-			blobAuditPolicyResponse: map[string]enricherResponse{
-				"serverName1": {}, //nolint:exhaustruct
-				"serverName2": {}, //nolint:exhaustruct
+			bapRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": noRes(),
+			},
+			tdeRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": noRes(),
 			},
 		},
-		"Multiple policy protectors": {
+		"Multiple encryption protectors": {
 			input: []inventory.AzureAsset{
 				mockSQLServer("id1", "serverName1"),
 			},
 			expected: []inventory.AzureAsset{
 				mockSQLServerWithEncryptionProtectorExtension("id1", "serverName1", map[string]any{
 					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{
-						{
-							"kind":                "azurekeyvault",
-							"serverKeyType":       "AzureKeyVault",
-							"autoRotationEnabled": true,
-							"serverKeyName":       "serverKey1",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						},
-						{
-							"serverKeyType":       "ServiceManaged",
-							"autoRotationEnabled": false,
-							"serverKeyName":       "serverKey2",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						},
+						epProps("serverKey1", true),
+						epProps("serverKey2", false),
 					},
 				}),
 			},
-			encryptionProtectorResponse: map[string]enricherResponse{
-				"serverName1": { //nolint:exhaustruct
-					assets: []inventory.AzureAsset{
-						mockEncryptionProtector("ep1", map[string]any{
-							"kind":                "azurekeyvault",
-							"serverKeyType":       "AzureKeyVault",
-							"autoRotationEnabled": true,
-							"serverKeyName":       "serverKey1",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						}),
-						mockEncryptionProtector("ep2", map[string]any{
-							"serverKeyType":       "ServiceManaged",
-							"autoRotationEnabled": false,
-							"serverKeyName":       "serverKey2",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						}),
-					},
-				},
+			epRes: map[string]enricherResponse{
+				"serverName1": assetRes(
+					mockEncryptionProtector("ep1", epProps("serverKey1", true)),
+					mockEncryptionProtector("ep2", epProps("serverKey2", false))),
 			},
-			blobAuditPolicyResponse: map[string]enricherResponse{
-				"serverName1": {}, //nolint:exhaustruct
+			bapRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+			},
+			tdeRes: map[string]enricherResponse{
+				"serverName1": noRes(),
 			},
 		},
-		"Error in one policy protector": {
+		"Error in one encryption protector": {
 			expectError: true,
 			input: []inventory.AzureAsset{
 				mockSQLServer("id1", "serverName1"),
@@ -151,39 +125,21 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 				mockSQLServer("id1", "serverName1"),
 				mockSQLServerWithEncryptionProtectorExtension("id2", "serverName2", map[string]any{
 					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{
-						{
-							"kind":                "azurekeyvault",
-							"serverKeyType":       "AzureKeyVault",
-							"autoRotationEnabled": true,
-							"serverKeyName":       "serverKey1",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						},
+						epProps("serverKey1", true),
 					},
 				}),
 			},
-			encryptionProtectorResponse: map[string]enricherResponse{
-				"serverName1": { //nolint:exhaustruct
-					err: errors.New("error"),
-				},
-				"serverName2": { //nolint:exhaustruct
-					assets: []inventory.AzureAsset{
-						mockEncryptionProtector("ep1", map[string]any{
-							"kind":                "azurekeyvault",
-							"serverKeyType":       "AzureKeyVault",
-							"autoRotationEnabled": true,
-							"serverKeyName":       "serverKey1",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						}),
-					},
-				},
+			epRes: map[string]enricherResponse{
+				"serverName1": errorRes(errors.New("error")),
+				"serverName2": assetRes(mockEncryptionProtector("ep1", epProps("serverKey1", true))),
 			},
-			blobAuditPolicyResponse: map[string]enricherResponse{
-				"serverName1": {}, //nolint:exhaustruct
-				"serverName2": {}, //nolint:exhaustruct
+			bapRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": noRes(),
+			},
+			tdeRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": noRes(),
 			},
 		},
 		"Error in one blob audit policy": {
@@ -196,104 +152,98 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 				mockSQLServer("id1", "serverName1"),
 				mockSQLServerWithEncryptionProtectorExtension("id2", "serverName2", map[string]any{
 					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{
-						{
-							"kind":                "azurekeyvault",
-							"serverKeyType":       "AzureKeyVault",
-							"autoRotationEnabled": true,
-							"serverKeyName":       "serverKey1",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						},
+						epProps("serverKey1", true),
 					},
 				}),
 			},
-			encryptionProtectorResponse: map[string]enricherResponse{
-				"serverName1": {}, //nolint:exhaustruct
-				"serverName2": { //nolint:exhaustruct
-					assets: []inventory.AzureAsset{
-						mockEncryptionProtector("ep1", map[string]any{
-							"kind":                "azurekeyvault",
-							"serverKeyType":       "AzureKeyVault",
-							"autoRotationEnabled": true,
-							"serverKeyName":       "serverKey1",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						}),
-					},
-				},
+			epRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": assetRes(mockEncryptionProtector("ep1", epProps("serverKey1", true))),
 			},
-			blobAuditPolicyResponse: map[string]enricherResponse{
-				"serverName1": {},                         //nolint:exhaustruct
-				"serverName2": {err: errors.New("error")}, //nolint:exhaustruct
+			bapRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": errorRes(errors.New("error")),
+			},
+			tdeRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": noRes(),
 			},
 		},
-		"Policy protector and blob audit policies": {
+		"Multiple transparent data encryption": {
+			input: []inventory.AzureAsset{
+				mockSQLServer("id1", "serverName1"),
+				mockSQLServer("id2", "serverName2"),
+			},
+			expected: []inventory.AzureAsset{
+				mockSQLServerWithEncryptionProtectorExtension("id1", "serverName1", map[string]any{
+					inventory.ExtensionSQLTransparentDataEncryptions: []map[string]any{
+						tdeProps("Enabled"),
+						tdeProps("Disabled"),
+					},
+				}),
+				mockSQLServer("id2", "serverName2"),
+			},
+			epRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": noRes(),
+			},
+			bapRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": noRes(),
+			},
+			tdeRes: map[string]enricherResponse{
+				"serverName1": assetRes(
+					mockTransparentDataEncryption("tde1", tdeProps("Enabled")),
+					mockTransparentDataEncryption("tde2", tdeProps("Disabled")),
+				),
+				"serverName2": noRes(),
+			},
+		},
+		"Error in one transparent data encryption": {
+			expectError: true,
+			input: []inventory.AzureAsset{
+				mockSQLServer("id1", "serverName1"),
+				mockSQLServer("id2", "serverName2"),
+			},
+			expected: []inventory.AzureAsset{
+				mockSQLServer("id1", "serverName1"),
+				mockSQLServerWithEncryptionProtectorExtension("id2", "serverName2", map[string]any{
+					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{epProps("serverKey1", true)},
+					inventory.ExtensionSQLBlobAuditPolicy:      bapProps("Enabled"),
+				}),
+			},
+			epRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": assetRes(mockEncryptionProtector("ep1", epProps("serverKey1", true))),
+			},
+			bapRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": assetRes(mockBlobAuditingPolicies("ep1", bapProps("Enabled"))),
+			},
+			tdeRes: map[string]enricherResponse{
+				"serverName1": noRes(),
+				"serverName2": errorRes(errors.New("error")),
+			},
+		},
+		"Encryption Protector,  blob audit policies and transparent data encryption": {
 			input: []inventory.AzureAsset{
 				mockSQLServer("id1", "serverName1"),
 			},
 			expected: []inventory.AzureAsset{
 				mockSQLServerWithEncryptionProtectorExtension("id1", "serverName1", map[string]any{
-					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{
-						{
-							"kind":                "azurekeyvault",
-							"serverKeyType":       "AzureKeyVault",
-							"autoRotationEnabled": true,
-							"serverKeyName":       "serverKey1",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						},
-					},
-					inventory.ExtensionSQLBlobAuditPolicy: map[string]any{
-						"state":                        "Enabled",
-						"isAzureMonitorTargetEnabled":  true,
-						"isDevopsAuditEnabled":         false,
-						"isManagedIdentityInUse":       true,
-						"isStorageSecondaryKeyInUse":   true,
-						"queueDelayMs":                 int32(100),
-						"retentionDays":                int32(90),
-						"storageAccountAccessKey":      "access-key",
-						"storageAccountSubscriptionID": "sub-id",
-						"storageEndpoint":              "",
-						"auditActionsAndGroups":        []string{"a", "b"},
-					},
+					inventory.ExtensionSQLEncryptionProtectors:       []map[string]any{epProps("serverKey1", true)},
+					inventory.ExtensionSQLBlobAuditPolicy:            bapProps("Disabled"),
+					inventory.ExtensionSQLTransparentDataEncryptions: []map[string]any{tdeProps("Enabled")},
 				}),
 			},
-			encryptionProtectorResponse: map[string]enricherResponse{
-				"serverName1": { //nolint:exhaustruct
-					assets: []inventory.AzureAsset{
-						mockEncryptionProtector("ep1", map[string]any{
-							"kind":                "azurekeyvault",
-							"serverKeyType":       "AzureKeyVault",
-							"autoRotationEnabled": true,
-							"serverKeyName":       "serverKey1",
-							"subregion":           "",
-							"thumbprint":          "",
-							"uri":                 "",
-						}),
-					},
-				},
+			epRes: map[string]enricherResponse{
+				"serverName1": assetRes(mockEncryptionProtector("ep1", epProps("serverKey1", true))),
 			},
-			blobAuditPolicyResponse: map[string]enricherResponse{
-				"serverName1": { //nolint:exhaustruct
-					assets: []inventory.AzureAsset{
-						mockBlobAuditingPolicies("ep1", map[string]any{
-							"state":                        "Enabled",
-							"isAzureMonitorTargetEnabled":  true,
-							"isDevopsAuditEnabled":         false,
-							"isManagedIdentityInUse":       true,
-							"isStorageSecondaryKeyInUse":   true,
-							"queueDelayMs":                 int32(100),
-							"retentionDays":                int32(90),
-							"storageAccountAccessKey":      "access-key",
-							"storageAccountSubscriptionID": "sub-id",
-							"storageEndpoint":              "",
-							"auditActionsAndGroups":        []string{"a", "b"},
-						}),
-					},
-				},
+			bapRes: map[string]enricherResponse{
+				"serverName1": assetRes(mockBlobAuditingPolicies("ep1", bapProps("Disabled"))),
+			},
+			tdeRes: map[string]enricherResponse{
+				"serverName1": assetRes(mockTransparentDataEncryption("tde1", tdeProps("Enabled"))),
 			},
 		},
 	}
@@ -303,12 +253,16 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			cmd := cycle.Metadata{}
 
 			provider := azurelib.NewMockProviderAPI(t)
-			for serverName, r := range tc.encryptionProtectorResponse {
+			for serverName, r := range tc.epRes {
 				provider.EXPECT().ListSQLEncryptionProtector(mock.Anything, "subId", "group", serverName).Return(r.assets, r.err)
 			}
 
-			for serverName, r := range tc.blobAuditPolicyResponse {
+			for serverName, r := range tc.bapRes {
 				provider.EXPECT().GetSQLBlobAuditingPolicies(mock.Anything, "subId", "group", serverName).Return(r.assets, r.err)
+			}
+
+			for serverName, r := range tc.tdeRes {
+				provider.EXPECT().ListSQLTransparentDataEncryptions(mock.Anything, "subId", "group", serverName).Return(r.assets, r.err)
 			}
 
 			e := sqlServerEnricher{provider: provider}
@@ -357,9 +311,51 @@ func mockBlobAuditingPolicies(id string, props map[string]any) inventory.AzureAs
 	}
 }
 
+func mockTransparentDataEncryption(id string, props map[string]any) inventory.AzureAsset {
+	return inventory.AzureAsset{
+		Id:         id,
+		Type:       inventory.SQLServersAssetType + "/transparentDataEncryption",
+		Properties: props,
+	}
+}
+
 func mockOther(id string) inventory.AzureAsset {
 	return inventory.AzureAsset{
 		Id:   id,
 		Type: "otherType",
+	}
+}
+
+func epProps(keyName string, rotationEnabled bool) map[string]any {
+	return map[string]any{
+		"kind":                "azurekeyvault",
+		"serverKeyType":       "AzureKeyVault",
+		"autoRotationEnabled": rotationEnabled,
+		"serverKeyName":       keyName,
+		"subregion":           "",
+		"thumbprint":          "",
+		"uri":                 "",
+	}
+}
+
+func bapProps(state string) map[string]any {
+	return map[string]any{
+		"state":                        state,
+		"isAzureMonitorTargetEnabled":  true,
+		"isDevopsAuditEnabled":         false,
+		"isManagedIdentityInUse":       true,
+		"isStorageSecondaryKeyInUse":   true,
+		"queueDelayMs":                 int32(100),
+		"retentionDays":                int32(90),
+		"storageAccountAccessKey":      "access-key",
+		"storageAccountSubscriptionID": "sub-id",
+		"storageEndpoint":              "",
+		"auditActionsAndGroups":        []string{"a", "b"},
+	}
+}
+
+func tdeProps(state string) map[string]any {
+	return map[string]any{
+		"state": state,
 	}
 }

--- a/resources/fetching/fetchers/azure/assets_fetcher_test.go
+++ b/resources/fetching/fetchers/azure/assets_fetcher_test.go
@@ -130,6 +130,9 @@ func (s *AzureAssetsFetcherTestSuite) TestFetcher_Fetch() {
 	mockProvider.EXPECT().
 		GetSQLBlobAuditingPolicies(mock.Anything, "subId", "rg", "name").
 		Return(nil, nil)
+	mockProvider.EXPECT().
+		ListSQLTransparentDataEncryptions(mock.Anything, "subId", "rg", "name").
+		Return(nil, nil)
 
 	results, err := s.fetch(mockProvider, totalMockAssets)
 	s.Require().NoError(err)

--- a/resources/providers/azurelib/inventory/asset.go
+++ b/resources/providers/azurelib/inventory/asset.go
@@ -50,16 +50,17 @@ const (
 	AssetGroupAuthorizationResources = "authorizationresources"
 
 	// Extension keys
-	ExtensionBlobService             = "blobService"
-	ExtensionNetwork                 = "network"
-	ExtensionUsedForActivityLogs     = "usedForActivityLogs"
-	ExtensionSQLEncryptionProtectors = "sqlEncryptionProtectors"
-	ExtensionSQLBlobAuditPolicy      = "sqlBlobAuditPolicy"
-	ExtensionStorageAccountID        = "storageAccountId"
-	ExtensionStorageAccountName      = "storageAccountName"
-	ExtensionBlobDiagnosticSettings  = "blobDiagnosticSettings"
-	ExtensionTableDiagnosticSettings = "tableDiagnosticSettings"
-	ExtensionQueueDiagnosticSettings = "queueDiagnosticSettings"
+	ExtensionBlobService                   = "blobService"
+	ExtensionNetwork                       = "network"
+	ExtensionUsedForActivityLogs           = "usedForActivityLogs"
+	ExtensionSQLEncryptionProtectors       = "sqlEncryptionProtectors"
+	ExtensionSQLBlobAuditPolicy            = "sqlBlobAuditPolicy"
+	ExtensionSQLTransparentDataEncryptions = "sqlTransparentDataEncryptions"
+	ExtensionStorageAccountID              = "storageAccountId"
+	ExtensionStorageAccountName            = "storageAccountName"
+	ExtensionBlobDiagnosticSettings        = "blobDiagnosticSettings"
+	ExtensionTableDiagnosticSettings       = "tableDiagnosticSettings"
+	ExtensionQueueDiagnosticSettings       = "queueDiagnosticSettings"
 )
 
 type AzureAsset struct {

--- a/resources/providers/azurelib/inventory/mock_provider_api.go
+++ b/resources/providers/azurelib/inventory/mock_provider_api.go
@@ -265,6 +265,63 @@ func (_c *MockProviderAPI_ListSQLEncryptionProtector_Call) RunAndReturn(run func
 	return _c
 }
 
+// ListSQLTransparentDataEncryptions provides a mock function with given fields: ctx, subID, resourceGroup, sqlServerName
+func (_m *MockProviderAPI) ListSQLTransparentDataEncryptions(ctx context.Context, subID string, resourceGroup string, sqlServerName string) ([]AzureAsset, error) {
+	ret := _m.Called(ctx, subID, resourceGroup, sqlServerName)
+
+	var r0 []AzureAsset
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]AzureAsset, error)); ok {
+		return rf(ctx, subID, resourceGroup, sqlServerName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []AzureAsset); ok {
+		r0 = rf(ctx, subID, resourceGroup, sqlServerName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]AzureAsset)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, subID, resourceGroup, sqlServerName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockProviderAPI_ListSQLTransparentDataEncryptions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSQLTransparentDataEncryptions'
+type MockProviderAPI_ListSQLTransparentDataEncryptions_Call struct {
+	*mock.Call
+}
+
+// ListSQLTransparentDataEncryptions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - subID string
+//   - resourceGroup string
+//   - sqlServerName string
+func (_e *MockProviderAPI_Expecter) ListSQLTransparentDataEncryptions(ctx interface{}, subID interface{}, resourceGroup interface{}, sqlServerName interface{}) *MockProviderAPI_ListSQLTransparentDataEncryptions_Call {
+	return &MockProviderAPI_ListSQLTransparentDataEncryptions_Call{Call: _e.mock.On("ListSQLTransparentDataEncryptions", ctx, subID, resourceGroup, sqlServerName)}
+}
+
+func (_c *MockProviderAPI_ListSQLTransparentDataEncryptions_Call) Run(run func(ctx context.Context, subID string, resourceGroup string, sqlServerName string)) *MockProviderAPI_ListSQLTransparentDataEncryptions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *MockProviderAPI_ListSQLTransparentDataEncryptions_Call) Return(_a0 []AzureAsset, _a1 error) *MockProviderAPI_ListSQLTransparentDataEncryptions_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockProviderAPI_ListSQLTransparentDataEncryptions_Call) RunAndReturn(run func(context.Context, string, string, string) ([]AzureAsset, error)) *MockProviderAPI_ListSQLTransparentDataEncryptions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListStorageAccountBlobServices provides a mock function with given fields: ctx, storageAccounts
 func (_m *MockProviderAPI) ListStorageAccountBlobServices(ctx context.Context, storageAccounts []AzureAsset) ([]AzureAsset, error) {
 	ret := _m.Called(ctx, storageAccounts)

--- a/resources/providers/azurelib/inventory/provider.go
+++ b/resources/providers/azurelib/inventory/provider.go
@@ -38,11 +38,13 @@ import (
 )
 
 type azureClientWrapper struct {
-	AssetQuery                   func(ctx context.Context, query armresourcegraph.QueryRequest, options *armresourcegraph.ClientResourcesOptions) (armresourcegraph.ClientResourcesResponse, error)
-	AssetDiagnosticSettings      func(ctx context.Context, subID string, options *armmonitor.DiagnosticSettingsClientListOptions) ([]armmonitor.DiagnosticSettingsClientListResponse, error)
-	AssetBlobServices            func(ctx context.Context, subID string, clientOptions *arm.ClientOptions, resourceGroup, storageAccountName string, options *armstorage.BlobServicesClientListOptions) ([]armstorage.BlobServicesClientListResponse, error)
-	AssetSQLEncryptionProtector  func(ctx context.Context, subID, resourceGroup, sqlServerName string, clientOptions *arm.ClientOptions, options *armsql.EncryptionProtectorsClientListByServerOptions) ([]armsql.EncryptionProtectorsClientListByServerResponse, error)
-	AssetSQLBlobAuditingPolicies func(ctx context.Context, subID, resourceGroup, sqlServerName string, clientOptions *arm.ClientOptions, options *armsql.ServerBlobAuditingPoliciesClientGetOptions) (armsql.ServerBlobAuditingPoliciesClientGetResponse, error)
+	AssetQuery                         func(ctx context.Context, query armresourcegraph.QueryRequest, options *armresourcegraph.ClientResourcesOptions) (armresourcegraph.ClientResourcesResponse, error)
+	AssetDiagnosticSettings            func(ctx context.Context, subID string, options *armmonitor.DiagnosticSettingsClientListOptions) ([]armmonitor.DiagnosticSettingsClientListResponse, error)
+	AssetBlobServices                  func(ctx context.Context, subID string, clientOptions *arm.ClientOptions, resourceGroup, storageAccountName string, options *armstorage.BlobServicesClientListOptions) ([]armstorage.BlobServicesClientListResponse, error)
+	AssetSQLEncryptionProtector        func(ctx context.Context, subID, resourceGroup, sqlServerName string, clientOptions *arm.ClientOptions, options *armsql.EncryptionProtectorsClientListByServerOptions) ([]armsql.EncryptionProtectorsClientListByServerResponse, error)
+	AssetSQLBlobAuditingPolicies       func(ctx context.Context, subID, resourceGroup, sqlServerName string, clientOptions *arm.ClientOptions, options *armsql.ServerBlobAuditingPoliciesClientGetOptions) (armsql.ServerBlobAuditingPoliciesClientGetResponse, error)
+	AssetSQLTransparentDataEncryptions func(ctx context.Context, subID, resourceGroup, sqlServerName, dbName string, clientOptions *arm.ClientOptions, options *armsql.TransparentDataEncryptionsClientListByDatabaseOptions) ([]armsql.TransparentDataEncryptionsClientListByDatabaseResponse, error)
+	AssetSQLDatabases                  func(ctx context.Context, subID, resourceGroup, sqlServerName string, clientOptions *arm.ClientOptions, options *armsql.DatabasesClientListByServerOptions) ([]armsql.DatabasesClientListByServerResponse, error)
 }
 
 type ProviderAPI interface {
@@ -51,6 +53,7 @@ type ProviderAPI interface {
 	ListDiagnosticSettingsAssetTypes(ctx context.Context, cycleMetadata cycle.Metadata, subscriptionIDs []string) ([]AzureAsset, error)
 	ListStorageAccountBlobServices(ctx context.Context, storageAccounts []AzureAsset) ([]AzureAsset, error)
 	ListSQLEncryptionProtector(ctx context.Context, subID, resourceGroup, sqlServerName string) ([]AzureAsset, error)
+	ListSQLTransparentDataEncryptions(ctx context.Context, subID, resourceGroup, sqlServerName string) ([]AzureAsset, error)
 	GetSQLBlobAuditingPolicies(ctx context.Context, subID, resourceGroup, sqlServerName string) ([]AzureAsset, error)
 	ListStorageAccountsBlobDiagnosticSettings(ctx context.Context, storageAccounts []AzureAsset) ([]AzureAsset, error)
 	ListStorageAccountsTableDiagnosticSettings(ctx context.Context, storageAccounts []AzureAsset) ([]AzureAsset, error)
@@ -85,7 +88,6 @@ func NewProvider(log *logp.Logger, resourceGraphClient *armresourcegraph.Client,
 			if err != nil {
 				return nil, err
 			}
-
 			return readPager(ctx, cl.NewListByServerPager(resourceGroup, sqlServerName, options))
 		},
 		AssetSQLBlobAuditingPolicies: func(ctx context.Context, subID, resourceGroup, sqlServerName string, clientOptions *arm.ClientOptions, options *armsql.ServerBlobAuditingPoliciesClientGetOptions) (armsql.ServerBlobAuditingPoliciesClientGetResponse, error) {
@@ -93,8 +95,21 @@ func NewProvider(log *logp.Logger, resourceGraphClient *armresourcegraph.Client,
 			if err != nil {
 				return armsql.ServerBlobAuditingPoliciesClientGetResponse{}, err
 			}
-
 			return cl.Get(ctx, resourceGroup, sqlServerName, options)
+		},
+		AssetSQLTransparentDataEncryptions: func(ctx context.Context, subID, resourceGroup, sqlServerName, dbName string, clientOptions *arm.ClientOptions, options *armsql.TransparentDataEncryptionsClientListByDatabaseOptions) ([]armsql.TransparentDataEncryptionsClientListByDatabaseResponse, error) {
+			cl, err := armsql.NewTransparentDataEncryptionsClient(subID, credentials, clientOptions)
+			if err != nil {
+				return nil, err
+			}
+			return readPager(ctx, cl.NewListByDatabasePager(resourceGroup, sqlServerName, dbName, options))
+		},
+		AssetSQLDatabases: func(ctx context.Context, subID, resourceGroup, sqlServerName string, clientOptions *arm.ClientOptions, options *armsql.DatabasesClientListByServerOptions) ([]armsql.DatabasesClientListByServerResponse, error) {
+			cl, err := armsql.NewDatabasesClient(subID, credentials, clientOptions)
+			if err != nil {
+				return nil, err
+			}
+			return readPager(ctx, cl.NewListByServerPager(resourceGroup, sqlServerName, options))
 		},
 	}
 

--- a/resources/providers/azurelib/inventory/sql_server.go
+++ b/resources/providers/azurelib/inventory/sql_server.go
@@ -19,6 +19,7 @@ package inventory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
@@ -90,6 +91,73 @@ func (p *provider) GetSQLBlobAuditingPolicies(ctx context.Context, subID, resour
 			Type:           deref(policy.Type),
 		},
 	}, nil
+}
+
+func (p *provider) ListSQLTransparentDataEncryptions(ctx context.Context, subID, resourceGroup, sqlServerName string) ([]AzureAsset, error) {
+	pagedDbs, err := p.client.AssetSQLDatabases(ctx, subID, resourceGroup, sqlServerName, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("problem on listing sql databases for sql server %s (%w)", sqlServerName, err)
+	}
+
+	dbs := lo.FlatMap(pagedDbs, func(db armsql.DatabasesClientListByServerResponse, _ int) []*armsql.Database {
+		return db.Value
+	})
+
+	var errs error
+	assets := make([]AzureAsset, 0)
+	for _, db := range dbs {
+		if db == nil {
+			continue
+		}
+
+		assetsByDb, err := p.listTransparentDataEncryptionsByDB(ctx, subID, resourceGroup, sqlServerName, deref(db.Name))
+		if err != nil {
+			errs = errors.Join(errs, err)
+		}
+
+		assets = append(assets, assetsByDb...)
+	}
+
+	return assets, errs
+}
+
+func (p *provider) listTransparentDataEncryptionsByDB(ctx context.Context, subID, resourceGroup, sqlServerName, dbName string) ([]AzureAsset, error) {
+	pagedTdes, err := p.client.AssetSQLTransparentDataEncryptions(ctx, subID, resourceGroup, sqlServerName, dbName, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	capacity := lo.Reduce(pagedTdes, func(acc int, i armsql.TransparentDataEncryptionsClientListByDatabaseResponse, _ int) int {
+		return acc + len(i.Value)
+	}, 0)
+
+	assets := make([]AzureAsset, 0, capacity)
+	for _, tdes := range pagedTdes {
+		for _, tde := range tdes.Value {
+			if tde == nil || tde.Properties == nil {
+				continue
+			}
+
+			assets = append(assets, convertTransparentDataEncryption(tde, subID, resourceGroup))
+		}
+	}
+
+	return assets, nil
+}
+
+func convertTransparentDataEncryption(tde *armsql.LogicalDatabaseTransparentDataEncryption, subID, resourceGroup string) AzureAsset {
+	return AzureAsset{
+		Id:       deref(tde.ID),
+		Name:     deref(tde.Name),
+		Location: "global",
+		Properties: map[string]any{
+			"state": string(deref(tde.Properties.State)),
+		},
+		ResourceGroup:  resourceGroup,
+		SubscriptionId: subID,
+		TenantId:       "",
+		Type:           deref(tde.Type),
+	}
 }
 
 func convertEncryptionProtector(ep *armsql.EncryptionProtector, resourceGroup string, subID string) AzureAsset {

--- a/resources/providers/azurelib/inventory/sql_server.go
+++ b/resources/providers/azurelib/inventory/sql_server.go
@@ -138,20 +138,21 @@ func (p *provider) listTransparentDataEncryptionsByDB(ctx context.Context, subID
 				continue
 			}
 
-			assets = append(assets, convertTransparentDataEncryption(tde, subID, resourceGroup))
+			assets = append(assets, convertTransparentDataEncryption(tde, dbName, subID, resourceGroup))
 		}
 	}
 
 	return assets, nil
 }
 
-func convertTransparentDataEncryption(tde *armsql.LogicalDatabaseTransparentDataEncryption, subID, resourceGroup string) AzureAsset {
+func convertTransparentDataEncryption(tde *armsql.LogicalDatabaseTransparentDataEncryption, dbName, subID, resourceGroup string) AzureAsset {
 	return AzureAsset{
 		Id:       deref(tde.ID),
 		Name:     deref(tde.Name),
 		Location: "global",
 		Properties: map[string]any{
-			"state": string(deref(tde.Properties.State)),
+			"databaseName": dbName,
+			"state":        string(deref(tde.Properties.State)),
 		},
 		ResourceGroup:  resourceGroup,
 		SubscriptionId: subID,

--- a/resources/providers/azurelib/inventory/sql_server_test.go
+++ b/resources/providers/azurelib/inventory/sql_server_test.go
@@ -249,8 +249,8 @@ func TestListSqlTransparentDataEncryptions(t *testing.T) {
 			},
 			expectError: true,
 			expectedAssets: []AzureAsset{
-				tdeAsset("db1-tde1", "Enabled"),
-				tdeAsset("db3-tde1", "Enabled"),
+				tdeAsset("db1-tde1", "db1", "Enabled"),
+				tdeAsset("db3-tde1", "db3", "Enabled"),
 			},
 		},
 		"Response of 3 dbs with multiple tdes (in different pages)": {
@@ -273,10 +273,10 @@ func TestListSqlTransparentDataEncryptions(t *testing.T) {
 			},
 			expectError: false,
 			expectedAssets: []AzureAsset{
-				tdeAsset("db1-tde1", "Enabled"),
-				tdeAsset("db1-tde2", "Disabled"),
-				tdeAsset("db2-tde1", "Enabled"),
-				tdeAsset("db3-tde1", "Enabled"),
+				tdeAsset("db1-tde1", "db1", "Enabled"),
+				tdeAsset("db1-tde2", "db1", "Disabled"),
+				tdeAsset("db2-tde1", "db2", "Enabled"),
+				tdeAsset("db3-tde1", "db3", "Enabled"),
 			},
 		},
 	}
@@ -393,7 +393,7 @@ func tdeAzure(id string, state armsql.TransparentDataEncryptionState) *armsql.Lo
 	}
 }
 
-func tdeAsset(id, state string) AzureAsset {
+func tdeAsset(id, dbName, state string) AzureAsset {
 	return AzureAsset{
 		Id:             id,
 		Name:           "name-" + id,
@@ -406,7 +406,8 @@ func tdeAsset(id, state string) AzureAsset {
 		Sku:            nil,
 		Identity:       nil,
 		Properties: map[string]any{
-			"state": state,
+			"databaseName": dbName,
+			"state":        state,
 		},
 		Extension: nil,
 	}

--- a/resources/providers/azurelib/inventory/sql_server_test.go
+++ b/resources/providers/azurelib/inventory/sql_server_test.go
@@ -23,12 +23,19 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/sql/armsql"
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 )
 
-func mockAssetSQLEncryptionProtector(f func() ([]armsql.EncryptionProtectorsClientListByServerResponse, error)) ProviderAPI {
+type encryptionProtectorFn func() ([]armsql.EncryptionProtectorsClientListByServerResponse, error)
+type auditingPoliciesFn func() (armsql.ServerBlobAuditingPoliciesClientGetResponse, error)
+type transparentDataEncryptionFn func(dbName string) ([]armsql.TransparentDataEncryptionsClientListByDatabaseResponse, error)
+type databaseFn func() ([]armsql.DatabasesClientListByServerResponse, error)
+
+func mockAssetSQLEncryptionProtector(f encryptionProtectorFn) ProviderAPI {
 	wrapper := &azureClientWrapper{
 		AssetSQLEncryptionProtector: func(_ context.Context, _, _, _ string, _ *arm.ClientOptions, _ *armsql.EncryptionProtectorsClientListByServerOptions) ([]armsql.EncryptionProtectorsClientListByServerResponse, error) {
 			return f()
@@ -41,10 +48,26 @@ func mockAssetSQLEncryptionProtector(f func() ([]armsql.EncryptionProtectorsClie
 	}
 }
 
-func mockAssetSQLBlobAuditingPolicies(f func() (armsql.ServerBlobAuditingPoliciesClientGetResponse, error)) ProviderAPI {
+func mockAssetSQLBlobAuditingPolicies(f auditingPoliciesFn) ProviderAPI {
 	wrapper := &azureClientWrapper{
 		AssetSQLBlobAuditingPolicies: func(ctx context.Context, subID, resourceGroup, sqlServerName string, clientOptions *arm.ClientOptions, options *armsql.ServerBlobAuditingPoliciesClientGetOptions) (armsql.ServerBlobAuditingPoliciesClientGetResponse, error) {
 			return f()
+		},
+	}
+
+	return &provider{
+		log:    logp.NewLogger("mock_asset_sql_encryption_protector"),
+		client: wrapper,
+	}
+}
+
+func mockAssetSQLTransparentDataEncryption(tdesFn transparentDataEncryptionFn, dbsFn databaseFn) ProviderAPI {
+	wrapper := &azureClientWrapper{
+		AssetSQLDatabases: func(_ context.Context, _, _, _ string, _ *arm.ClientOptions, _ *armsql.DatabasesClientListByServerOptions) ([]armsql.DatabasesClientListByServerResponse, error) {
+			return dbsFn()
+		},
+		AssetSQLTransparentDataEncryptions: func(_ context.Context, _, _, _, dbName string, _ *arm.ClientOptions, _ *armsql.TransparentDataEncryptionsClientListByDatabaseOptions) ([]armsql.TransparentDataEncryptionsClientListByDatabaseResponse, error) {
+			return tdesFn(dbName)
 		},
 	}
 
@@ -76,128 +99,21 @@ func TestListSQLEncryptionProtector(t *testing.T) {
 		},
 		"Response with encryption protectors in different pages": {
 			apiMockCall: func() ([]armsql.EncryptionProtectorsClientListByServerResponse, error) {
-				return []armsql.EncryptionProtectorsClientListByServerResponse{
-					{
-						EncryptionProtectorListResult: armsql.EncryptionProtectorListResult{
-							Value: []*armsql.EncryptionProtector{
-								{
-									Name:     ref("Encryption Protector"),
-									ID:       ref("id1"),
-									Kind:     ref("azurekeyvault"),
-									Location: ref("eu-west"),
-									Type:     ref("encryptionProtector"),
-									Properties: &armsql.EncryptionProtectorProperties{
-										ServerKeyType:       ref(armsql.ServerKeyTypeAzureKeyVault),
-										AutoRotationEnabled: ref(true),
-										ServerKeyName:       ref("serverKeyName1"),
-										Subregion:           ref("eu-west-1"),
-									},
-								},
-								{
-									Name:     ref("Encryption Protector"),
-									ID:       ref("id2"),
-									Kind:     ref("azurekeyvault"),
-									Location: ref("eu-west"),
-									Type:     ref("encryptionProtector"),
-									Properties: &armsql.EncryptionProtectorProperties{
-										ServerKeyType:       ref(armsql.ServerKeyTypeAzureKeyVault),
-										AutoRotationEnabled: ref(true),
-										ServerKeyName:       ref("serverKeyName2"),
-										Subregion:           ref("eu-west-1"),
-									},
-								},
-							},
-						},
-					},
-					{
-						EncryptionProtectorListResult: armsql.EncryptionProtectorListResult{
-							Value: []*armsql.EncryptionProtector{
-								{
-									Name:     ref("Encryption Protector"),
-									ID:       ref("id3"),
-									Kind:     ref("azurekeyvault"),
-									Location: ref("eu-west"),
-									Type:     ref("encryptionProtector"),
-									Properties: &armsql.EncryptionProtectorProperties{
-										ServerKeyType:       ref(armsql.ServerKeyTypeServiceManaged),
-										AutoRotationEnabled: ref(true),
-										ServerKeyName:       ref("serverKeyName3"),
-										Subregion:           ref("eu-west-1"),
-									},
-								},
-							},
-						},
-					},
-				}, nil
+				return wrapEpResponse(
+					wrapEpResult(
+						epAzure("id1", armsql.ServerKeyTypeAzureKeyVault),
+						epAzure("id2", armsql.ServerKeyTypeAzureKeyVault),
+					),
+					wrapEpResult(
+						epAzure("id3", armsql.ServerKeyTypeServiceManaged),
+					),
+				), nil
 			},
 			expectError: false,
 			expectedAssets: []AzureAsset{
-				{
-					Id:             "id1",
-					Name:           "Encryption Protector",
-					DisplayName:    "",
-					Location:       "eu-west",
-					ResourceGroup:  "resourceGroup",
-					SubscriptionId: "subId",
-					Type:           "encryptionProtector",
-					TenantId:       "",
-					Sku:            nil,
-					Identity:       nil,
-					Properties: map[string]any{
-						"kind":                "azurekeyvault",
-						"serverKeyType":       "AzureKeyVault",
-						"autoRotationEnabled": true,
-						"serverKeyName":       "serverKeyName1",
-						"subregion":           "eu-west-1",
-						"thumbprint":          "",
-						"uri":                 "",
-					},
-					Extension: nil,
-				},
-				{
-					Id:             "id2",
-					Name:           "Encryption Protector",
-					DisplayName:    "",
-					Location:       "eu-west",
-					ResourceGroup:  "resourceGroup",
-					SubscriptionId: "subId",
-					Type:           "encryptionProtector",
-					TenantId:       "",
-					Sku:            nil,
-					Identity:       nil,
-					Properties: map[string]any{
-						"kind":                "azurekeyvault",
-						"serverKeyType":       "AzureKeyVault",
-						"autoRotationEnabled": true,
-						"serverKeyName":       "serverKeyName2",
-						"subregion":           "eu-west-1",
-						"thumbprint":          "",
-						"uri":                 "",
-					},
-					Extension: nil,
-				},
-				{
-					Id:             "id3",
-					Name:           "Encryption Protector",
-					DisplayName:    "",
-					Location:       "eu-west",
-					ResourceGroup:  "resourceGroup",
-					SubscriptionId: "subId",
-					Type:           "encryptionProtector",
-					TenantId:       "",
-					Sku:            nil,
-					Identity:       nil,
-					Properties: map[string]any{
-						"kind":                "azurekeyvault",
-						"serverKeyType":       "ServiceManaged",
-						"autoRotationEnabled": true,
-						"serverKeyName":       "serverKeyName3",
-						"subregion":           "eu-west-1",
-						"thumbprint":          "",
-						"uri":                 "",
-					},
-					Extension: nil,
-				},
+				epAsset("id1", "AzureKeyVault"),
+				epAsset("id2", "AzureKeyVault"),
+				epAsset("id3", "ServiceManaged"),
 			},
 		},
 	}
@@ -231,25 +147,25 @@ func TestGetSQLBlobAuditingPolicies(t *testing.T) {
 			expectError:    true,
 			expectedAssets: nil,
 		},
-		"Response with encryption protectors in different pages": {
+		"Response with blob auditing policy": {
 			apiMockCall: func() (armsql.ServerBlobAuditingPoliciesClientGetResponse, error) {
 				return armsql.ServerBlobAuditingPoliciesClientGetResponse{
 					ServerBlobAuditingPolicy: armsql.ServerBlobAuditingPolicy{
-						ID:   ref("id1"),
-						Name: ref("policy"),
-						Type: ref("audit-policy"),
+						ID:   to.Ptr("id1"),
+						Name: to.Ptr("policy"),
+						Type: to.Ptr("audit-policy"),
 						Properties: &armsql.ServerBlobAuditingPolicyProperties{
-							State:                        ref(armsql.BlobAuditingPolicyStateEnabled),
-							IsAzureMonitorTargetEnabled:  ref(true),
-							IsDevopsAuditEnabled:         ref(false),
-							IsManagedIdentityInUse:       ref(true),
-							IsStorageSecondaryKeyInUse:   ref(true),
-							QueueDelayMs:                 ref(int32(100)),
-							RetentionDays:                ref(int32(90)),
-							StorageAccountAccessKey:      ref("access-key"),
-							StorageAccountSubscriptionID: ref("sub-id"),
+							State:                        to.Ptr(armsql.BlobAuditingPolicyStateEnabled),
+							IsAzureMonitorTargetEnabled:  to.Ptr(true),
+							IsDevopsAuditEnabled:         to.Ptr(false),
+							IsManagedIdentityInUse:       to.Ptr(true),
+							IsStorageSecondaryKeyInUse:   to.Ptr(true),
+							QueueDelayMs:                 to.Ptr(int32(100)),
+							RetentionDays:                to.Ptr(int32(90)),
+							StorageAccountAccessKey:      to.Ptr("access-key"),
+							StorageAccountSubscriptionID: to.Ptr("sub-id"),
 							StorageEndpoint:              nil,
-							AuditActionsAndGroups:        []*string{ref("a"), ref("b")},
+							AuditActionsAndGroups:        []*string{to.Ptr("a"), to.Ptr("b")},
 						},
 					},
 				}, nil
@@ -302,6 +218,196 @@ func TestGetSQLBlobAuditingPolicies(t *testing.T) {
 	}
 }
 
-func ref[T any](v T) *T {
-	return &v
+func TestListSqlTransparentDataEncryptions(t *testing.T) {
+	tcs := map[string]struct {
+		tdeFn          transparentDataEncryptionFn
+		dbFn           databaseFn
+		expectError    bool
+		expectedAssets []AzureAsset
+	}{
+		"Error on fetching databases": {
+			dbFn: func() ([]armsql.DatabasesClientListByServerResponse, error) {
+				return nil, errors.New("error")
+			},
+			expectError:    true,
+			expectedAssets: nil,
+		},
+		"Error on fetching 1 transparent data encryption (out of 3)": {
+			dbFn: func() ([]armsql.DatabasesClientListByServerResponse, error) {
+				return wrapDBResponse(
+					[]string{"db1"},
+					[]string{"db2", "db3"},
+				), nil
+			},
+			tdeFn: func(dbName string) ([]armsql.TransparentDataEncryptionsClientListByDatabaseResponse, error) {
+				if dbName == "db2" {
+					return nil, errors.New("error")
+				}
+				return wrapTdeResponse(
+					wrapTdeResult(tdeAzure(dbName+"-tde1", armsql.TransparentDataEncryptionStateEnabled)),
+				), nil
+			},
+			expectError: true,
+			expectedAssets: []AzureAsset{
+				tdeAsset("db1-tde1", "Enabled"),
+				tdeAsset("db3-tde1", "Enabled"),
+			},
+		},
+		"Response of 3 dbs with multiple tdes (in different pages)": {
+			dbFn: func() ([]armsql.DatabasesClientListByServerResponse, error) {
+				return wrapDBResponse(
+					[]string{"db1"},
+					[]string{"db2", "db3"},
+				), nil
+			},
+			tdeFn: func(dbName string) ([]armsql.TransparentDataEncryptionsClientListByDatabaseResponse, error) {
+				if dbName == "db1" {
+					return wrapTdeResponse(
+						wrapTdeResult(tdeAzure(dbName+"-tde1", armsql.TransparentDataEncryptionStateEnabled)),
+						wrapTdeResult(tdeAzure(dbName+"-tde2", armsql.TransparentDataEncryptionStateDisabled)),
+					), nil
+				}
+				return wrapTdeResponse(
+					wrapTdeResult(tdeAzure(dbName+"-tde1", armsql.TransparentDataEncryptionStateEnabled)),
+				), nil
+			},
+			expectError: false,
+			expectedAssets: []AzureAsset{
+				tdeAsset("db1-tde1", "Enabled"),
+				tdeAsset("db1-tde2", "Disabled"),
+				tdeAsset("db2-tde1", "Enabled"),
+				tdeAsset("db3-tde1", "Enabled"),
+			},
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			p := mockAssetSQLTransparentDataEncryption(tc.tdeFn, tc.dbFn)
+			got, err := p.ListSQLTransparentDataEncryptions(context.Background(), "subId", "resourceGroup", "sqlServerInstanceName")
+
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.ElementsMatch(t, tc.expectedAssets, got)
+		})
+	}
+}
+
+func wrapEpResult(eps ...*armsql.EncryptionProtector) armsql.EncryptionProtectorListResult {
+	return armsql.EncryptionProtectorListResult{
+		Value: eps,
+	}
+}
+
+func wrapEpResponse(results ...armsql.EncryptionProtectorListResult) []armsql.EncryptionProtectorsClientListByServerResponse {
+	return lo.Map(results, func(r armsql.EncryptionProtectorListResult, index int) armsql.EncryptionProtectorsClientListByServerResponse {
+		return armsql.EncryptionProtectorsClientListByServerResponse{
+			EncryptionProtectorListResult: r,
+		}
+	})
+}
+
+func epAzure(id string, keyType armsql.ServerKeyType) *armsql.EncryptionProtector {
+	return &armsql.EncryptionProtector{
+		ID:       to.Ptr(id),
+		Name:     to.Ptr("Name " + id),
+		Kind:     to.Ptr("azurekeyvault"),
+		Location: to.Ptr("eu-west"),
+		Type:     to.Ptr("encryptionProtector"),
+		Properties: &armsql.EncryptionProtectorProperties{
+			ServerKeyType:       to.Ptr(keyType),
+			AutoRotationEnabled: to.Ptr(true),
+			ServerKeyName:       to.Ptr("key-" + id),
+			Subregion:           to.Ptr("eu-west-1"),
+		},
+	}
+}
+
+func epAsset(id, keyType string) AzureAsset {
+	return AzureAsset{
+		Id:             id,
+		Name:           "Name " + id,
+		DisplayName:    "",
+		Location:       "eu-west",
+		ResourceGroup:  "resourceGroup",
+		SubscriptionId: "subId",
+		Type:           "encryptionProtector",
+		TenantId:       "",
+		Sku:            nil,
+		Identity:       nil,
+		Properties: map[string]any{
+			"kind":                "azurekeyvault",
+			"serverKeyType":       keyType,
+			"autoRotationEnabled": true,
+			"serverKeyName":       "key-" + id,
+			"subregion":           "eu-west-1",
+			"thumbprint":          "",
+			"uri":                 "",
+		},
+		Extension: nil,
+	}
+}
+
+func wrapDBResponse(ids ...[]string) []armsql.DatabasesClientListByServerResponse {
+	return lo.Map(ids, func(ids []string, _ int) armsql.DatabasesClientListByServerResponse {
+		values := lo.Map(ids, func(id string, _ int) *armsql.Database {
+			return &armsql.Database{
+				Name: to.Ptr(id),
+			}
+		})
+
+		return armsql.DatabasesClientListByServerResponse{
+			DatabaseListResult: armsql.DatabaseListResult{
+				Value: values,
+			},
+		}
+	})
+}
+
+func wrapTdeResponse(results ...armsql.LogicalDatabaseTransparentDataEncryptionListResult) []armsql.TransparentDataEncryptionsClientListByDatabaseResponse {
+	return lo.Map(results, func(r armsql.LogicalDatabaseTransparentDataEncryptionListResult, _ int) armsql.TransparentDataEncryptionsClientListByDatabaseResponse {
+		return armsql.TransparentDataEncryptionsClientListByDatabaseResponse{
+			LogicalDatabaseTransparentDataEncryptionListResult: r,
+		}
+	})
+}
+
+func wrapTdeResult(tdes ...*armsql.LogicalDatabaseTransparentDataEncryption) armsql.LogicalDatabaseTransparentDataEncryptionListResult {
+	return armsql.LogicalDatabaseTransparentDataEncryptionListResult{
+		Value: tdes,
+	}
+}
+
+func tdeAzure(id string, state armsql.TransparentDataEncryptionState) *armsql.LogicalDatabaseTransparentDataEncryption {
+	return &armsql.LogicalDatabaseTransparentDataEncryption{
+		ID:   to.Ptr(id),
+		Name: to.Ptr("name-" + id),
+		Type: to.Ptr("transparentDataEncryption"),
+		Properties: &armsql.TransparentDataEncryptionProperties{
+			State: to.Ptr(state),
+		},
+	}
+}
+
+func tdeAsset(id, state string) AzureAsset {
+	return AzureAsset{
+		Id:             id,
+		Name:           "name-" + id,
+		DisplayName:    "",
+		Location:       "global",
+		ResourceGroup:  "resourceGroup",
+		SubscriptionId: "subId",
+		Type:           "transparentDataEncryption",
+		TenantId:       "",
+		Sku:            nil,
+		Identity:       nil,
+		Properties: map[string]any{
+			"state": state,
+		},
+		Extension: nil,
+	}
 }

--- a/resources/providers/azurelib/mock_provider_api.go
+++ b/resources/providers/azurelib/mock_provider_api.go
@@ -324,6 +324,63 @@ func (_c *MockProviderAPI_ListSQLEncryptionProtector_Call) RunAndReturn(run func
 	return _c
 }
 
+// ListSQLTransparentDataEncryptions provides a mock function with given fields: ctx, subID, resourceGroup, sqlServerName
+func (_m *MockProviderAPI) ListSQLTransparentDataEncryptions(ctx context.Context, subID string, resourceGroup string, sqlServerName string) ([]inventory.AzureAsset, error) {
+	ret := _m.Called(ctx, subID, resourceGroup, sqlServerName)
+
+	var r0 []inventory.AzureAsset
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]inventory.AzureAsset, error)); ok {
+		return rf(ctx, subID, resourceGroup, sqlServerName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []inventory.AzureAsset); ok {
+		r0 = rf(ctx, subID, resourceGroup, sqlServerName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]inventory.AzureAsset)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, subID, resourceGroup, sqlServerName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockProviderAPI_ListSQLTransparentDataEncryptions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSQLTransparentDataEncryptions'
+type MockProviderAPI_ListSQLTransparentDataEncryptions_Call struct {
+	*mock.Call
+}
+
+// ListSQLTransparentDataEncryptions is a helper method to define mock.On call
+//   - ctx context.Context
+//   - subID string
+//   - resourceGroup string
+//   - sqlServerName string
+func (_e *MockProviderAPI_Expecter) ListSQLTransparentDataEncryptions(ctx interface{}, subID interface{}, resourceGroup interface{}, sqlServerName interface{}) *MockProviderAPI_ListSQLTransparentDataEncryptions_Call {
+	return &MockProviderAPI_ListSQLTransparentDataEncryptions_Call{Call: _e.mock.On("ListSQLTransparentDataEncryptions", ctx, subID, resourceGroup, sqlServerName)}
+}
+
+func (_c *MockProviderAPI_ListSQLTransparentDataEncryptions_Call) Run(run func(ctx context.Context, subID string, resourceGroup string, sqlServerName string)) *MockProviderAPI_ListSQLTransparentDataEncryptions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *MockProviderAPI_ListSQLTransparentDataEncryptions_Call) Return(_a0 []inventory.AzureAsset, _a1 error) *MockProviderAPI_ListSQLTransparentDataEncryptions_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockProviderAPI_ListSQLTransparentDataEncryptions_Call) RunAndReturn(run func(context.Context, string, string, string) ([]inventory.AzureAsset, error)) *MockProviderAPI_ListSQLTransparentDataEncryptions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListStorageAccountBlobServices provides a mock function with given fields: ctx, storageAccounts
 func (_m *MockProviderAPI) ListStorageAccountBlobServices(ctx context.Context, storageAccounts []inventory.AzureAsset) ([]inventory.AzureAsset, error) {
 	ret := _m.Called(ctx, storageAccounts)

--- a/resources/providers/azurelib/provider.go
+++ b/resources/providers/azurelib/provider.go
@@ -85,6 +85,10 @@ func (p provider) ListSQLEncryptionProtector(ctx context.Context, subID, resourc
 	return p.inventory.ListSQLEncryptionProtector(ctx, subID, resourceGroup, sqlServerName)
 }
 
+func (p provider) ListSQLTransparentDataEncryptions(ctx context.Context, subID, resourceGroup, sqlServerName string) ([]inventory.AzureAsset, error) {
+	return p.inventory.ListSQLTransparentDataEncryptions(ctx, subID, resourceGroup, sqlServerName)
+}
+
 func (p provider) GetSQLBlobAuditingPolicies(ctx context.Context, subID, resourceGroup, sqlServerName string) ([]inventory.AzureAsset, error) {
 	return p.inventory.GetSQLBlobAuditingPolicies(ctx, subID, resourceGroup, sqlServerName)
 }

--- a/security-policies/RULES.md
+++ b/security-policies/RULES.md
@@ -390,9 +390,9 @@
 
 ## AZURE CIS Benchmark
 
-### 48/151 implemented rules (32%)
+### 49/151 implemented rules (32%)
 
-#### Automated rules: 48/77 (62%)
+#### Automated rules: 49/77 (64%)
 
 #### Manual rules: 0/74 (0%)
 
@@ -476,7 +476,7 @@
 |  [4.1.2](bundle/compliance/cis_azure/rules/cis_4_1_2)  | SQL Server - Auditing                   | Ensure no Azure SQL Databases allow ingress from 0.0.0.0/0 (ANY IP)                                                                                    | :white_check_mark: | Automated |
 |  [4.1.3](bundle/compliance/cis_azure/rules/cis_4_1_3)  | SQL Server - Auditing                   | Ensure SQL server's Transparent Data Encryption (TDE) protector is encrypted with Customer-managed key                                                 | :white_check_mark: | Automated |
 |  [4.1.4](bundle/compliance/cis_azure/rules/cis_4_1_4)  | SQL Server - Auditing                   | Ensure that Azure Active Directory Admin is Configured for SQL Servers                                                                                 | :white_check_mark: | Automated |
-|                         4.1.5                          | SQL Server - Auditing                   | Ensure that 'Data encryption' is set to 'On' on a SQL Database                                                                                         |        :x:         | Automated |
+|  [4.1.5](bundle/compliance/cis_azure/rules/cis_4_1_5)  | SQL Server - Auditing                   | Ensure that 'Data encryption' is set to 'On' on a SQL Database                                                                                         | :white_check_mark: | Automated |
 |                         4.1.6                          | SQL Server - Auditing                   | Ensure that 'Auditing' Retention is 'greater than 90 days'                                                                                             |        :x:         | Automated |
 |                         4.2.1                          | SQL Server - Microsoft Defender for SQL | Ensure that Microsoft Defender for SQL is set to 'On' for critical SQL Servers                                                                         |        :x:         | Automated |
 |                         4.2.2                          | SQL Server - Microsoft Defender for SQL | Ensure that Vulnerability Assessment (VA) is enabled on a SQL server by setting a Storage Account                                                      |        :x:         | Automated |

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_5/data.yaml
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_5/data.yaml
@@ -1,0 +1,94 @@
+metadata:
+  id: 89ebec6b-3cc4-5898-a3b9-534174f93051
+  name: Ensure that 'Data encryption' is set to 'On' on a SQL Database
+  profile_applicability: '* Level 1'
+  description: Enable Transparent Data Encryption on every SQL server.
+  rationale: |-
+    Azure SQL Database transparent data encryption helps protect against the threat of malicious activity by performing real-time encryption and decryption of the database, associated backups, and transaction log files at rest without requiring changes to the application.
+  audit: |-
+    **From Azure Portal**
+
+    1. Go to `SQL databases`
+    2. For each DB instance
+    3. Click on `Transparent data encryption`
+    4. Ensure that `Data encryption` is set to `On`
+
+    **From Azure CLI**
+
+    Ensure the output of the below command is `Enabled`
+
+    ```
+    az sql db tde show --resource-group <resourceGroup> --server <dbServerName> --database <dbName> --query status
+    ```
+
+    **From PowerShell**
+
+    Get a list of SQL Servers.
+
+    ```
+    Get-AzSqlServer
+    ```
+
+    For each server, list the databases.
+
+    ```
+    Get-AzSqlDatabase -ServerName <SQL Server Name> -ResourceGroupName <Resource Group Name>
+    ```
+
+    For each database not listed as a `Master` database, check for Transparent Data Encryption.
+
+    ```
+    Get-AzSqlDatabaseTransparentDataEncryption -ResourceGroupName <Resource Group Name> -ServerName <SQL Server Name> -DatabaseName <Database Name>
+    ```
+
+    Make sure `DataEncryption` is `Enabled` for each database except the `Master` database.
+  remediation: |-
+    **From Azure Portal**
+
+    1. Go to `SQL databases`
+    2. For each DB instance
+    3. Click on `Transparent data encryption`
+    4. Set `Data encryption` to `On`
+
+    **From Azure CLI**
+
+    Use the below command to enable `Transparent data encryption` for SQL DB instance.
+
+    ```
+    az sql db tde set --resource-group <resourceGroup> --server <dbServerName> --database <dbName> --status Enabled
+    ```
+
+    **From PowerShell**
+
+    Use the below command to enable `Transparent data encryption` for SQL DB instance.
+
+    ```
+    Set-AzSqlDatabaseTransparentDataEncryption -ResourceGroupName <Resource Group Name> -ServerName <SQL Server Name> -DatabaseName <Database Name> -State 'Enabled'
+    ```
+
+    **Note:**
+
+    - TDE cannot be used to encrypt the logical master database in SQL Database.
+    The master database contains objects that are needed to perform the TDE operations on the user databases.
+
+    - Azure Portal does not show master databases per SQL server.
+    However, CLI/API responses will show master databases.
+  impact: ''
+  default_value: ''
+  references: |-
+    1. https://docs.microsoft.com/en-us/sql/relational-databases/security/encryption/transparent-data-encryption-with-azure-sql-database
+    2. https://docs.microsoft.com/en-us/security/benchmark/azure/security-controls-v3-data-protection#dp-4-enable-data-at-rest-encryption-by-default
+    3. https://learn.microsoft.com/en-us/powershell/module/az.sql/set-azsqldatabasetransparentdataencryption?view=azps-9.2.0
+  section: SQL Server - Auditing
+  version: '1.0'
+  tags:
+  - CIS
+  - AZURE
+  - CIS 4.1.5
+  - SQL Server - Auditing
+  benchmark:
+    name: CIS Microsoft Azure Foundations
+    version: v2.0.0
+    id: cis_azure
+    rule_number: 4.1.5
+    posture_type: cspm

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_5/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_5/rule.rego
@@ -1,0 +1,34 @@
+package compliance.cis_azure.rules.cis_4_1_5
+
+import data.compliance.lib.common
+import data.compliance.policy.azure.data_adapter
+import future.keywords.every
+import future.keywords.if
+
+finding = result if {
+	# filter
+	data_adapter.is_sql_server
+
+	# set result
+	result := common.generate_result_without_expected(
+		common.calculate_result(is_transaparent_data_encryption_enabled_for_all_dbs),
+		{"Resource": data_adapter.resource},
+	)
+}
+
+default is_transaparent_data_encryption_enabled_for_all_dbs = false
+
+is_transaparent_data_encryption_enabled_for_all_dbs if {
+	count(data_adapter.resource.extension.sqlTransparentDataEncryptions) > 0
+
+	every p in data_adapter.resource.extension.sqlTransparentDataEncryptions {
+		is_transparent_data_encryption_enabled(p.databaseName, p.state)
+	}
+}
+
+is_transparent_data_encryption_enabled("master", _) := true
+
+is_transparent_data_encryption_enabled(dbName, state) if {
+	dbName != "master"
+	state == "Enabled"
+}

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_5/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_5/test.rego
@@ -1,0 +1,73 @@
+package compliance.cis_azure.rules.cis_4_1_5
+
+import data.cis_azure.test_data
+import data.compliance.policy.azure.data_adapter
+import data.lib.test
+import future.keywords.if
+
+test_violation if {
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [{
+		"state": "Disabled",
+		"databaseName": "dbName",
+	}]})
+
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [
+		{
+			"state": "Disabled",
+			"databaseName": "dbName",
+		},
+		{
+			"state": "Enabled",
+			"databaseName": "dbName",
+		},
+		{
+			"state": "Enabled",
+			"databaseName": "master",
+		},
+	]})
+
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {})
+}
+
+test_pass if {
+	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [{
+		"state": "Enabled",
+		"databaseName": "dbName",
+	}]})
+
+	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [{
+		"state": "Disabled",
+		"databaseName": "master",
+	}]})
+
+	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [
+		{
+			"state": "Enabled",
+			"databaseName": "dbName",
+		},
+		{
+			"state": "Enabled",
+			"databaseName": "dbName",
+		},
+		{
+			"state": "Disabled",
+			"databaseName": "master",
+		},
+	]})
+}
+
+test_not_evaluated if {
+	not_eval with input as test_data.not_eval_non_exist_type
+}
+
+eval_fail if {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass if {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval if {
+	not finding with data.benchmark_data_adapter as data_adapter
+}


### PR DESCRIPTION
### Summary of your changes

Implement CIS 4.1.5.

Goal: verify that all sql server databases, with a name different of master, have Transparent Data Encryption enabled.

The change was verified locally.

With TDE enabled
![Screenshot 2024-01-05 at 16 17 24](https://github.com/elastic/cloudbeat/assets/5350001/fdf9a7b8-f377-45a4-8692-58263776c309)

Without
![Screenshot 2024-01-05 at 16 17 15](https://github.com/elastic/cloudbeat/assets/5350001/d985c869-20ae-45d6-8514-c531f693bd9b)

Some code refactoring on the tests was also made.

### Decisions

There is a resource `microsoft.sql/servers/databases` in the ARG. However, this resource doesn't contain the sql server instance name, which we need to make the call to retrieve TDE. I could not find an attribute to correlate servers with databases.

The decision made was to evaluate this rule as part of the SQLServer resource, and on enrichment level fetch all the databases, and for each database, call the TDE.

### Related Issues
- Related https://github.com/elastic/cloudbeat/issues/1417

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [x] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [x] Add relevant unit tests
- [x] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
