### PR TITLE
CIS Azure 4.3.8

### DIFF
--- a/security-policies/README.md
+++ b/security-policies/README.md
@@ -4,7 +4,7 @@
 [![CIS EKS](https://img.shields.io/badge/CIS-Amazon%20EKS%20(60%25)-FF9900?logo=Amazon+EKS)](RULES.md#eks-cis-benchmark)
 [![CIS AWS](https://img.shields.io/badge/CIS-AWS%20(87%25)-232F3E?logo=Amazon+AWS)](RULES.md#aws-cis-benchmark)
 [![CIS GCP](https://img.shields.io/badge/CIS-GCP%20(85%25)-4285F4?logo=Google+Cloud)](RULES.md#gcp-cis-benchmark)
-[![CIS AZURE](https://img.shields.io/badge/CIS-AZURE%20(36%25)-0078D4?logo=Microsoft+Azure)](RULES.md#azure-cis-benchmark)
+[![CIS AZURE](https://img.shields.io/badge/CIS-AZURE%20(37%25)-0078D4?logo=Microsoft+Azure)](RULES.md#azure-cis-benchmark)
 
 ![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/oren-zohar/a7160df46e48dff45b24096de9302d38/raw/csp-security-policies_coverage.json)
 

--- a/security-policies/RULES.md
+++ b/security-policies/RULES.md
@@ -390,9 +390,9 @@
 
 ## AZURE CIS Benchmark
 
-### 55/151 implemented rules (36%)
+### 56/151 implemented rules (37%)
 
-#### Automated rules: 55/77 (71%)
+#### Automated rules: 56/77 (73%)
 
 #### Manual rules: 0/74 (0%)
 
@@ -490,7 +490,7 @@
 |  [4.3.5](bundle/compliance/cis_azure/rules/cis_4_3_5)  | PostgreSQL Database Server              | Ensure server parameter 'connection_throttling' is set to 'ON' for PostgreSQL Database Server                                                          | :white_check_mark: | Automated |
 |  [4.3.6](bundle/compliance/cis_azure/rules/cis_4_3_6)  | PostgreSQL Database Server              | Ensure Server Parameter 'log_retention_days' is greater than 3 days for PostgreSQL Database Server                                                     | :white_check_mark: | Automated |
 |                         4.3.7                          | PostgreSQL Database Server              | Ensure 'Allow access to Azure services' for PostgreSQL Database Server is disabled                                                                     |        :x:         | Automated |
-|                         4.3.8                          | PostgreSQL Database Server              | Ensure 'Infrastructure double encryption' for PostgreSQL Database Server is 'Enabled'                                                                  |        :x:         | Automated |
+|  [4.3.8](bundle/compliance/cis_azure/rules/cis_4_3_8)  | PostgreSQL Database Server              | Ensure 'Infrastructure double encryption' for PostgreSQL Database Server is 'Enabled'                                                                  | :white_check_mark: | Automated |
 |  [4.4.1](bundle/compliance/cis_azure/rules/cis_4_4_1)  | MySQL Database                          | Ensure 'Enforce SSL connection' is set to 'Enabled' for Standard MySQL Database Server                                                                 | :white_check_mark: | Automated |
 |                         4.4.2                          | MySQL Database                          | Ensure 'TLS Version' is set to 'TLSV1.2' for MySQL flexible Database Server                                                                            |        :x:         | Automated |
 |                         4.4.3                          | MySQL Database                          | Ensure server parameter 'audit_log_enabled' is set to 'ON' for MySQL Database Server                                                                   |        :x:         |  Manual   |

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_1/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_1/rule.rego
@@ -16,5 +16,5 @@ finding = result if {
 }
 
 ssl_enforcement_enabled if {
-	data_adapter.properties.sslEnforcement == "Enabled"
+	lower(data_adapter.properties.sslEnforcement) == "enabled"
 } else = false

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_1/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_1/test.rego
@@ -8,11 +8,14 @@ import future.keywords.if
 test_violation if {
 	# fail if ssl_enforcement is disabled
 	eval_fail with input as test_data.generate_postgresql_server_with_ssl_enforcement("Disabled")
+	eval_fail with input as test_data.generate_postgresql_server_with_ssl_enforcement("")
 }
 
 test_pass if {
 	# pass if ssl_enforcement is enabled
 	eval_pass with input as test_data.generate_postgresql_server_with_ssl_enforcement("Enabled")
+	eval_pass with input as test_data.generate_postgresql_server_with_ssl_enforcement("enabled")
+	eval_pass with input as test_data.generate_postgresql_server_with_ssl_enforcement("ENABLED")
 }
 
 test_not_evaluated if {

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_8/data.yaml
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_8/data.yaml
@@ -1,0 +1,69 @@
+metadata:
+  id: 70f92ed3-5659-5c95-a8f8-a63211c57635
+  name: Ensure 'Infrastructure double encryption' for PostgreSQL Database Server is
+    'Enabled'
+  profile_applicability: '* Level 1'
+  description: |-
+    Azure Database for PostgreSQL servers should be created with 'infrastructure double encryption' enabled.
+  rationale: |-
+    If Double Encryption is enabled, another layer of encryption is implemented at the hardware level before the storage or network level.
+    Information will be encrypted before it is even accessed, preventing both interception of data in motion if the network layer encryption is broken and data at rest in system resources such as memory or processor cache.
+    Encryption will also be in place for any backups taken of the database, so the key will secure access the data in all forms.
+    For the most secure implementation of key based encryption, it is recommended to use a Customer Managed asymmetric RSA 2048 Key in Azure Key Vault.
+  audit: |-
+    **From Azure Portal**
+
+    1. From Azure Home, click on more services.
+    2. Click on Databases.
+    3. Click on Azure Database for PostgreSQL servers.
+    4. Select the database by clicking on its name.
+    5. Under Security, click Data encryption.
+    6. Ensure that 'Infrastructure encryption enabled' is displayed and is 'checked'.
+
+    **From Azure CLI**
+
+    7. Enter the command
+    ```
+    az postgres server configuration show --name <servername> --resource-group <resourcegroup> --query 'properties.infrastructureEncryption' -o tsv
+    ```
+    8. Verify that Infrastructure encryption is enabled.
+  remediation: |-
+    It is not possible to enable 'infrastructure double encryption' on an existing Azure Database for PostgreSQL server.
+    The remediation steps detail the creation of a new Azure Database for PostgreSQL server with 'infrastructure double encryption' enabled.
+
+    **From Azure Portal**
+
+    1. Go through the normal process of database creation.
+    2. On step 2 titled 'Additional settings' ensure that 'Infrastructure double encryption enabled' is 'checked'.
+    3. Acknowledge that you understand this will impact database performance.
+    4. Finish database creation as normal.
+
+    **From Azure CLI**
+
+    ```
+    az postgres server create --resource-group <resourcegroup> --name <servername> --location <location> --admin-user <adminusername> --admin-password <server_admin_password> --sku-name GP_Gen4_2 --version 11 --infrastructure-encryption Enabled
+    ```
+  impact: |-
+    The read and write speeds to the database will be impacted if both default encryption and Infrastructure Encryption are checked, as a secondary form of encryption requires more resource overhead for the cryptography of information. This cost is justified for information security.
+    Customer managed keys are recommended for the most secure implementation, leading to overhead of key management. The key will also need to be backed up in a secure location, as loss of the key will mean loss of the information in the database.
+  default_value: ''
+  references: |-
+    1. https://docs.microsoft.com/en-us/azure/postgresql/howto-double-encryption
+    2. https://docs.microsoft.com/en-us/azure/postgresql/concepts-infrastructure-double-encryption
+    3. https://docs.microsoft.com/en-us/azure/postgresql/concepts-data-encryption-postgresql
+    4. https://docs.microsoft.com/en-us/azure/key-vault/keys/byok-specification
+    5. https://docs.microsoft.com/en-us/azure/postgresql/howto-double-encryption
+    6. https://docs.microsoft.com/en-us/security/benchmark/azure/security-controls-v3-data-protection#dp-4-enable-data-at-rest-encryption-by-default
+  section: PostgreSQL Database Server
+  version: '1.0'
+  tags:
+  - CIS
+  - AZURE
+  - CIS 4.3.8
+  - PostgreSQL Database Server
+  benchmark:
+    name: CIS Microsoft Azure Foundations
+    version: v2.0.0
+    id: cis_azure
+    rule_number: 4.3.8
+    posture_type: cspm

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_8/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_8/rule.rego
@@ -1,0 +1,22 @@
+package compliance.cis_azure.rules.cis_4_3_8
+
+import data.compliance.lib.common
+import data.compliance.policy.azure.data_adapter
+import future.keywords.if
+
+finding = result if {
+	# filter
+	data_adapter.is_postgresql_single_server_db
+
+	# set result
+	result := common.generate_result_without_expected(
+		common.calculate_result(infrastructure_encryption_enabled),
+		{"Resource": data_adapter.resource},
+	)
+}
+
+default infrastructure_encryption_enabled = false
+
+infrastructure_encryption_enabled if {
+	data_adapter.properties.infrastructureEncryption == "Enabled"
+}

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_8/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_8/rule.rego
@@ -18,5 +18,5 @@ finding = result if {
 default infrastructure_encryption_enabled = false
 
 infrastructure_encryption_enabled if {
-	data_adapter.properties.infrastructureEncryption == "Enabled"
+	lower(data_adapter.properties.infrastructureEncryption) == "enabled"
 }

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_8/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_8/test.rego
@@ -6,13 +6,14 @@ import data.lib.test
 import future.keywords.if
 
 test_violation if {
-	# fail if ssl_enforcement is disabled
 	eval_fail with input as test_data.generate_postgresql_server_with_infrastructure_encryption("Disabled")
+	eval_fail with input as test_data.generate_postgresql_server_with_infrastructure_encryption("")
 }
 
 test_pass if {
-	# pass if ssl_enforcement is enabled
 	eval_pass with input as test_data.generate_postgresql_server_with_infrastructure_encryption("Enabled")
+	eval_pass with input as test_data.generate_postgresql_server_with_infrastructure_encryption("enabled")
+	eval_pass with input as test_data.generate_postgresql_server_with_infrastructure_encryption("ENABLED")
 }
 
 test_not_evaluated if {

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_8/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_8/test.rego
@@ -1,0 +1,32 @@
+package compliance.cis_azure.rules.cis_4_3_8
+
+import data.cis_azure.test_data
+import data.compliance.policy.azure.data_adapter
+import data.lib.test
+import future.keywords.if
+
+test_violation if {
+	# fail if ssl_enforcement is disabled
+	eval_fail with input as test_data.generate_postgresql_server_with_infrastructure_encryption("Disabled")
+}
+
+test_pass if {
+	# pass if ssl_enforcement is enabled
+	eval_pass with input as test_data.generate_postgresql_server_with_infrastructure_encryption("Enabled")
+}
+
+test_not_evaluated if {
+	not_eval with input as test_data.not_eval_non_exist_type
+}
+
+eval_fail if {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass if {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval if {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/security-policies/bundle/compliance/cis_azure/test_data.rego
+++ b/security-policies/bundle/compliance/cis_azure/test_data.rego
@@ -103,6 +103,11 @@ generate_postgresql_server_with_extension(ext) = {
 	"resource": {"extension": ext},
 }
 
+generate_postgresql_server_with_infrastructure_encryption(enabled) = {
+	"subType": "azure-postgresql-server-db",
+	"resource": {"properties": {"infrastructureEncryption": enabled}},
+}
+
 generate_mysql_server_with_ssl_enforcement(enabled) = {
 	"subType": "azure-mysql-server-db",
 	"resource": {"properties": {"sslEnforcement": enabled}},


### PR DESCRIPTION
### Summary of your changes

Implement CIS Azure 4.3.8 Ensure 'Infrastructure double encryption' for PostgreSQL Database Server is 'Enabled'

I could not test this rule passing because it's available only for postgre single servers, and that's not [possible to be created anymore](https://learn.microsoft.com/en-us/azure/postgresql/single-server/whats-happening-to-postgresql-single-server). In 2025 it will be completely phased out.

But is possible to see it failing on the already created servers with Disabled infrastructure double encryption

![image](https://github.com/elastic/cloudbeat/assets/5350001/8df004ff-61fa-463f-9a19-d4509035b0db)

### Related Issues
- Related https://github.com/elastic/cloudbeat/issues/1417

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [x] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [x] Add relevant unit tests
- [x] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
