### PR TITLE
CIS Azure 4.3.7

### DIFF
--- a/resources/fetching/fetchers/azure/assets_enricher_postgresql_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_postgresql_test.go
@@ -91,7 +91,7 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 			expected: []inventory.AzureAsset{
 				addExtension(mockPostgresAsset("id1", "psql-a"), map[string]any{
 					inventory.ExtensionPostgresqlFirewallRules: []map[string]any{
-						psqlFirewallRuleProps("0.0.0.0", "196.198.198.256"),
+						psqlFirewallRuleProps("name-fr1", "0.0.0.0", "196.198.198.256"),
 					},
 				}),
 				mockOther("id2"),
@@ -102,7 +102,7 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 				"psql-b": {serverType: psqlServerTypeSingle}, //nolint:exhaustruct
 			},
 			firewallRulesRes: map[string]psqlEnricherResponse{
-				"psql-a": {assetRes(mockPostgresFirewallRuleAsset("fr1", psqlFirewallRuleProps("0.0.0.0", "196.198.198.256"))), psqlServerTypeSingle},
+				"psql-a": {assetRes(mockPostgresFirewallRuleAsset("fr1", psqlFirewallRuleProps("name-fr1", "0.0.0.0", "196.198.198.256"))), psqlServerTypeSingle},
 				"psql-b": {errorRes(errors.New("error")), psqlServerTypeSingle},
 			},
 		},
@@ -121,7 +121,7 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 						psqlConfigProps("log_connections", "off"),
 					},
 					inventory.ExtensionPostgresqlFirewallRules: []map[string]any{
-						psqlFirewallRuleProps("0.0.0.0", "196.198.198.256"),
+						psqlFirewallRuleProps("name-fr1", "0.0.0.0", "196.198.198.256"),
 					},
 				}),
 				mockOther("id2"),
@@ -131,7 +131,7 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 						psqlConfigProps("connection_throttling", "off"),
 					},
 					inventory.ExtensionPostgresqlFirewallRules: []map[string]any{
-						psqlFirewallRuleProps("0.0.0.1", "196.198.198.255"),
+						psqlFirewallRuleProps("name-fr2", "0.0.0.1", "196.198.198.255"),
 					},
 				}),
 				addExtension(mockFlexiblePostgresAsset("id4", "flex-psql-a"), map[string]any{
@@ -139,7 +139,7 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 						psqlConfigProps("log_disconnections", "on"),
 					},
 					inventory.ExtensionPostgresqlFirewallRules: []map[string]any{
-						psqlFirewallRuleProps("0.0.0.2", "196.198.198.254"),
+						psqlFirewallRuleProps("name-fr3", "0.0.0.2", "196.198.198.254"),
 					},
 				}),
 			},
@@ -163,9 +163,9 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 				},
 			},
 			firewallRulesRes: map[string]psqlEnricherResponse{
-				"psql-a":      {assetRes(mockPostgresFirewallRuleAsset("fr1", psqlFirewallRuleProps("0.0.0.0", "196.198.198.256"))), psqlServerTypeSingle},
-				"psql-b":      {assetRes(mockPostgresFirewallRuleAsset("fr2", psqlFirewallRuleProps("0.0.0.1", "196.198.198.255"))), psqlServerTypeSingle},
-				"flex-psql-a": {assetRes(mockPostgresFirewallRuleAsset("fr3", psqlFirewallRuleProps("0.0.0.2", "196.198.198.254"))), psqlServerTypeFlexible},
+				"psql-a":      {assetRes(mockPostgresFirewallRuleAsset("fr1", psqlFirewallRuleProps("name-fr1", "0.0.0.0", "196.198.198.256"))), psqlServerTypeSingle},
+				"psql-b":      {assetRes(mockPostgresFirewallRuleAsset("fr2", psqlFirewallRuleProps("name-fr2", "0.0.0.1", "196.198.198.255"))), psqlServerTypeSingle},
+				"flex-psql-a": {assetRes(mockPostgresFirewallRuleAsset("fr3", psqlFirewallRuleProps("name-fr3", "0.0.0.2", "196.198.198.254"))), psqlServerTypeFlexible},
 			},
 		},
 	}
@@ -245,8 +245,9 @@ func psqlConfigProps(name, value string) map[string]any {
 	}
 }
 
-func psqlFirewallRuleProps(startIpAddr, endIpAddr string) map[string]any {
+func psqlFirewallRuleProps(name, startIpAddr, endIpAddr string) map[string]any {
 	return map[string]any{
+		"name":           name,
 		"startIPAddress": startIpAddr,
 		"endIPAddress":   endIpAddr,
 	}

--- a/resources/fetching/fetchers/azure/assets_fetcher_test.go
+++ b/resources/fetching/fetchers/azure/assets_fetcher_test.go
@@ -136,10 +136,16 @@ func (s *AzureAssetsFetcherTestSuite) TestFetcher_Fetch() {
 
 	// since we have postgresql asset we need to mock the enricher
 	mockProvider.EXPECT().
-		ListPostgresConfigurations(mock.Anything, "subId", "rg", "name").
+		ListSinglePostgresConfigurations(mock.Anything, "subId", "rg", "name").
 		Return(nil, nil)
 	mockProvider.EXPECT().
 		ListFlexiblePostgresConfigurations(mock.Anything, "subId", "rg", "name").
+		Return(nil, nil)
+	mockProvider.EXPECT().
+		ListSinglePostgresFirewallRules(mock.Anything, "subId", "rg", "name").
+		Return(nil, nil)
+	mockProvider.EXPECT().
+		ListFlexiblePostgresFirewallRules(mock.Anything, "subId", "rg", "name").
 		Return(nil, nil)
 
 	results, err := s.fetch(mockProvider, totalMockAssets)

--- a/resources/providers/azurelib/inventory/asset.go
+++ b/resources/providers/azurelib/inventory/asset.go
@@ -58,7 +58,7 @@ const (
 	ExtensionSQLBlobAuditPolicy            = "sqlBlobAuditPolicy"
 	ExtensionSQLTransparentDataEncryptions = "sqlTransparentDataEncryptions"
 	ExtensionPostgresqlConfigurations      = "psqlConfigurations"
-	ExtensionPostgresqlFirewallRules       = "psqlFirewalRules"
+	ExtensionPostgresqlFirewallRules       = "psqlFirewallRules"
 	ExtensionStorageAccountID              = "storageAccountId"
 	ExtensionStorageAccountName            = "storageAccountName"
 	ExtensionBlobDiagnosticSettings        = "blobDiagnosticSettings"

--- a/resources/providers/azurelib/inventory/asset.go
+++ b/resources/providers/azurelib/inventory/asset.go
@@ -58,6 +58,7 @@ const (
 	ExtensionSQLBlobAuditPolicy            = "sqlBlobAuditPolicy"
 	ExtensionSQLTransparentDataEncryptions = "sqlTransparentDataEncryptions"
 	ExtensionPostgresqlConfigurations      = "psqlConfigurations"
+	ExtensionPostgresqlFirewallRules       = "psqlFirewalRules"
 	ExtensionStorageAccountID              = "storageAccountId"
 	ExtensionStorageAccountName            = "storageAccountName"
 	ExtensionBlobDiagnosticSettings        = "blobDiagnosticSettings"

--- a/resources/providers/azurelib/inventory/mock_postgresql_provider_api.go
+++ b/resources/providers/azurelib/inventory/mock_postgresql_provider_api.go
@@ -95,8 +95,8 @@ func (_c *MockPostgresqlProviderAPI_ListFlexiblePostgresConfigurations_Call) Run
 	return _c
 }
 
-// ListPostgresConfigurations provides a mock function with given fields: ctx, subID, resourceGroup, serverName
-func (_m *MockPostgresqlProviderAPI) ListPostgresConfigurations(ctx context.Context, subID string, resourceGroup string, serverName string) ([]AzureAsset, error) {
+// ListFlexiblePostgresFirewallRules provides a mock function with given fields: ctx, subID, resourceGroup, serverName
+func (_m *MockPostgresqlProviderAPI) ListFlexiblePostgresFirewallRules(ctx context.Context, subID string, resourceGroup string, serverName string) ([]AzureAsset, error) {
 	ret := _m.Called(ctx, subID, resourceGroup, serverName)
 
 	var r0 []AzureAsset
@@ -121,33 +121,147 @@ func (_m *MockPostgresqlProviderAPI) ListPostgresConfigurations(ctx context.Cont
 	return r0, r1
 }
 
-// MockPostgresqlProviderAPI_ListPostgresConfigurations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListPostgresConfigurations'
-type MockPostgresqlProviderAPI_ListPostgresConfigurations_Call struct {
+// MockPostgresqlProviderAPI_ListFlexiblePostgresFirewallRules_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListFlexiblePostgresFirewallRules'
+type MockPostgresqlProviderAPI_ListFlexiblePostgresFirewallRules_Call struct {
 	*mock.Call
 }
 
-// ListPostgresConfigurations is a helper method to define mock.On call
+// ListFlexiblePostgresFirewallRules is a helper method to define mock.On call
 //   - ctx context.Context
 //   - subID string
 //   - resourceGroup string
 //   - serverName string
-func (_e *MockPostgresqlProviderAPI_Expecter) ListPostgresConfigurations(ctx interface{}, subID interface{}, resourceGroup interface{}, serverName interface{}) *MockPostgresqlProviderAPI_ListPostgresConfigurations_Call {
-	return &MockPostgresqlProviderAPI_ListPostgresConfigurations_Call{Call: _e.mock.On("ListPostgresConfigurations", ctx, subID, resourceGroup, serverName)}
+func (_e *MockPostgresqlProviderAPI_Expecter) ListFlexiblePostgresFirewallRules(ctx interface{}, subID interface{}, resourceGroup interface{}, serverName interface{}) *MockPostgresqlProviderAPI_ListFlexiblePostgresFirewallRules_Call {
+	return &MockPostgresqlProviderAPI_ListFlexiblePostgresFirewallRules_Call{Call: _e.mock.On("ListFlexiblePostgresFirewallRules", ctx, subID, resourceGroup, serverName)}
 }
 
-func (_c *MockPostgresqlProviderAPI_ListPostgresConfigurations_Call) Run(run func(ctx context.Context, subID string, resourceGroup string, serverName string)) *MockPostgresqlProviderAPI_ListPostgresConfigurations_Call {
+func (_c *MockPostgresqlProviderAPI_ListFlexiblePostgresFirewallRules_Call) Run(run func(ctx context.Context, subID string, resourceGroup string, serverName string)) *MockPostgresqlProviderAPI_ListFlexiblePostgresFirewallRules_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
 	})
 	return _c
 }
 
-func (_c *MockPostgresqlProviderAPI_ListPostgresConfigurations_Call) Return(_a0 []AzureAsset, _a1 error) *MockPostgresqlProviderAPI_ListPostgresConfigurations_Call {
+func (_c *MockPostgresqlProviderAPI_ListFlexiblePostgresFirewallRules_Call) Return(_a0 []AzureAsset, _a1 error) *MockPostgresqlProviderAPI_ListFlexiblePostgresFirewallRules_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockPostgresqlProviderAPI_ListPostgresConfigurations_Call) RunAndReturn(run func(context.Context, string, string, string) ([]AzureAsset, error)) *MockPostgresqlProviderAPI_ListPostgresConfigurations_Call {
+func (_c *MockPostgresqlProviderAPI_ListFlexiblePostgresFirewallRules_Call) RunAndReturn(run func(context.Context, string, string, string) ([]AzureAsset, error)) *MockPostgresqlProviderAPI_ListFlexiblePostgresFirewallRules_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListSinglePostgresConfigurations provides a mock function with given fields: ctx, subID, resourceGroup, serverName
+func (_m *MockPostgresqlProviderAPI) ListSinglePostgresConfigurations(ctx context.Context, subID string, resourceGroup string, serverName string) ([]AzureAsset, error) {
+	ret := _m.Called(ctx, subID, resourceGroup, serverName)
+
+	var r0 []AzureAsset
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]AzureAsset, error)); ok {
+		return rf(ctx, subID, resourceGroup, serverName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []AzureAsset); ok {
+		r0 = rf(ctx, subID, resourceGroup, serverName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]AzureAsset)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, subID, resourceGroup, serverName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockPostgresqlProviderAPI_ListSinglePostgresConfigurations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSinglePostgresConfigurations'
+type MockPostgresqlProviderAPI_ListSinglePostgresConfigurations_Call struct {
+	*mock.Call
+}
+
+// ListSinglePostgresConfigurations is a helper method to define mock.On call
+//   - ctx context.Context
+//   - subID string
+//   - resourceGroup string
+//   - serverName string
+func (_e *MockPostgresqlProviderAPI_Expecter) ListSinglePostgresConfigurations(ctx interface{}, subID interface{}, resourceGroup interface{}, serverName interface{}) *MockPostgresqlProviderAPI_ListSinglePostgresConfigurations_Call {
+	return &MockPostgresqlProviderAPI_ListSinglePostgresConfigurations_Call{Call: _e.mock.On("ListSinglePostgresConfigurations", ctx, subID, resourceGroup, serverName)}
+}
+
+func (_c *MockPostgresqlProviderAPI_ListSinglePostgresConfigurations_Call) Run(run func(ctx context.Context, subID string, resourceGroup string, serverName string)) *MockPostgresqlProviderAPI_ListSinglePostgresConfigurations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *MockPostgresqlProviderAPI_ListSinglePostgresConfigurations_Call) Return(_a0 []AzureAsset, _a1 error) *MockPostgresqlProviderAPI_ListSinglePostgresConfigurations_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockPostgresqlProviderAPI_ListSinglePostgresConfigurations_Call) RunAndReturn(run func(context.Context, string, string, string) ([]AzureAsset, error)) *MockPostgresqlProviderAPI_ListSinglePostgresConfigurations_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListSinglePostgresFirewallRules provides a mock function with given fields: ctx, subID, resourceGroup, serverName
+func (_m *MockPostgresqlProviderAPI) ListSinglePostgresFirewallRules(ctx context.Context, subID string, resourceGroup string, serverName string) ([]AzureAsset, error) {
+	ret := _m.Called(ctx, subID, resourceGroup, serverName)
+
+	var r0 []AzureAsset
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]AzureAsset, error)); ok {
+		return rf(ctx, subID, resourceGroup, serverName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []AzureAsset); ok {
+		r0 = rf(ctx, subID, resourceGroup, serverName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]AzureAsset)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, subID, resourceGroup, serverName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockPostgresqlProviderAPI_ListSinglePostgresFirewallRules_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSinglePostgresFirewallRules'
+type MockPostgresqlProviderAPI_ListSinglePostgresFirewallRules_Call struct {
+	*mock.Call
+}
+
+// ListSinglePostgresFirewallRules is a helper method to define mock.On call
+//   - ctx context.Context
+//   - subID string
+//   - resourceGroup string
+//   - serverName string
+func (_e *MockPostgresqlProviderAPI_Expecter) ListSinglePostgresFirewallRules(ctx interface{}, subID interface{}, resourceGroup interface{}, serverName interface{}) *MockPostgresqlProviderAPI_ListSinglePostgresFirewallRules_Call {
+	return &MockPostgresqlProviderAPI_ListSinglePostgresFirewallRules_Call{Call: _e.mock.On("ListSinglePostgresFirewallRules", ctx, subID, resourceGroup, serverName)}
+}
+
+func (_c *MockPostgresqlProviderAPI_ListSinglePostgresFirewallRules_Call) Run(run func(ctx context.Context, subID string, resourceGroup string, serverName string)) *MockPostgresqlProviderAPI_ListSinglePostgresFirewallRules_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *MockPostgresqlProviderAPI_ListSinglePostgresFirewallRules_Call) Return(_a0 []AzureAsset, _a1 error) *MockPostgresqlProviderAPI_ListSinglePostgresFirewallRules_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockPostgresqlProviderAPI_ListSinglePostgresFirewallRules_Call) RunAndReturn(run func(context.Context, string, string, string) ([]AzureAsset, error)) *MockPostgresqlProviderAPI_ListSinglePostgresFirewallRules_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/resources/providers/azurelib/inventory/postgresql_provider.go
+++ b/resources/providers/azurelib/inventory/postgresql_provider.go
@@ -182,18 +182,18 @@ func (p *psqlProvider) ListSinglePostgresFirewallRules(ctx context.Context, subI
 		}
 
 		assets = append(assets, AzureAsset{
-			Id:       ptrs.Deref(fr.ID),
-			Name:     ptrs.Deref(fr.Name),
+			Id:       pointers.Deref(fr.ID),
+			Name:     pointers.Deref(fr.Name),
 			Location: assetLocationGlobal,
 			Properties: map[string]any{
-				"name":           ptrs.Deref(fr.Name),
-				"startIPAddress": ptrs.Deref(fr.Properties.StartIPAddress),
-				"endIPAddress":   ptrs.Deref(fr.Properties.EndIPAddress),
+				"name":           pointers.Deref(fr.Name),
+				"startIPAddress": pointers.Deref(fr.Properties.StartIPAddress),
+				"endIPAddress":   pointers.Deref(fr.Properties.EndIPAddress),
 			},
 			ResourceGroup:  resourceGroup,
 			SubscriptionId: subID,
 			TenantId:       "",
-			Type:           ptrs.Deref(fr.Type),
+			Type:           pointers.Deref(fr.Type),
 		})
 	}
 
@@ -217,18 +217,18 @@ func (p *psqlProvider) ListFlexiblePostgresFirewallRules(ctx context.Context, su
 		}
 
 		assets = append(assets, AzureAsset{
-			Id:       ptrs.Deref(fr.ID),
-			Name:     ptrs.Deref(fr.Name),
+			Id:       pointers.Deref(fr.ID),
+			Name:     pointers.Deref(fr.Name),
 			Location: assetLocationGlobal,
 			Properties: map[string]any{
-				"name":           ptrs.Deref(fr.Name),
-				"startIPAddress": ptrs.Deref(fr.Properties.StartIPAddress),
-				"endIPAddress":   ptrs.Deref(fr.Properties.EndIPAddress),
+				"name":           pointers.Deref(fr.Name),
+				"startIPAddress": pointers.Deref(fr.Properties.StartIPAddress),
+				"endIPAddress":   pointers.Deref(fr.Properties.EndIPAddress),
 			},
 			ResourceGroup:  resourceGroup,
 			SubscriptionId: subID,
 			TenantId:       "",
-			Type:           ptrs.Deref(fr.Type),
+			Type:           pointers.Deref(fr.Type),
 		})
 	}
 

--- a/resources/providers/azurelib/inventory/postgresql_provider.go
+++ b/resources/providers/azurelib/inventory/postgresql_provider.go
@@ -186,6 +186,7 @@ func (p *psqlProvider) ListSinglePostgresFirewallRules(ctx context.Context, subI
 			Name:     ptrs.Deref(fr.Name),
 			Location: assetLocationGlobal,
 			Properties: map[string]any{
+				"name":           ptrs.Deref(fr.Name),
 				"startIPAddress": ptrs.Deref(fr.Properties.StartIPAddress),
 				"endIPAddress":   ptrs.Deref(fr.Properties.EndIPAddress),
 			},
@@ -220,6 +221,7 @@ func (p *psqlProvider) ListFlexiblePostgresFirewallRules(ctx context.Context, su
 			Name:     ptrs.Deref(fr.Name),
 			Location: assetLocationGlobal,
 			Properties: map[string]any{
+				"name":           ptrs.Deref(fr.Name),
 				"startIPAddress": ptrs.Deref(fr.Properties.StartIPAddress),
 				"endIPAddress":   ptrs.Deref(fr.Properties.EndIPAddress),
 			},

--- a/resources/providers/azurelib/inventory/postgresql_provider_test.go
+++ b/resources/providers/azurelib/inventory/postgresql_provider_test.go
@@ -495,6 +495,7 @@ func singlePsqlFirewallConfigAsset(id, startIpAddr, endIpAddr string) AzureAsset
 		Sku:            nil,
 		Identity:       nil,
 		Properties: map[string]any{
+			"name":           "name-" + id,
 			"startIPAddress": startIpAddr,
 			"endIPAddress":   endIpAddr,
 		},
@@ -541,6 +542,7 @@ func flexPsqlFirewallConfigAsset(id, startIpAddr, endIpAddr string) AzureAsset {
 		Sku:            nil,
 		Identity:       nil,
 		Properties: map[string]any{
+			"name":           "name-" + id,
 			"startIPAddress": startIpAddr,
 			"endIPAddress":   endIpAddr,
 		},

--- a/resources/providers/azurelib/mock_provider_api.go
+++ b/resources/providers/azurelib/mock_provider_api.go
@@ -324,8 +324,8 @@ func (_c *MockProviderAPI_ListFlexiblePostgresConfigurations_Call) RunAndReturn(
 	return _c
 }
 
-// ListPostgresConfigurations provides a mock function with given fields: ctx, subID, resourceGroup, serverName
-func (_m *MockProviderAPI) ListPostgresConfigurations(ctx context.Context, subID string, resourceGroup string, serverName string) ([]inventory.AzureAsset, error) {
+// ListFlexiblePostgresFirewallRules provides a mock function with given fields: ctx, subID, resourceGroup, serverName
+func (_m *MockProviderAPI) ListFlexiblePostgresFirewallRules(ctx context.Context, subID string, resourceGroup string, serverName string) ([]inventory.AzureAsset, error) {
 	ret := _m.Called(ctx, subID, resourceGroup, serverName)
 
 	var r0 []inventory.AzureAsset
@@ -350,33 +350,33 @@ func (_m *MockProviderAPI) ListPostgresConfigurations(ctx context.Context, subID
 	return r0, r1
 }
 
-// MockProviderAPI_ListPostgresConfigurations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListPostgresConfigurations'
-type MockProviderAPI_ListPostgresConfigurations_Call struct {
+// MockProviderAPI_ListFlexiblePostgresFirewallRules_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListFlexiblePostgresFirewallRules'
+type MockProviderAPI_ListFlexiblePostgresFirewallRules_Call struct {
 	*mock.Call
 }
 
-// ListPostgresConfigurations is a helper method to define mock.On call
+// ListFlexiblePostgresFirewallRules is a helper method to define mock.On call
 //   - ctx context.Context
 //   - subID string
 //   - resourceGroup string
 //   - serverName string
-func (_e *MockProviderAPI_Expecter) ListPostgresConfigurations(ctx interface{}, subID interface{}, resourceGroup interface{}, serverName interface{}) *MockProviderAPI_ListPostgresConfigurations_Call {
-	return &MockProviderAPI_ListPostgresConfigurations_Call{Call: _e.mock.On("ListPostgresConfigurations", ctx, subID, resourceGroup, serverName)}
+func (_e *MockProviderAPI_Expecter) ListFlexiblePostgresFirewallRules(ctx interface{}, subID interface{}, resourceGroup interface{}, serverName interface{}) *MockProviderAPI_ListFlexiblePostgresFirewallRules_Call {
+	return &MockProviderAPI_ListFlexiblePostgresFirewallRules_Call{Call: _e.mock.On("ListFlexiblePostgresFirewallRules", ctx, subID, resourceGroup, serverName)}
 }
 
-func (_c *MockProviderAPI_ListPostgresConfigurations_Call) Run(run func(ctx context.Context, subID string, resourceGroup string, serverName string)) *MockProviderAPI_ListPostgresConfigurations_Call {
+func (_c *MockProviderAPI_ListFlexiblePostgresFirewallRules_Call) Run(run func(ctx context.Context, subID string, resourceGroup string, serverName string)) *MockProviderAPI_ListFlexiblePostgresFirewallRules_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
 	})
 	return _c
 }
 
-func (_c *MockProviderAPI_ListPostgresConfigurations_Call) Return(_a0 []inventory.AzureAsset, _a1 error) *MockProviderAPI_ListPostgresConfigurations_Call {
+func (_c *MockProviderAPI_ListFlexiblePostgresFirewallRules_Call) Return(_a0 []inventory.AzureAsset, _a1 error) *MockProviderAPI_ListFlexiblePostgresFirewallRules_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockProviderAPI_ListPostgresConfigurations_Call) RunAndReturn(run func(context.Context, string, string, string) ([]inventory.AzureAsset, error)) *MockProviderAPI_ListPostgresConfigurations_Call {
+func (_c *MockProviderAPI_ListFlexiblePostgresFirewallRules_Call) RunAndReturn(run func(context.Context, string, string, string) ([]inventory.AzureAsset, error)) *MockProviderAPI_ListFlexiblePostgresFirewallRules_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -491,6 +491,120 @@ func (_c *MockProviderAPI_ListSQLTransparentDataEncryptions_Call) Return(_a0 []i
 }
 
 func (_c *MockProviderAPI_ListSQLTransparentDataEncryptions_Call) RunAndReturn(run func(context.Context, string, string, string) ([]inventory.AzureAsset, error)) *MockProviderAPI_ListSQLTransparentDataEncryptions_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListSinglePostgresConfigurations provides a mock function with given fields: ctx, subID, resourceGroup, serverName
+func (_m *MockProviderAPI) ListSinglePostgresConfigurations(ctx context.Context, subID string, resourceGroup string, serverName string) ([]inventory.AzureAsset, error) {
+	ret := _m.Called(ctx, subID, resourceGroup, serverName)
+
+	var r0 []inventory.AzureAsset
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]inventory.AzureAsset, error)); ok {
+		return rf(ctx, subID, resourceGroup, serverName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []inventory.AzureAsset); ok {
+		r0 = rf(ctx, subID, resourceGroup, serverName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]inventory.AzureAsset)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, subID, resourceGroup, serverName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockProviderAPI_ListSinglePostgresConfigurations_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSinglePostgresConfigurations'
+type MockProviderAPI_ListSinglePostgresConfigurations_Call struct {
+	*mock.Call
+}
+
+// ListSinglePostgresConfigurations is a helper method to define mock.On call
+//   - ctx context.Context
+//   - subID string
+//   - resourceGroup string
+//   - serverName string
+func (_e *MockProviderAPI_Expecter) ListSinglePostgresConfigurations(ctx interface{}, subID interface{}, resourceGroup interface{}, serverName interface{}) *MockProviderAPI_ListSinglePostgresConfigurations_Call {
+	return &MockProviderAPI_ListSinglePostgresConfigurations_Call{Call: _e.mock.On("ListSinglePostgresConfigurations", ctx, subID, resourceGroup, serverName)}
+}
+
+func (_c *MockProviderAPI_ListSinglePostgresConfigurations_Call) Run(run func(ctx context.Context, subID string, resourceGroup string, serverName string)) *MockProviderAPI_ListSinglePostgresConfigurations_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *MockProviderAPI_ListSinglePostgresConfigurations_Call) Return(_a0 []inventory.AzureAsset, _a1 error) *MockProviderAPI_ListSinglePostgresConfigurations_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockProviderAPI_ListSinglePostgresConfigurations_Call) RunAndReturn(run func(context.Context, string, string, string) ([]inventory.AzureAsset, error)) *MockProviderAPI_ListSinglePostgresConfigurations_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListSinglePostgresFirewallRules provides a mock function with given fields: ctx, subID, resourceGroup, serverName
+func (_m *MockProviderAPI) ListSinglePostgresFirewallRules(ctx context.Context, subID string, resourceGroup string, serverName string) ([]inventory.AzureAsset, error) {
+	ret := _m.Called(ctx, subID, resourceGroup, serverName)
+
+	var r0 []inventory.AzureAsset
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) ([]inventory.AzureAsset, error)); ok {
+		return rf(ctx, subID, resourceGroup, serverName)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) []inventory.AzureAsset); ok {
+		r0 = rf(ctx, subID, resourceGroup, serverName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]inventory.AzureAsset)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, subID, resourceGroup, serverName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockProviderAPI_ListSinglePostgresFirewallRules_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSinglePostgresFirewallRules'
+type MockProviderAPI_ListSinglePostgresFirewallRules_Call struct {
+	*mock.Call
+}
+
+// ListSinglePostgresFirewallRules is a helper method to define mock.On call
+//   - ctx context.Context
+//   - subID string
+//   - resourceGroup string
+//   - serverName string
+func (_e *MockProviderAPI_Expecter) ListSinglePostgresFirewallRules(ctx interface{}, subID interface{}, resourceGroup interface{}, serverName interface{}) *MockProviderAPI_ListSinglePostgresFirewallRules_Call {
+	return &MockProviderAPI_ListSinglePostgresFirewallRules_Call{Call: _e.mock.On("ListSinglePostgresFirewallRules", ctx, subID, resourceGroup, serverName)}
+}
+
+func (_c *MockProviderAPI_ListSinglePostgresFirewallRules_Call) Run(run func(ctx context.Context, subID string, resourceGroup string, serverName string)) *MockProviderAPI_ListSinglePostgresFirewallRules_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
+	})
+	return _c
+}
+
+func (_c *MockProviderAPI_ListSinglePostgresFirewallRules_Call) Return(_a0 []inventory.AzureAsset, _a1 error) *MockProviderAPI_ListSinglePostgresFirewallRules_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockProviderAPI_ListSinglePostgresFirewallRules_Call) RunAndReturn(run func(context.Context, string, string, string) ([]inventory.AzureAsset, error)) *MockProviderAPI_ListSinglePostgresFirewallRules_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/security-policies/README.md
+++ b/security-policies/README.md
@@ -4,7 +4,7 @@
 [![CIS EKS](https://img.shields.io/badge/CIS-Amazon%20EKS%20(60%25)-FF9900?logo=Amazon+EKS)](RULES.md#eks-cis-benchmark)
 [![CIS AWS](https://img.shields.io/badge/CIS-AWS%20(87%25)-232F3E?logo=Amazon+AWS)](RULES.md#aws-cis-benchmark)
 [![CIS GCP](https://img.shields.io/badge/CIS-GCP%20(85%25)-4285F4?logo=Google+Cloud)](RULES.md#gcp-cis-benchmark)
-[![CIS AZURE](https://img.shields.io/badge/CIS-AZURE%20(37%25)-0078D4?logo=Microsoft+Azure)](RULES.md#azure-cis-benchmark)
+[![CIS AZURE](https://img.shields.io/badge/CIS-AZURE%20(38%25)-0078D4?logo=Microsoft+Azure)](RULES.md#azure-cis-benchmark)
 
 ![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/oren-zohar/a7160df46e48dff45b24096de9302d38/raw/csp-security-policies_coverage.json)
 

--- a/security-policies/RULES.md
+++ b/security-policies/RULES.md
@@ -390,9 +390,9 @@
 
 ## AZURE CIS Benchmark
 
-### 56/151 implemented rules (37%)
+### 57/151 implemented rules (38%)
 
-#### Automated rules: 56/77 (73%)
+#### Automated rules: 57/77 (74%)
 
 #### Manual rules: 0/74 (0%)
 
@@ -489,7 +489,7 @@
 |  [4.3.4](bundle/compliance/cis_azure/rules/cis_4_3_4)  | PostgreSQL Database Server              | Ensure server parameter 'log_disconnections' is set to 'ON' for PostgreSQL Database Server                                                             | :white_check_mark: | Automated |
 |  [4.3.5](bundle/compliance/cis_azure/rules/cis_4_3_5)  | PostgreSQL Database Server              | Ensure server parameter 'connection_throttling' is set to 'ON' for PostgreSQL Database Server                                                          | :white_check_mark: | Automated |
 |  [4.3.6](bundle/compliance/cis_azure/rules/cis_4_3_6)  | PostgreSQL Database Server              | Ensure Server Parameter 'log_retention_days' is greater than 3 days for PostgreSQL Database Server                                                     | :white_check_mark: | Automated |
-|                         4.3.7                          | PostgreSQL Database Server              | Ensure 'Allow access to Azure services' for PostgreSQL Database Server is disabled                                                                     |        :x:         | Automated |
+|  [4.3.7](bundle/compliance/cis_azure/rules/cis_4_3_7)  | PostgreSQL Database Server              | Ensure 'Allow access to Azure services' for PostgreSQL Database Server is disabled                                                                     | :white_check_mark: | Automated |
 |  [4.3.8](bundle/compliance/cis_azure/rules/cis_4_3_8)  | PostgreSQL Database Server              | Ensure 'Infrastructure double encryption' for PostgreSQL Database Server is 'Enabled'                                                                  | :white_check_mark: | Automated |
 |  [4.4.1](bundle/compliance/cis_azure/rules/cis_4_4_1)  | MySQL Database                          | Ensure 'Enforce SSL connection' is set to 'Enabled' for Standard MySQL Database Server                                                                 | :white_check_mark: | Automated |
 |                         4.4.2                          | MySQL Database                          | Ensure 'TLS Version' is set to 'TLSV1.2' for MySQL flexible Database Server                                                                            |        :x:         | Automated |

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_7/data.yaml
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_7/data.yaml
@@ -1,0 +1,59 @@
+metadata:
+  id: eb9e71ae-113b-5631-9e5c-b7fdc0b0666e
+  name: Ensure 'Allow access to Azure services' for PostgreSQL Database Server is
+    disabled
+  profile_applicability: '* Level 1'
+  description: Disable access from Azure services to PostgreSQL Database Server.
+  rationale: |-
+    If access from Azure services is enabled, the server's firewall will accept connections from all Azure resources, including resources not in your subscription.
+    This is usually not a desired configuration.
+    Instead, set up firewall rules to allow access from specific network ranges or VNET rules to allow access from specific virtual networks.
+  audit: |-
+    **From Azure Portal**
+
+    1. Login to Azure Portal using https://portal.azure.com.
+    2. Go to `Azure Database for PostgreSQL servers`.
+    3. For each database, click on `Connection security`.
+    4. Under `Firewall rules`, ensure `Allow access to Azure services` is set to `No`.
+
+    **From Azure CLI**
+
+    Ensure the output of the below command does not include a rule with the name AllowAllWindowsAzureIps or "startIpAddress": "0.0.0.0" & "endIpAddress": "0.0.0.0",
+    ```
+    az postgres server firewall-rule list --resource-group <resourceGroupName> --server <serverName>
+    ```
+  remediation: |-
+    **From Azure Portal**
+
+    1. Login to Azure Portal using https://portal.azure.com.
+    2. Go to `Azure Database for PostgreSQL servers`.
+    3. For each database, click on `Connection security`.
+    4. Under `Firewall rules`, set `Allow access to Azure services` to `No`.
+    5. Click `Save`.
+
+    **From Azure CLI**
+
+    Use the below command to delete the AllowAllWindowsAzureIps rule for PostgreSQL Database.
+    ```
+    az postgres server firewall-rule delete --name AllowAllWindowsAzureIps --resource-group <resourceGroupName> --server-name <serverName>
+    ```
+  impact: ''
+  default_value: ''
+  references: |-
+    1. https://docs.microsoft.com/en-us/azure/postgresql/concepts-firewall-rules
+    2. https://docs.microsoft.com/en-us/azure/postgresql/howto-manage-firewall-using-cli
+    3. https://docs.microsoft.com/en-us/security/benchmark/azure/security-controls-v3-network-security#ns-1-establish-network-segmentation-boundaries
+    4. https://docs.microsoft.com/en-us/security/benchmark/azure/security-controls-v3-network-security#ns-6-deploy-web-application-firewall
+  section: PostgreSQL Database Server
+  version: '1.0'
+  tags:
+  - CIS
+  - AZURE
+  - CIS 4.3.7
+  - PostgreSQL Database Server
+  benchmark:
+    name: CIS Microsoft Azure Foundations
+    version: v2.0.0
+    id: cis_azure
+    rule_number: 4.3.7
+    posture_type: cspm

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_7/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_7/rule.rego
@@ -1,0 +1,33 @@
+package compliance.cis_azure.rules.cis_4_3_7
+
+import data.compliance.lib.common
+import data.compliance.policy.azure.data_adapter
+import future.keywords.if
+
+finding = result if {
+	# filter
+	data_adapter.is_postgresql_server_db
+
+	# set result
+	result := common.generate_result_without_expected(
+		common.calculate_result(firewall_rules_properly_configured),
+		{"Resource": data_adapter.resource},
+	)
+}
+
+default firewall_rules_properly_configured = false
+
+firewall_rules_properly_configured if {
+	not has_allow_all_firewall_rule
+}
+
+has_allow_all_firewall_rule if {
+	some i
+	data_adapter.resource.extension.psqlFirewallRules[i].name == "AllowAllWindowsAzureIps"
+}
+
+has_allow_all_firewall_rule if {
+	some i
+	data_adapter.resource.extension.psqlFirewallRules[i].startIPAddress == "0.0.0.0"
+	data_adapter.resource.extension.psqlFirewallRules[i].endIPAddress == "0.0.0.0"
+}

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_7/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_7/test.rego
@@ -1,0 +1,107 @@
+package compliance.cis_azure.rules.cis_4_3_7
+
+import data.cis_azure.test_data
+import data.compliance.policy.azure.data_adapter
+import data.lib.test
+import future.keywords.if
+
+# regal ignore:rule-length
+test_violation if {
+	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [{
+		"name": "AllowAllWindowsAzureIps",
+		"startIPAddress": "196.203.255.0",
+		"endIPAddress": "196.203.255.254",
+	}]})
+
+	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [{
+		"name": "AllowAllWindowsAzureIps",
+		"startIPAddress": "0.0.0.0",
+		"endIPAddress": "0.0.0.0",
+	}]})
+
+	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [{
+		"name": "randomName",
+		"startIPAddress": "0.0.0.0",
+		"endIPAddress": "0.0.0.0",
+	}]})
+
+	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [
+		{
+			"name": "randomName",
+			"startIPAddress": "0.0.0.0",
+			"endIPAddress": "0.0.0.0",
+		},
+		{
+			"name": "randomName",
+			"startIPAddress": "196.203.255.0",
+			"endIPAddress": "196.203.255.254",
+		},
+	]})
+
+	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [
+		{
+			"name": "AllowAllWindowsAzureIps",
+			"startIPAddress": "0.0.0.0",
+			"endIPAddress": "0.0.0.0",
+		},
+		{
+			"name": "randomName",
+			"startIPAddress": "196.203.255.0",
+			"endIPAddress": "196.203.255.254",
+		},
+	]})
+
+	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [
+		{
+			"name": "randomName",
+			"startIPAddress": "196.203.253.0",
+			"endIPAddress": "196.203.253.254",
+		},
+		{
+			"name": "AllowAllWindowsAzureIps",
+			"startIPAddress": "196.203.255.0",
+			"endIPAddress": "196.203.255.254",
+		},
+	]})
+}
+
+test_pass if {
+	eval_pass with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [{
+		"name": "randomName",
+		"startIPAddress": "196.203.255.0",
+		"endIPAddress": "196.203.255.254",
+	}]})
+
+	eval_pass with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [
+		{
+			"name": "randomName",
+			"startIPAddress": "196.203.255.0",
+			"endIPAddress": "196.203.255.254",
+		},
+		{
+			"name": "randomName2",
+			"startIPAddress": "196.203.200.0",
+			"endIPAddress": "196.203.200.254",
+		},
+	]})
+
+	eval_pass with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": []})
+
+	eval_pass with input as test_data.generate_postgresql_server_with_extension({})
+}
+
+test_not_evaluated if {
+	not_eval with input as test_data.not_eval_non_exist_type
+}
+
+eval_fail if {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass if {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval if {
+	not finding with data.benchmark_data_adapter as data_adapter
+}


### PR DESCRIPTION
### Summary of your changes

Implement CIS Azure 4.3.7 Ensure 'Allow access to Azure services' for PostgreSQL Database Server is disabled

#### Test results with flexible

✅  When the allow access to azure service is _not enabled_ it **passes**
![image](https://github.com/elastic/cloudbeat/assets/5350001/f5b7bba2-5543-45e0-9d2b-966153c40e73)

✅  When the allow access to azure service is _enabled_ it **fails**
![image](https://github.com/elastic/cloudbeat/assets/5350001/60eb61c7-e84f-4c3a-a227-9fb359358989)

On the flexible UI you enabled through: 
![image](https://github.com/elastic/cloudbeat/assets/5350001/c64b3c6f-bedd-4d13-b900-2fbd03111ec8)


#### Test results with single

✅  When the allow access to azure service is _not enabled_ it **passes**
![image](https://github.com/elastic/cloudbeat/assets/5350001/1f6cab4e-215f-496b-9613-316c7faf0b90)

✅  When the allow access to azure service is _enabled_ it **fails**
![image](https://github.com/elastic/cloudbeat/assets/5350001/498de923-29b2-40ef-8320-e10f1feb4a5d)

On the single UI you enable through
![image](https://github.com/elastic/cloudbeat/assets/5350001/2fd7a979-1ea2-47bc-b4c9-5442aa0959e1)


### Related Issues
- Related https://github.com/elastic/cloudbeat/issues/1417

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [x] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [x] Add relevant unit tests
- [x] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
