### PR TITLE
[Create Environment] Update cleanup step statement

### DIFF
--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -9,11 +9,10 @@ on:
   #     - "[0-9]+.[0-9]+"
   #   types: [ opened, synchronize, reopened ]
 
-# Skipping post-merge K8s tests until https://github:com/elastic/cloudbeat/issues/1638 is resolved
-#  push:
-#    branches:
-#      - main
-#      - "[0-9]+.[0-9]+"
+  push:
+    branches:
+      - main
+      - "[0-9]+.[0-9]+"
 
 env:
   CONTAINER_SUFFIX: ${{ github.run_id }}
@@ -29,6 +28,8 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     timeout-minutes: 40
+    # Skipping post-merge K8s tests until https://github:com/elastic/cloudbeat/issues/1638 is resolved
+    if: false
     steps:
       # Disk cleanup
       - name: Free Disk Space (Ubuntu)
@@ -109,7 +110,9 @@ jobs:
 
   k8s_functional_tests:
     # Run only selected tests on PRs
-    if: github.event_name == 'pull_request'
+    # if: github.event_name == 'pull_request'
+    # Skipping post-merge K8s tests until https://github:com/elastic/cloudbeat/issues/1638 is resolved
+    if: false
     name: ${{ matrix.test-target }}-tests
     needs: [ Build ]
     runs-on: ubuntu-22.04
@@ -193,7 +196,9 @@ jobs:
   k8s_functional_tests_full:
     # Run full test suit on post-merge
     name: ${{ matrix.test-target }}-${{ matrix.range }}-tests
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
+    # Skipping post-merge K8s tests until https://github:com/elastic/cloudbeat/issues/1638 is resolved
+    if: false
     needs: [ Build ]
     runs-on: ubuntu-22.04
     timeout-minutes: 55

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -403,7 +403,7 @@ jobs:
           poetry run pytest -m "sanity" --alluredir=./allure/results/ --clean-alluredir --maxfail=4
 
       - name: Cleanup Environment
-        if: ${{ inputs.cleanup-env == true }}
+        if: ${{ !cancelled() && inputs.cleanup-env == true }}
         run: |
           just delete-cloud-env ${{ env.DEPLOYMENT_NAME }} '' "false"
 


### PR DESCRIPTION
### Summary of your changes

This PR fixes the scenario when workflow fails in any of the steps, and cleanup resources checkbox is selected, the workflow won't delete the environment.

### Screenshot/Data

Evidence of the workflow run with cleanup resources selected and executed during a failure can be found [here](https://github.com/elastic/cloudbeat/actions/runs/7438955180/job/20238277675).


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
