### PR TITLE
Refactor extensions to use full asset instead of properties only

### DIFF
--- a/resources/fetching/fetchers/azure/assets_enricher.go
+++ b/resources/fetching/fetchers/azure/assets_enricher.go
@@ -41,16 +41,3 @@ func initEnrichers(provider azurelib.ProviderAPI) []AssetsEnricher {
 
 	return enrichers
 }
-
-func enrichExtension(a *inventory.AzureAsset, key string, assets []inventory.AzureAsset) {
-	if len(assets) == 0 {
-		return
-	}
-
-	props := make([]map[string]any, 0, len(assets))
-	for _, asset := range assets {
-		props = append(props, asset.Properties)
-	}
-
-	a.AddExtension(key, props)
-}

--- a/resources/fetching/fetchers/azure/assets_enricher_mysql.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_mysql.go
@@ -48,15 +48,15 @@ func (e mysqlAssetEnricher) Enrich(ctx context.Context, _ cycle.Metadata, assets
 }
 
 func (e mysqlAssetEnricher) enrichTLSVersion(ctx context.Context, asset *inventory.AzureAsset) error {
-	tlsVersion, err := e.provider.GetFlexibleTLSVersionConfiguration(ctx, asset.SubscriptionId, asset.ResourceGroup, asset.Name)
+	configs, err := e.provider.GetFlexibleTLSVersionConfiguration(ctx, asset.SubscriptionId, asset.ResourceGroup, asset.Name)
 	if err != nil {
 		return err
 	}
 
-	if len(tlsVersion) == 0 {
+	if len(configs) == 0 {
 		return nil
 	}
 
-	enrichExtension(asset, inventory.ExtensionMysqlConfigurations, tlsVersion)
+	asset.AddExtension(inventory.ExtensionMysqlConfigurations, configs)
 	return nil
 }

--- a/resources/fetching/fetchers/azure/assets_enricher_mysql_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_mysql_test.go
@@ -46,8 +46,8 @@ func TestMysqlAssetEnricher_Enrich(t *testing.T) {
 				mockFlexibleMysqlAsset("mysql-1", "mysql-1"),
 				mockPostgresAsset("psql-1", "psql"),
 				addExtension(mockFlexibleMysqlAsset("mysql-2", "mysql-2"), map[string]any{
-					inventory.ExtensionMysqlConfigurations: []map[string]any{
-						flexMysqlTLSVersionProps("tlsv1.2"),
+					inventory.ExtensionMysqlConfigurations: []inventory.AzureAsset{
+						mockFlexMysqlTLSVersionConfig("mysql-2/tls_version", "tlsv1.2"),
 					},
 				}),
 			},
@@ -66,20 +66,20 @@ func TestMysqlAssetEnricher_Enrich(t *testing.T) {
 			},
 			expected: []inventory.AzureAsset{
 				addExtension(mockFlexibleMysqlAsset("mysql-1", "mysql-1"), map[string]any{
-					inventory.ExtensionMysqlConfigurations: []map[string]any{
-						flexMysqlTLSVersionProps("tlsv1.2"),
+					inventory.ExtensionMysqlConfigurations: []inventory.AzureAsset{
+						mockFlexMysqlTLSVersionConfig("mysql-1/tls_version", "tlsv1.2"),
 					},
 				}),
 				addExtension(mockFlexibleMysqlAsset("mysql-2", "mysql-2"), map[string]any{
-					inventory.ExtensionMysqlConfigurations: []map[string]any{
-						flexMysqlTLSVersionProps("tlsv1.3"),
+					inventory.ExtensionMysqlConfigurations: []inventory.AzureAsset{
+						mockFlexMysqlTLSVersionConfig("mysql-2/tls_version", "tlsv1.3"),
 					},
 				}),
 				mockFlexibleMysqlAsset("mysql-3", "mysql-3"),
 			},
 			expectError: false,
 			configRes: map[string]enricherResponse{
-				"mysql-1": assetRes(mockFlexMysqlTLSVersionConfig("mysql-2/tls_version", "tlsv1.2")),
+				"mysql-1": assetRes(mockFlexMysqlTLSVersionConfig("mysql-1/tls_version", "tlsv1.2")),
 				"mysql-2": assetRes(mockFlexMysqlTLSVersionConfig("mysql-2/tls_version", "tlsv1.3")),
 				"mysql-3": assetRes(),
 			},
@@ -118,20 +118,15 @@ func mockFlexMysqlTLSVersionConfig(id, tlsVersion string) inventory.AzureAsset {
 		ResourceGroup:  "group",
 		Name:           "tls_version",
 		Type:           inventory.FlexibleMySQLDBAssetType + "/configuration",
-		Properties:     flexMysqlTLSVersionProps(tlsVersion),
+		Properties: map[string]any{
+			"name":         "tls_version",
+			"source":       "system-default",
+			"value":        tlsVersion,
+			"dataType":     "string",
+			"defaultValue": "",
+		},
 	}
 }
-
-func flexMysqlTLSVersionProps(tlsVersion string) map[string]any {
-	return map[string]any{
-		"name":         "tls_version",
-		"source":       "system-default",
-		"value":        tlsVersion,
-		"dataType":     "string",
-		"defaultValue": "",
-	}
-}
-
 func mockFlexibleMysqlAsset(id string, name string) inventory.AzureAsset {
 	return inventory.AzureAsset{
 		Id:             id,

--- a/resources/fetching/fetchers/azure/assets_enricher_postgresql.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_postgresql.go
@@ -83,7 +83,11 @@ func (p postgresqlEnricher) enrichFirewallRules(ctx context.Context, a *inventor
 		return err
 	}
 
-	enrichExtension(a, inventory.ExtensionPostgresqlFirewallRules, configs)
+	if len(configs) == 0 {
+		return nil
+	}
+
+	a.AddExtension(inventory.ExtensionPostgresqlFirewallRules, configs)
 	return nil
 }
 

--- a/resources/fetching/fetchers/azure/assets_enricher_postgresql.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_postgresql.go
@@ -61,7 +61,11 @@ func (p postgresqlEnricher) enrichConfigurations(ctx context.Context, a *invento
 		return err
 	}
 
-	enrichExtension(a, inventory.ExtensionPostgresqlConfigurations, configs)
+	if len(configs) == 0 {
+		return nil
+	}
+
+	a.AddExtension(inventory.ExtensionPostgresqlConfigurations, configs)
 	return nil
 }
 

--- a/resources/fetching/fetchers/azure/assets_enricher_postgresql_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_postgresql_test.go
@@ -59,9 +59,9 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 			},
 			expected: []inventory.AzureAsset{
 				addExtension(mockPostgresAsset("id1", "psql-a"), map[string]any{
-					inventory.ExtensionPostgresqlConfigurations: []map[string]any{
-						psqlConfigProps("log_checkpoints", "on"),
-						psqlConfigProps("log_connections", "off"),
+					inventory.ExtensionPostgresqlConfigurations: []inventory.AzureAsset{
+						mockPostgresConfigAsset("log_checkpoints", psqlConfigProps("on")),
+						mockPostgresConfigAsset("log_connections", psqlConfigProps("off")),
 					},
 				}),
 				mockOther("id2"),
@@ -69,8 +69,8 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 			},
 			configRes: map[string]psqlEnricherResponse{
 				"psql-a": {assetRes(
-					mockPostgresConfigAsset("conf1", psqlConfigProps("log_checkpoints", "on")),
-					mockPostgresConfigAsset("conf2", psqlConfigProps("log_connections", "off")),
+					mockPostgresConfigAsset("log_checkpoints", psqlConfigProps("on")),
+					mockPostgresConfigAsset("log_connections", psqlConfigProps("off")),
 				), psqlServerTypeSingle},
 				"psql-b": {
 					errorRes(errors.New("error")), psqlServerTypeSingle,
@@ -116,9 +116,9 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 			},
 			expected: []inventory.AzureAsset{
 				addExtension(mockPostgresAsset("id1", "psql-a"), map[string]any{
-					inventory.ExtensionPostgresqlConfigurations: []map[string]any{
-						psqlConfigProps("log_checkpoints", "on"),
-						psqlConfigProps("log_connections", "off"),
+					inventory.ExtensionPostgresqlConfigurations: []inventory.AzureAsset{
+						mockPostgresConfigAsset("log_checkpoints", psqlConfigProps("on")),
+						mockPostgresConfigAsset("log_connections", psqlConfigProps("off")),
 					},
 					inventory.ExtensionPostgresqlFirewallRules: []map[string]any{
 						psqlFirewallRuleProps("name-fr1", "0.0.0.0", "196.198.198.256"),
@@ -126,17 +126,17 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 				}),
 				mockOther("id2"),
 				addExtension(mockPostgresAsset("id3", "psql-b"), map[string]any{
-					inventory.ExtensionPostgresqlConfigurations: []map[string]any{
-						psqlConfigProps("log_disconnections", "on"),
-						psqlConfigProps("connection_throttling", "off"),
+					inventory.ExtensionPostgresqlConfigurations: []inventory.AzureAsset{
+						mockPostgresConfigAsset("log_disconnections", psqlConfigProps("on")),
+						mockPostgresConfigAsset("connection_throttling", psqlConfigProps("off")),
 					},
 					inventory.ExtensionPostgresqlFirewallRules: []map[string]any{
 						psqlFirewallRuleProps("name-fr2", "0.0.0.1", "196.198.198.255"),
 					},
 				}),
 				addExtension(mockFlexiblePostgresAsset("id4", "flex-psql-a"), map[string]any{
-					inventory.ExtensionPostgresqlConfigurations: []map[string]any{
-						psqlConfigProps("log_disconnections", "on"),
+					inventory.ExtensionPostgresqlConfigurations: []inventory.AzureAsset{
+						mockPostgresConfigAsset("log_disconnections", psqlConfigProps("on")),
 					},
 					inventory.ExtensionPostgresqlFirewallRules: []map[string]any{
 						psqlFirewallRuleProps("name-fr3", "0.0.0.2", "196.198.198.254"),
@@ -146,19 +146,19 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 			configRes: map[string]psqlEnricherResponse{
 				"psql-a": {
 					assetRes(
-						mockPostgresConfigAsset("conf1", psqlConfigProps("log_checkpoints", "on")),
-						mockPostgresConfigAsset("conf2", psqlConfigProps("log_connections", "off"))),
+						mockPostgresConfigAsset("log_checkpoints", psqlConfigProps("on")),
+						mockPostgresConfigAsset("log_connections", psqlConfigProps("off"))),
 					psqlServerTypeSingle,
 				},
 				"psql-b": {
 					assetRes(
-						mockPostgresConfigAsset("conf1", psqlConfigProps("log_disconnections", "on")),
-						mockPostgresConfigAsset("conf2", psqlConfigProps("connection_throttling", "off")),
+						mockPostgresConfigAsset("log_disconnections", psqlConfigProps("on")),
+						mockPostgresConfigAsset("connection_throttling", psqlConfigProps("off")),
 					), psqlServerTypeSingle,
 				},
 				"flex-psql-a": {
 					assetRes(
-						mockPostgresConfigAsset("conf1", psqlConfigProps("log_disconnections", "on"))),
+						mockPostgresConfigAsset("log_disconnections", psqlConfigProps("on"))),
 					psqlServerTypeFlexible,
 				},
 			},
@@ -235,9 +235,8 @@ func mockPostgresFirewallRuleAsset(id string, props map[string]any) inventory.Az
 	return a
 }
 
-func psqlConfigProps(name, value string) map[string]any {
+func psqlConfigProps(value string) map[string]any {
 	return map[string]any{
-		"name":         name,
 		"source":       "system-default",
 		"value":        value,
 		"dataType":     "Boolean",

--- a/resources/fetching/fetchers/azure/assets_enricher_postgresql_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_postgresql_test.go
@@ -90,8 +90,8 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 			},
 			expected: []inventory.AzureAsset{
 				addExtension(mockPostgresAsset("id1", "psql-a"), map[string]any{
-					inventory.ExtensionPostgresqlFirewallRules: []map[string]any{
-						psqlFirewallRuleProps("name-fr1", "0.0.0.0", "196.198.198.256"),
+					inventory.ExtensionPostgresqlFirewallRules: []inventory.AzureAsset{
+						mockPostgresFirewallRuleAsset("fr1", psqlFirewallRuleProps("name-fr1", "0.0.0.0", "196.198.198.256")),
 					},
 				}),
 				mockOther("id2"),
@@ -120,8 +120,8 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 						mockPostgresConfigAsset("log_checkpoints", psqlConfigProps("on")),
 						mockPostgresConfigAsset("log_connections", psqlConfigProps("off")),
 					},
-					inventory.ExtensionPostgresqlFirewallRules: []map[string]any{
-						psqlFirewallRuleProps("name-fr1", "0.0.0.0", "196.198.198.256"),
+					inventory.ExtensionPostgresqlFirewallRules: []inventory.AzureAsset{
+						mockPostgresFirewallRuleAsset("fr1", psqlFirewallRuleProps("name-fr1", "0.0.0.0", "196.198.198.256")),
 					},
 				}),
 				mockOther("id2"),
@@ -130,16 +130,16 @@ func TestPostgresqlEnricher_Enrich(t *testing.T) {
 						mockPostgresConfigAsset("log_disconnections", psqlConfigProps("on")),
 						mockPostgresConfigAsset("connection_throttling", psqlConfigProps("off")),
 					},
-					inventory.ExtensionPostgresqlFirewallRules: []map[string]any{
-						psqlFirewallRuleProps("name-fr2", "0.0.0.1", "196.198.198.255"),
+					inventory.ExtensionPostgresqlFirewallRules: []inventory.AzureAsset{
+						mockPostgresFirewallRuleAsset("fr2", psqlFirewallRuleProps("name-fr2", "0.0.0.1", "196.198.198.255")),
 					},
 				}),
 				addExtension(mockFlexiblePostgresAsset("id4", "flex-psql-a"), map[string]any{
 					inventory.ExtensionPostgresqlConfigurations: []inventory.AzureAsset{
 						mockPostgresConfigAsset("log_disconnections", psqlConfigProps("on")),
 					},
-					inventory.ExtensionPostgresqlFirewallRules: []map[string]any{
-						psqlFirewallRuleProps("name-fr3", "0.0.0.2", "196.198.198.254"),
+					inventory.ExtensionPostgresqlFirewallRules: []inventory.AzureAsset{
+						mockPostgresFirewallRuleAsset("fr3", psqlFirewallRuleProps("name-fr3", "0.0.0.2", "196.198.198.254")),
 					},
 				}),
 			},

--- a/resources/fetching/fetchers/azure/assets_enricher_sql_server.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_sql_server.go
@@ -63,7 +63,11 @@ func (s sqlServerEnricher) enrichSQLEncryptionProtector(ctx context.Context, a *
 		return err
 	}
 
-	enrichExtension(a, inventory.ExtensionSQLEncryptionProtectors, encryptProtectors)
+	if len(encryptProtectors) == 0 {
+		return nil
+	}
+
+	a.AddExtension(inventory.ExtensionSQLEncryptionProtectors, encryptProtectors)
 	return nil
 }
 

--- a/resources/fetching/fetchers/azure/assets_enricher_sql_server.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_sql_server.go
@@ -87,7 +87,11 @@ func (s sqlServerEnricher) enrichTransparentDataEncryption(ctx context.Context, 
 		return err
 	}
 
-	enrichExtension(a, inventory.ExtensionSQLTransparentDataEncryptions, tdes)
+	if len(tdes) == 0 {
+		return nil
+	}
+
+	a.AddExtension(inventory.ExtensionSQLTransparentDataEncryptions, tdes)
 	return nil
 }
 

--- a/resources/fetching/fetchers/azure/assets_enricher_sql_server.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_sql_server.go
@@ -97,6 +97,10 @@ func (s sqlServerEnricher) enrichAdvancedThreatProtectionSettings(ctx context.Co
 		return err
 	}
 
-	enrichExtension(a, inventory.ExtensionSQLAdvancedThreatProtectionSettings, settings)
+	if len(settings) == 0 {
+		return nil
+	}
+
+	a.AddExtension(inventory.ExtensionSQLAdvancedThreatProtectionSettings, settings)
 	return nil
 }

--- a/resources/fetching/fetchers/azure/assets_enricher_sql_server.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_sql_server.go
@@ -77,7 +77,7 @@ func (s sqlServerEnricher) enrichSQLBlobAuditPolicy(ctx context.Context, a *inve
 		return nil
 	}
 
-	a.AddExtension(inventory.ExtensionSQLBlobAuditPolicy, policy[0].Properties)
+	a.AddExtension(inventory.ExtensionSQLBlobAuditPolicy, policy[0])
 	return nil
 }
 

--- a/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
@@ -235,7 +235,7 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 				mockSQLServer("id1", "serverName1"),
 				addExtension(mockSQLServer("id2", "serverName2"), map[string]any{
 					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{epProps("serverKey1", true)},
-					inventory.ExtensionSQLBlobAuditPolicy:      bapProps("Enabled"),
+					inventory.ExtensionSQLBlobAuditPolicy:      mockBlobAuditingPolicies("ep1", bapProps("Enabled")),
 				}),
 			},
 			epRes: map[string]enricherResponse{
@@ -262,7 +262,7 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			expected: []inventory.AzureAsset{
 				addExtension(mockSQLServer("id1", "serverName1"), map[string]any{
 					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{epProps("serverKey1", true)},
-					inventory.ExtensionSQLBlobAuditPolicy:      bapProps("Disabled"),
+					inventory.ExtensionSQLBlobAuditPolicy:      mockBlobAuditingPolicies("ep1", bapProps("Disabled")),
 					inventory.ExtensionSQLTransparentDataEncryptions: []inventory.AzureAsset{
 						mockTransparentDataEncryption("tde1", tdeProps("Enabled")),
 					},

--- a/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
@@ -49,7 +49,9 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			},
 			expected: []inventory.AzureAsset{
 				addExtension(mockSQLServer("id1", "serverName1"), map[string]any{
-					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{epProps("serverKey1", true)},
+					inventory.ExtensionSQLEncryptionProtectors: []inventory.AzureAsset{
+						mockEncryptionProtector("ep1", epProps("serverKey1", true)),
+					},
 				}),
 				mockOther("id4"),
 				mockSQLServer("id2", "serverName2"),
@@ -77,9 +79,9 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			},
 			expected: []inventory.AzureAsset{
 				addExtension(mockSQLServer("id1", "serverName1"), map[string]any{
-					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{
-						epProps("serverKey1", true),
-						epProps("serverKey2", false),
+					inventory.ExtensionSQLEncryptionProtectors: []inventory.AzureAsset{
+						mockEncryptionProtector("ep1", epProps("serverKey1", true)),
+						mockEncryptionProtector("ep2", epProps("serverKey2", false)),
 					},
 				}),
 			},
@@ -107,8 +109,8 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			expected: []inventory.AzureAsset{
 				mockSQLServer("id1", "serverName1"),
 				addExtension(mockSQLServer("id2", "serverName2"), map[string]any{
-					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{
-						epProps("serverKey1", true),
+					inventory.ExtensionSQLEncryptionProtectors: []inventory.AzureAsset{
+						mockEncryptionProtector("ep1", epProps("serverKey1", true)),
 					},
 				}),
 			},
@@ -138,8 +140,8 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			expected: []inventory.AzureAsset{
 				mockSQLServer("id1", "serverName1"),
 				addExtension(mockSQLServer("id2", "serverName2"), map[string]any{
-					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{
-						epProps("serverKey1", true),
+					inventory.ExtensionSQLEncryptionProtectors: []inventory.AzureAsset{
+						mockEncryptionProtector("ep1", epProps("serverKey1", true)),
 					},
 				}),
 			},
@@ -169,8 +171,8 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			expected: []inventory.AzureAsset{
 				mockSQLServer("id1", "serverName1"),
 				addExtension(mockSQLServer("id2", "serverName2"), map[string]any{
-					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{
-						epProps("serverKey1", true),
+					inventory.ExtensionSQLEncryptionProtectors: []inventory.AzureAsset{
+						mockEncryptionProtector("ep1", epProps("serverKey1", true)),
 					},
 				}),
 			},
@@ -234,8 +236,10 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			expected: []inventory.AzureAsset{
 				mockSQLServer("id1", "serverName1"),
 				addExtension(mockSQLServer("id2", "serverName2"), map[string]any{
-					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{epProps("serverKey1", true)},
-					inventory.ExtensionSQLBlobAuditPolicy:      mockBlobAuditingPolicies("ep1", bapProps("Enabled")),
+					inventory.ExtensionSQLEncryptionProtectors: []inventory.AzureAsset{
+						mockEncryptionProtector("ep1", epProps("serverKey1", true)),
+					},
+					inventory.ExtensionSQLBlobAuditPolicy: mockBlobAuditingPolicies("ep1", bapProps("Enabled")),
 				}),
 			},
 			epRes: map[string]enricherResponse{
@@ -261,8 +265,10 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			},
 			expected: []inventory.AzureAsset{
 				addExtension(mockSQLServer("id1", "serverName1"), map[string]any{
-					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{epProps("serverKey1", true)},
-					inventory.ExtensionSQLBlobAuditPolicy:      mockBlobAuditingPolicies("ep1", bapProps("Disabled")),
+					inventory.ExtensionSQLEncryptionProtectors: []inventory.AzureAsset{
+						mockEncryptionProtector("ep1", epProps("serverKey1", true)),
+					},
+					inventory.ExtensionSQLBlobAuditPolicy: mockBlobAuditingPolicies("ep1", bapProps("Disabled")),
 					inventory.ExtensionSQLTransparentDataEncryptions: []inventory.AzureAsset{
 						mockTransparentDataEncryption("tde1", tdeProps("Enabled")),
 					},

--- a/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
@@ -261,10 +261,12 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			},
 			expected: []inventory.AzureAsset{
 				addExtension(mockSQLServer("id1", "serverName1"), map[string]any{
-					inventory.ExtensionSQLEncryptionProtectors:             []map[string]any{epProps("serverKey1", true)},
-					inventory.ExtensionSQLBlobAuditPolicy:                  bapProps("Disabled"),
-					inventory.ExtensionSQLTransparentDataEncryptions:       []map[string]any{tdeProps("Enabled")},
-					inventory.ExtensionSQLAdvancedThreatProtectionSettings: []map[string]any{threatProtectionPros("Enabled")},
+					inventory.ExtensionSQLEncryptionProtectors:       []map[string]any{epProps("serverKey1", true)},
+					inventory.ExtensionSQLBlobAuditPolicy:            bapProps("Disabled"),
+					inventory.ExtensionSQLTransparentDataEncryptions: []map[string]any{tdeProps("Enabled")},
+					inventory.ExtensionSQLAdvancedThreatProtectionSettings: []inventory.AzureAsset{
+						mockThreatProtection("tde1", threatProtectionPros("Enabled")),
+					},
 				}),
 			},
 			epRes: map[string]enricherResponse{

--- a/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
@@ -198,9 +198,9 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			},
 			expected: []inventory.AzureAsset{
 				addExtension(mockSQLServer("id1", "serverName1"), map[string]any{
-					inventory.ExtensionSQLTransparentDataEncryptions: []map[string]any{
-						tdeProps("Enabled"),
-						tdeProps("Disabled"),
+					inventory.ExtensionSQLTransparentDataEncryptions: []inventory.AzureAsset{
+						mockTransparentDataEncryption("tde1", tdeProps("Enabled")),
+						mockTransparentDataEncryption("tde2", tdeProps("Disabled")),
 					},
 				}),
 				mockSQLServer("id2", "serverName2"),
@@ -261,9 +261,11 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			},
 			expected: []inventory.AzureAsset{
 				addExtension(mockSQLServer("id1", "serverName1"), map[string]any{
-					inventory.ExtensionSQLEncryptionProtectors:       []map[string]any{epProps("serverKey1", true)},
-					inventory.ExtensionSQLBlobAuditPolicy:            bapProps("Disabled"),
-					inventory.ExtensionSQLTransparentDataEncryptions: []map[string]any{tdeProps("Enabled")},
+					inventory.ExtensionSQLEncryptionProtectors: []map[string]any{epProps("serverKey1", true)},
+					inventory.ExtensionSQLBlobAuditPolicy:      bapProps("Disabled"),
+					inventory.ExtensionSQLTransparentDataEncryptions: []inventory.AzureAsset{
+						mockTransparentDataEncryption("tde1", tdeProps("Enabled")),
+					},
 					inventory.ExtensionSQLAdvancedThreatProtectionSettings: []inventory.AzureAsset{
 						mockThreatProtection("tde1", threatProtectionPros("Enabled")),
 					},

--- a/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
+++ b/resources/fetching/fetchers/azure/assets_enricher_sql_server_test.go
@@ -239,7 +239,7 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 					inventory.ExtensionSQLEncryptionProtectors: []inventory.AzureAsset{
 						mockEncryptionProtector("ep1", epProps("serverKey1", true)),
 					},
-					inventory.ExtensionSQLBlobAuditPolicy: mockBlobAuditingPolicies("ep1", bapProps("Enabled")),
+					inventory.ExtensionSQLBlobAuditPolicy: mockBlobAuditingPolicies("ep2", bapProps("Enabled")),
 				}),
 			},
 			epRes: map[string]enricherResponse{
@@ -248,7 +248,7 @@ func TestSQLServerEnricher_Enrich(t *testing.T) {
 			},
 			bapRes: map[string]enricherResponse{
 				"serverName1": noRes(),
-				"serverName2": assetRes(mockBlobAuditingPolicies("ep1", bapProps("Enabled"))),
+				"serverName2": assetRes(mockBlobAuditingPolicies("ep2", bapProps("Enabled"))),
 			},
 			tdeRes: map[string]enricherResponse{
 				"serverName1": noRes(),

--- a/resources/providers/azurelib/inventory/mysql_provider.go
+++ b/resources/providers/azurelib/inventory/mysql_provider.go
@@ -87,7 +87,6 @@ func (p *mysqlProvider) GetFlexibleTLSVersionConfiguration(ctx context.Context, 
 			SubscriptionId: subID,
 			Location:       assetLocationGlobal,
 			Properties: map[string]any{
-				"name":         pointers.Deref(tlsVersion.Name),
 				"source":       string(pointers.Deref(tlsVersion.Properties.Source)),
 				"value":        strings.ToLower(pointers.Deref(tlsVersion.Properties.Value)),
 				"dataType":     pointers.Deref(tlsVersion.Properties.DataType),

--- a/resources/providers/azurelib/inventory/mysql_provider_test.go
+++ b/resources/providers/azurelib/inventory/mysql_provider_test.go
@@ -89,7 +89,6 @@ func TestMysqlProvider_GetFlexibleTLSVersionConfiguration(t *testing.T) {
 					SubscriptionId: "subscription",
 					ResourceGroup:  "resource",
 					Properties: map[string]any{
-						"name":         "tls_version",
 						"source":       "system-default",
 						"value":        "tlsv1.2",
 						"dataType":     "string",

--- a/resources/providers/azurelib/inventory/postgresql_provider.go
+++ b/resources/providers/azurelib/inventory/postgresql_provider.go
@@ -184,7 +184,6 @@ func (p *psqlProvider) ListSinglePostgresFirewallRules(ctx context.Context, subI
 			Name:     pointers.Deref(fr.Name),
 			Location: assetLocationGlobal,
 			Properties: map[string]any{
-				"name":           pointers.Deref(fr.Name),
 				"startIPAddress": pointers.Deref(fr.Properties.StartIPAddress),
 				"endIPAddress":   pointers.Deref(fr.Properties.EndIPAddress),
 			},
@@ -219,7 +218,6 @@ func (p *psqlProvider) ListFlexiblePostgresFirewallRules(ctx context.Context, su
 			Name:     pointers.Deref(fr.Name),
 			Location: assetLocationGlobal,
 			Properties: map[string]any{
-				"name":           pointers.Deref(fr.Name),
 				"startIPAddress": pointers.Deref(fr.Properties.StartIPAddress),
 				"endIPAddress":   pointers.Deref(fr.Properties.EndIPAddress),
 			},

--- a/resources/providers/azurelib/inventory/postgresql_provider.go
+++ b/resources/providers/azurelib/inventory/postgresql_provider.go
@@ -112,7 +112,6 @@ func (p *psqlProvider) ListSinglePostgresConfigurations(ctx context.Context, sub
 			Name:     pointers.Deref(c.Name),
 			Location: assetLocationGlobal,
 			Properties: map[string]any{
-				"name":         pointers.Deref(c.Name),
 				"source":       pointers.Deref(c.Properties.Source),
 				"value":        strings.ToLower(pointers.Deref(c.Properties.Value)),
 				"dataType":     pointers.Deref(c.Properties.DataType),
@@ -149,7 +148,6 @@ func (p *psqlProvider) ListFlexiblePostgresConfigurations(ctx context.Context, s
 			Name:     pointers.Deref(c.Name),
 			Location: assetLocationGlobal,
 			Properties: map[string]any{
-				"name":         pointers.Deref(c.Name),
 				"source":       pointers.Deref(c.Properties.Source),
 				"value":        strings.ToLower(pointers.Deref(c.Properties.Value)),
 				"dataType":     string(pointers.Deref(c.Properties.DataType)),

--- a/resources/providers/azurelib/inventory/postgresql_provider_test.go
+++ b/resources/providers/azurelib/inventory/postgresql_provider_test.go
@@ -393,7 +393,6 @@ func singlePsqlConfigAsset(id, name, value string) AzureAsset {
 		Sku:            nil,
 		Identity:       nil,
 		Properties: map[string]any{
-			"name":         name,
 			"source":       "system-default",
 			"value":        value,
 			"dataType":     "Boolean",
@@ -446,7 +445,6 @@ func flexPsqlConfigAsset(id, name, value string) AzureAsset {
 		Sku:            nil,
 		Identity:       nil,
 		Properties: map[string]any{
-			"name":         name,
 			"source":       "system-default",
 			"value":        value,
 			"dataType":     "Boolean",

--- a/resources/providers/azurelib/inventory/postgresql_provider_test.go
+++ b/resources/providers/azurelib/inventory/postgresql_provider_test.go
@@ -493,7 +493,6 @@ func singlePsqlFirewallConfigAsset(id, startIpAddr, endIpAddr string) AzureAsset
 		Sku:            nil,
 		Identity:       nil,
 		Properties: map[string]any{
-			"name":           "name-" + id,
 			"startIPAddress": startIpAddr,
 			"endIPAddress":   endIpAddr,
 		},
@@ -540,7 +539,6 @@ func flexPsqlFirewallConfigAsset(id, startIpAddr, endIpAddr string) AzureAsset {
 		Sku:            nil,
 		Identity:       nil,
 		Properties: map[string]any{
-			"name":           "name-" + id,
 			"startIPAddress": startIpAddr,
 			"endIPAddress":   endIpAddr,
 		},

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_1/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_1/rule.rego
@@ -19,5 +19,5 @@ finding = result if {
 default is_audit_enabled = false
 
 is_audit_enabled if {
-	data_adapter.resource.extension.sqlBlobAuditPolicy.state == "Enabled"
+	data_adapter.resource.extension.sqlBlobAuditPolicy.properties.state == "Enabled"
 }

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_1/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_1/test.rego
@@ -6,13 +6,13 @@ import data.lib.test
 import future.keywords.if
 
 test_violation if {
-	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"state": "Disabled"}})
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"properties": {"state": "Disabled"}}})
 
 	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {})
 }
 
 test_pass if {
-	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"state": "Enabled"}})
+	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"properties": {"state": "Enabled"}}})
 }
 
 test_not_evaluated if {

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_3/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_3/rule.rego
@@ -22,8 +22,8 @@ is_encryption_protector_key_vault if {
 	count(data_adapter.resource.extension.sqlEncryptionProtectors) > 0
 
 	every p in data_adapter.resource.extension.sqlEncryptionProtectors {
-		p.serverKeyType == "AzureKeyVault"
-		p.kind == "azurekeyvault"
-		count(trim_space(p.uri)) > 0
+		p.properties.serverKeyType == "AzureKeyVault"
+		p.properties.kind == "azurekeyvault"
+		count(trim_space(p.properties.uri)) > 0
 	}
 }

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_3/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_3/test.rego
@@ -7,43 +7,43 @@ import future.keywords.if
 
 test_violation if {
 	# Fail with ServiceManaged
-	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [{
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [{"properties": {
 		"serverKeyType": "ServiceManaged",
 		"kind": "azurekeyvault",
 		"uri": "any",
-	}]})
+	}}]})
 
 	# Fail with non azurekeyvault kind
-	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [{
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [{"properties": {
 		"serverKeyType": "AzureKeyVault",
 		"kind": "other",
 		"uri": "any",
-	}]})
+	}}]})
 
 	# Fail with empty uri
-	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [{
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [{"properties": {
 		"serverKeyType": "AzureKeyVault",
 		"kind": "azurekeyvault",
 		"uri": "",
-	}]})
+	}}]})
 
-	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [{
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [{"properties": {
 		"serverKeyType": "AzureKeyVault",
 		"kind": "azurekeyvault",
-	}]})
+	}}]})
 
 	# fail with one good
 	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [
-		{
+		{"properties": {
 			"serverKeyType": "AzureKeyVault",
 			"kind": "azurekeyvault",
 			"uri": "",
-		},
-		{
+		}},
+		{"properties": {
 			"serverKeyType": "AzureKeyVault",
 			"kind": "azurekeyvault",
 			"uri": "uri",
-		},
+		}},
 	]})
 
 	# fail with without protector
@@ -51,28 +51,28 @@ test_violation if {
 }
 
 test_pass if {
-	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [{
+	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [{"properties": {
 		"serverKeyType": "AzureKeyVault",
 		"kind": "azurekeyvault",
 		"uri": "uri",
-	}]})
+	}}]})
 
 	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlEncryptionProtectors": [
-		{
+		{"properties": {
 			"serverKeyType": "AzureKeyVault",
 			"kind": "azurekeyvault",
 			"uri": "uri",
-		},
-		{
+		}},
+		{"properties": {
 			"serverKeyType": "AzureKeyVault",
 			"kind": "azurekeyvault",
 			"uri": "uri",
-		},
-		{
+		}},
+		{"properties": {
 			"serverKeyType": "AzureKeyVault",
 			"kind": "azurekeyvault",
 			"uri": "uri",
-		},
+		}},
 	]})
 }
 

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_5/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_5/rule.rego
@@ -22,7 +22,7 @@ is_transaparent_data_encryption_enabled_for_all_dbs if {
 	count(data_adapter.resource.extension.sqlTransparentDataEncryptions) > 0
 
 	every p in data_adapter.resource.extension.sqlTransparentDataEncryptions {
-		is_transparent_data_encryption_enabled(p.databaseName, p.state)
+		is_transparent_data_encryption_enabled(p.properties.databaseName, p.properties.state)
 	}
 }
 

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_5/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_5/test.rego
@@ -6,53 +6,53 @@ import data.lib.test
 import future.keywords.if
 
 test_violation if {
-	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [{
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [{"properties": {
 		"state": "Disabled",
 		"databaseName": "dbName",
-	}]})
+	}}]})
 
 	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [
-		{
+		{"properties": {
 			"state": "Disabled",
 			"databaseName": "dbName",
-		},
-		{
+		}},
+		{"properties": {
 			"state": "Enabled",
 			"databaseName": "dbName",
-		},
-		{
+		}},
+		{"properties": {
 			"state": "Enabled",
 			"databaseName": "master",
-		},
+		}},
 	]})
 
 	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {})
 }
 
 test_pass if {
-	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [{
+	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [{"properties": {
 		"state": "Enabled",
 		"databaseName": "dbName",
-	}]})
+	}}]})
 
-	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [{
+	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [{"properties": {
 		"state": "Disabled",
 		"databaseName": "master",
-	}]})
+	}}]})
 
 	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlTransparentDataEncryptions": [
-		{
+		{"properties": {
 			"state": "Enabled",
 			"databaseName": "dbName",
-		},
-		{
+		}},
+		{"properties": {
 			"state": "Enabled",
 			"databaseName": "dbName",
-		},
-		{
+		}},
+		{"properties": {
 			"state": "Disabled",
 			"databaseName": "master",
-		},
+		}},
 	]})
 }
 

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_6/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_6/rule.rego
@@ -19,9 +19,9 @@ finding = result if {
 default is_retention_long_enough = false
 
 is_retention_long_enough if {
-	data_adapter.resource.extension.sqlBlobAuditPolicy.retentionDays > 90
+	data_adapter.resource.extension.sqlBlobAuditPolicy.properties.retentionDays > 90
 }
 
 is_retention_long_enough if {
-	data_adapter.resource.extension.sqlBlobAuditPolicy.retentionDays == 0 # unlimited retention
+	data_adapter.resource.extension.sqlBlobAuditPolicy.properties.retentionDays == 0 # unlimited retention
 }

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_6/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_1_6/test.rego
@@ -6,17 +6,17 @@ import data.lib.test
 import future.keywords.if
 
 test_violation if {
-	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"retentionDays": 55}})
-	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"retentionDays": 90}})
-	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"retentionDays": 1}})
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"properties": {"retentionDays": 55}}})
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"properties": {"retentionDays": 90}}})
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"properties": {"retentionDays": 1}}})
 
 	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {})
 }
 
 test_pass if {
-	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"retentionDays": 91}})
-	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"retentionDays": 1000}})
-	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"retentionDays": 0}})
+	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"properties": {"retentionDays": 91}}})
+	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"properties": {"retentionDays": 1000}}})
+	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlBlobAuditPolicy": {"properties": {"retentionDays": 0}}})
 }
 
 test_not_evaluated if {

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_2_1/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_2_1/rule.rego
@@ -22,6 +22,6 @@ is_defender_on if {
 	count(data_adapter.resource.extension.sqlAdvancedThreatProtectionSettings) > 0
 
 	every setting in data_adapter.resource.extension.sqlAdvancedThreatProtectionSettings {
-		setting.state == "Enabled"
+		setting.properties.state == "Enabled"
 	}
 }

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_2_1/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_2_1/test.rego
@@ -7,25 +7,25 @@ import future.keywords.if
 
 test_violation if {
 	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlAdvancedThreatProtectionSettings": []})
-	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlAdvancedThreatProtectionSettings": [{"state": "Disabled"}]})
+	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlAdvancedThreatProtectionSettings": [{"properties": {"state": "Disabled"}}]})
 	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlAdvancedThreatProtectionSettings": [
-		{"state": "Disabled"},
-		{"state": "Enabled"},
+		{"properties": {"state": "Disabled"}},
+		{"properties": {"state": "Enabled"}},
 	]})
 	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlAdvancedThreatProtectionSettings": [
-		{"state": "Disabled"},
-		{"state": "Disabled"},
+		{"properties": {"state": "Disabled"}},
+		{"properties": {"state": "Disabled"}},
 	]})
 
 	eval_fail with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {})
 }
 
 test_pass if {
-	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlAdvancedThreatProtectionSettings": [{"state": "Enabled"}]})
+	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlAdvancedThreatProtectionSettings": [{"properties": {"state": "Enabled"}}]})
 	eval_pass with input as test_data.generate_azure_asset_with_ext("azure-sql-server", {}, {"sqlAdvancedThreatProtectionSettings": [
-		{"state": "Enabled"},
-		{"state": "Enabled"},
-		{"state": "Enabled"},
+		{"properties": {"state": "Enabled"}},
+		{"properties": {"state": "Enabled"}},
+		{"properties": {"state": "Enabled"}},
 	]})
 }
 

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_2/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_2/rule.rego
@@ -20,5 +20,5 @@ default config_enabled = false
 config_enabled if {
 	some i
 	data_adapter.resource.extension.psqlConfigurations[i].name == "log_checkpoints"
-	data_adapter.resource.extension.psqlConfigurations[i].value == "on"
+	data_adapter.resource.extension.psqlConfigurations[i].properties.value == "on"
 }

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_2/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_2/test.rego
@@ -8,12 +8,12 @@ import future.keywords.if
 test_violation if {
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_checkpoints",
-		"value": "off",
+		"properties": {"value": "off"},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_connections",
-		"value": "on",
+		"properties": {"value": "on"},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": []})
@@ -24,7 +24,7 @@ test_violation if {
 test_pass if {
 	eval_pass with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_checkpoints",
-		"value": "on",
+		"properties": {"value": "on"},
 	}]})
 }
 

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_3/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_3/rule.rego
@@ -20,5 +20,5 @@ default config_enabled = false
 config_enabled if {
 	some i
 	data_adapter.resource.extension.psqlConfigurations[i].name == "log_connections"
-	data_adapter.resource.extension.psqlConfigurations[i].value == "on"
+	data_adapter.resource.extension.psqlConfigurations[i].properties.value == "on"
 }

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_3/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_3/test.rego
@@ -8,12 +8,12 @@ import future.keywords.if
 test_violation if {
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_connections",
-		"value": "off",
+		"properties": {"value": "off"},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_checkpoints",
-		"value": "on",
+		"properties": {"value": "on"},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": []})
@@ -24,7 +24,7 @@ test_violation if {
 test_pass if {
 	eval_pass with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_connections",
-		"value": "on",
+		"properties": {"value": "on"},
 	}]})
 }
 

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_4/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_4/rule.rego
@@ -20,5 +20,5 @@ default config_enabled = false
 config_enabled if {
 	some i
 	data_adapter.resource.extension.psqlConfigurations[i].name == "log_disconnections"
-	data_adapter.resource.extension.psqlConfigurations[i].value == "on"
+	data_adapter.resource.extension.psqlConfigurations[i].properties.value == "on"
 }

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_4/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_4/test.rego
@@ -8,12 +8,12 @@ import future.keywords.if
 test_violation if {
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_disconnections",
-		"value": "off",
+		"properties": {"value": "off"},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_checkpoints",
-		"value": "on",
+		"properties": {"value": "on"},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": []})
@@ -24,7 +24,7 @@ test_violation if {
 test_pass if {
 	eval_pass with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_disconnections",
-		"value": "on",
+		"properties": {"value": "on"},
 	}]})
 }
 

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_5/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_5/rule.rego
@@ -20,5 +20,5 @@ default config_enabled = false
 config_enabled if {
 	some i
 	data_adapter.resource.extension.psqlConfigurations[i].name == "connection_throttling"
-	data_adapter.resource.extension.psqlConfigurations[i].value == "on"
+	data_adapter.resource.extension.psqlConfigurations[i].properties.value == "on"
 }

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_5/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_5/test.rego
@@ -8,12 +8,12 @@ import future.keywords.if
 test_violation if {
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "connection_throttling",
-		"value": "off",
+		"properties": {"value": "off"},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_checkpoints",
-		"value": "on",
+		"properties": {"value": "on"},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": []})
@@ -24,7 +24,7 @@ test_violation if {
 test_pass if {
 	eval_pass with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "connection_throttling",
-		"value": "on",
+		"properties": {"value": "on"},
 	}]})
 }
 

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_6/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_6/rule.rego
@@ -20,5 +20,5 @@ default log_retention_long_enough = false
 log_retention_long_enough if {
 	some i
 	data_adapter.resource.extension.psqlConfigurations[i].name == "log_retention_days"
-	to_number(data_adapter.resource.extension.psqlConfigurations[i].value) > 3
+	to_number(data_adapter.resource.extension.psqlConfigurations[i].properties.value) > 3
 }

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_6/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_6/test.rego
@@ -8,17 +8,17 @@ import future.keywords.if
 test_violation if {
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_retention_days",
-		"value": "3",
+		"properties": {"value": "3"},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_retention_days",
-		"value": "1",
+		"properties": {"value": "1"},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_checkpoints",
-		"value": "on",
+		"properties": {"value": "on"},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": []})
@@ -29,12 +29,12 @@ test_violation if {
 test_pass if {
 	eval_pass with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_retention_days",
-		"value": "4",
+		"properties": {"value": "4"},
 	}]})
 
 	eval_pass with input as test_data.generate_postgresql_server_with_extension({"psqlConfigurations": [{
 		"name": "log_retention_days",
-		"value": "99",
+		"properties": {"value": "99"},
 	}]})
 }
 

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_7/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_7/rule.rego
@@ -28,6 +28,6 @@ has_allow_all_firewall_rule if {
 
 has_allow_all_firewall_rule if {
 	some i
-	data_adapter.resource.extension.psqlFirewallRules[i].startIPAddress == "0.0.0.0"
-	data_adapter.resource.extension.psqlFirewallRules[i].endIPAddress == "0.0.0.0"
+	data_adapter.resource.extension.psqlFirewallRules[i].properties.startIPAddress == "0.0.0.0"
+	data_adapter.resource.extension.psqlFirewallRules[i].properties.endIPAddress == "0.0.0.0"
 }

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_7/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_3_7/test.rego
@@ -9,58 +9,76 @@ import future.keywords.if
 test_violation if {
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [{
 		"name": "AllowAllWindowsAzureIps",
-		"startIPAddress": "196.203.255.0",
-		"endIPAddress": "196.203.255.254",
+		"properties": {
+			"startIPAddress": "196.203.255.0",
+			"endIPAddress": "196.203.255.254",
+		},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [{
 		"name": "AllowAllWindowsAzureIps",
-		"startIPAddress": "0.0.0.0",
-		"endIPAddress": "0.0.0.0",
+		"properties": {
+			"startIPAddress": "0.0.0.0",
+			"endIPAddress": "0.0.0.0",
+		},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [{
 		"name": "randomName",
-		"startIPAddress": "0.0.0.0",
-		"endIPAddress": "0.0.0.0",
+		"properties": {
+			"startIPAddress": "0.0.0.0",
+			"endIPAddress": "0.0.0.0",
+		},
 	}]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [
 		{
 			"name": "randomName",
-			"startIPAddress": "0.0.0.0",
-			"endIPAddress": "0.0.0.0",
+			"properties": {
+				"startIPAddress": "0.0.0.0",
+				"endIPAddress": "0.0.0.0",
+			},
 		},
 		{
 			"name": "randomName",
-			"startIPAddress": "196.203.255.0",
-			"endIPAddress": "196.203.255.254",
+			"properties": {
+				"startIPAddress": "196.203.255.0",
+				"endIPAddress": "196.203.255.254",
+			},
 		},
 	]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [
 		{
 			"name": "AllowAllWindowsAzureIps",
-			"startIPAddress": "0.0.0.0",
-			"endIPAddress": "0.0.0.0",
+			"properties": {
+				"startIPAddress": "0.0.0.0",
+				"endIPAddress": "0.0.0.0",
+			},
 		},
 		{
 			"name": "randomName",
-			"startIPAddress": "196.203.255.0",
-			"endIPAddress": "196.203.255.254",
+			"properties": {
+				"startIPAddress": "196.203.255.0",
+				"endIPAddress": "196.203.255.254",
+			},
 		},
 	]})
 
 	eval_fail with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [
 		{
 			"name": "randomName",
-			"startIPAddress": "196.203.253.0",
-			"endIPAddress": "196.203.253.254",
+			"properties": {
+				"startIPAddress": "196.203.253.0",
+				"endIPAddress": "196.203.253.254",
+			},
 		},
 		{
 			"name": "AllowAllWindowsAzureIps",
-			"startIPAddress": "196.203.255.0",
-			"endIPAddress": "196.203.255.254",
+			"properties": {
+				"startIPAddress": "196.203.255.0",
+				"endIPAddress": "196.203.255.254",
+			},
 		},
 	]})
 }
@@ -68,20 +86,26 @@ test_violation if {
 test_pass if {
 	eval_pass with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [{
 		"name": "randomName",
-		"startIPAddress": "196.203.255.0",
-		"endIPAddress": "196.203.255.254",
+		"properties": {
+			"startIPAddress": "196.203.255.0",
+			"endIPAddress": "196.203.255.254",
+		},
 	}]})
 
 	eval_pass with input as test_data.generate_postgresql_server_with_extension({"psqlFirewallRules": [
 		{
 			"name": "randomName",
-			"startIPAddress": "196.203.255.0",
-			"endIPAddress": "196.203.255.254",
+			"properties": {
+				"startIPAddress": "196.203.255.0",
+				"endIPAddress": "196.203.255.254",
+			},
 		},
 		{
 			"name": "randomName2",
-			"startIPAddress": "196.203.200.0",
-			"endIPAddress": "196.203.200.254",
+			"properties": {
+				"startIPAddress": "196.203.200.0",
+				"endIPAddress": "196.203.200.254",
+			},
 		},
 	]})
 

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_4_2/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_4_2/rule.rego
@@ -20,7 +20,7 @@ default contains_tls_version_higher_than_1_2 = false
 contains_tls_version_higher_than_1_2 if {
 	some i
 	data_adapter.resource.extension.mysqlConfigurations[i].name == "tls_version"
-	is_list_of_versions_higher(data_adapter.resource.extension.mysqlConfigurations[i].value)
+	is_list_of_versions_higher(data_adapter.resource.extension.mysqlConfigurations[i].properties.value)
 }
 
 is_list_of_versions_higher(version) if {

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_4_4_2/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_4_4_2/test.rego
@@ -15,19 +15,19 @@ test_violation if {
 	# fail if different configuration
 	eval_fail with input as test_data.generate_flexible_mysql_server_with_extension({"mysqlConfigurations": [{
 		"name": "audit_log_enabled",
-		"value": "off",
+		"properties": {"value": "off"},
 	}]})
 
 	# fail if tls is not v1.2
 	eval_fail with input as test_data.generate_flexible_mysql_server_with_extension({"mysqlConfigurations": [{
 		"name": "tls_version",
-		"value": "tlsv1.1,tlsv1.0",
+		"properties": {"value": "tlsv1.1,tlsv1.0"},
 	}]})
 
 	# fail if tls is not v1.2
 	eval_fail with input as test_data.generate_flexible_mysql_server_with_extension({"mysqlConfigurations": [{
 		"name": "tls_version",
-		"value": "tlsv0.9",
+		"properties": {"value": "tlsv0.9"},
 	}]})
 }
 
@@ -35,27 +35,27 @@ test_pass if {
 	# pass if tls version is v.1.2
 	eval_pass with input as test_data.generate_flexible_mysql_server_with_extension({"mysqlConfigurations": [{
 		"name": "tls_version",
-		"value": "tlsv1.2",
+		"properties": {"value": "tlsv1.2"},
 	}]})
 
 	eval_pass with input as test_data.generate_flexible_mysql_server_with_extension({"mysqlConfigurations": [{
 		"name": "tls_version",
-		"value": "tlsv1.2,tlsv1.3",
+		"properties": {"value": "tlsv1.2,tlsv1.3"},
 	}]})
 
 	eval_pass with input as test_data.generate_flexible_mysql_server_with_extension({"mysqlConfigurations": [{
 		"name": "tls_version",
-		"value": "tlsv1.3,tlsv1.2",
+		"properties": {"value": "tlsv1.3,tlsv1.2"},
 	}]})
 
 	eval_pass with input as test_data.generate_flexible_mysql_server_with_extension({"mysqlConfigurations": [{
 		"name": "tls_version",
-		"value": "tlsv1.3,tlsv1.2",
+		"properties": {"value": "tlsv1.3,tlsv1.2"},
 	}]})
 
 	eval_pass with input as test_data.generate_flexible_mysql_server_with_extension({"mysqlConfigurations": [{
 		"name": "tls_version",
-		"value": "tlsv2.7",
+		"properties": {"value": "tlsv2.7"},
 	}]})
 }
 


### PR DESCRIPTION
### Summary of your changes

@moukoublen @original-brownbear @kubasobon and I agreed to add the whole asset to the extensions field whenever it's possible, instead of adding the properties only as it was being done.

The reason to do so is to have a richer evidence field.

Each extension was a commit, might be easier to review the changes by commit.

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works