### PR TITLE
k8s fix process name matching

### DIFF
--- a/resources/fetching/fetchers/k8s/process_fetcher.go
+++ b/resources/fetching/fetchers/k8s/process_fetcher.go
@@ -142,14 +142,14 @@ func (f *ProcessesFetcher) Fetch(_ context.Context, cycleMetadata cycle.Metadata
 	for _, p := range pids {
 		stat, err := proc.ReadStatFS(f.Fs, p)
 		if err != nil {
-			f.log.Error(err)
+			f.log.Errorf("error while reading /proc/<pid>/stat: %s", err.Error())
 			continue
 		}
 
 		// Get the full command line name and not the /proc/pid/status one which might be silently truncated.
 		cmd, err := proc.ReadCmdLineFS(f.Fs, p)
 		if err != nil {
-			f.log.Error(err)
+			f.log.Error("error while reading /proc/<pid>/cmdline: %s", err.Error())
 			continue
 		}
 		name := extractCommandName(cmd)

--- a/resources/fetching/fetchers/k8s/process_fetcher.go
+++ b/resources/fetching/fetchers/k8s/process_fetcher.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -141,33 +142,35 @@ func (f *ProcessesFetcher) Fetch(_ context.Context, cycleMetadata cycle.Metadata
 	for _, p := range pids {
 		stat, err := proc.ReadStatFS(f.Fs, p)
 		if err != nil {
-			return err
-		}
-		processConfig, isProcessRequired := f.processes[stat.Name]
-		if !isProcessRequired {
+			f.log.Error(err)
 			continue
 		}
 
-		fetchedResource, err := f.fetchProcessData(stat, processConfig, p)
+		// Get the full command line name and not the /proc/pid/status one which might be silently truncated.
+		cmd, err := proc.ReadCmdLineFS(f.Fs, p)
 		if err != nil {
 			f.log.Error(err)
 			continue
 		}
+		name := extractCommandName(cmd)
+
+		processConfig, isProcessRequired := f.processes[name]
+		if !isProcessRequired {
+			continue
+		}
+
+		fetchedResource := f.fetchProcessData(stat, processConfig, p, cmd)
 		f.resourceCh <- fetching.ResourceInfo{Resource: fetchedResource, CycleMetadata: cycleMetadata}
 	}
 
 	return nil
 }
 
-func (f *ProcessesFetcher) fetchProcessData(procStat proc.ProcStat, processConf ProcessInputConfiguration, processId string) (fetching.Resource, error) {
-	cmd, err := proc.ReadCmdLineFS(f.Fs, processId)
-	if err != nil {
-		return nil, err
-	}
+func (f *ProcessesFetcher) fetchProcessData(procStat proc.ProcStat, processConf ProcessInputConfiguration, processId string, cmd string) fetching.Resource {
 	configMap := f.getProcessConfigurationFile(processConf, cmd, procStat.Name)
 	evalRes := EvalProcResource{PID: processId, Cmd: cmd, Stat: procStat, ExternalData: configMap}
 	procCd := f.createProcCommonData(procStat, cmd, processId)
-	return ProcResource{EvalResource: evalRes, ElasticCommon: procCd}, nil
+	return ProcResource{EvalResource: evalRes, ElasticCommon: procCd}
 }
 
 func (f *ProcessesFetcher) createProcCommonData(stat proc.ProcStat, cmd string, pid string) ProcCommonData {
@@ -305,4 +308,19 @@ func (res ProcResource) GetElasticCommonData() (map[string]any, error) {
 func ticksToDuration(ticks uint64) time.Duration {
 	seconds := float64(ticks) / float64(userHz) * float64(time.Second)
 	return time.Duration(int64(seconds))
+}
+
+func extractCommandName(cmdline string) string {
+	// remove command line arguments by finding the first space.
+	// <root>/proc/pid/cmdline separates the strings with null bytes ('\0'),
+	// but proc.ReadCmdLineFS replaces them with space.
+	i := strings.IndexByte(cmdline, ' ')
+	if i > -1 {
+		cmdline = cmdline[:i]
+	}
+
+	// remove the path (if exists) and return the process' executable file name.
+	_, file := path.Split(cmdline)
+
+	return file
 }

--- a/resources/fetching/preset/k8s_preset.go
+++ b/resources/fetching/preset/k8s_preset.go
@@ -45,11 +45,11 @@ var vanillaFsPatterns = []string{
 }
 
 var vanillaRequiredProcesses = fetchers.ProcessesConfigMap{
-	"etcd":            {ConfigFileArguments: nil},
-	"kube-apiserver":  {ConfigFileArguments: nil},
-	"kube-controller": {ConfigFileArguments: nil},
-	"kube-scheduler":  {ConfigFileArguments: nil},
-	"kubelet":         {ConfigFileArguments: []string{"config"}},
+	"etcd":                    {ConfigFileArguments: nil},
+	"kube-apiserver":          {ConfigFileArguments: nil},
+	"kube-controller-manager": {ConfigFileArguments: nil},
+	"kube-scheduler":          {ConfigFileArguments: nil},
+	"kubelet":                 {ConfigFileArguments: []string{"config"}},
 }
 
 func NewCisK8sFetchers(log *logp.Logger, ch chan fetching.ResourceInfo, le uniqueness.Manager, k8sClient k8s.Interface) registry.FetchersMap {


### PR DESCRIPTION
### Summary of your changes
**The issue**
KSPM produces false negative results when [calico](https://www.tigera.io/project-calico/) CNI is used in the cluster.  

The failing rules examine specific running processes in Kubernetes nodes.

**Note: how cloudbeat fetches processes information about running processes:**
Cloudbeat fetches all running process IDs, and for each one of those, it retrieves the name from [proc status file](https://man7.org/linux/man-pages/man5/proc.5.html) (_check section `/proc/pid/status`_). 
Based on the **name** retrieved from the status file, Cloudbeat filters the processes that evaluates.  The names cloudbeat filters are included in the code, for example, for self-managed k8s clusters are in the file `resources/fetching/preset/k8s_preset.go` in `vanillaRequiredProcesses` map. 

**Root Cause**
When the Calico Kubernetes controller is installed, it runs in the control plane node and executes this process `/usr/bin/kube-controllers` inside a pod. 

But [proc status file](https://man7.org/linux/man-pages/man5/proc.5.html) has a limitation regarding process names, as is mentioned in the section `/proc/pid/status`:

```plain
Name   Command run by this process.  Strings longer than
    TASK_COMM_LEN (16) characters (including the
    terminating null byte) are silently truncated.
```

This means that both calico `kube-controllers` and kubernetes `kube-controller-manager` are silently truncated to `kube-controller` which is one of the names that Cloudbeat filters with.

And as a result, Cloudbeat identifies both processes as `kube-controller` and runs the rules that targets `kube-controller` on both of them.
<img width="1833" alt="Screenshot 2024-01-18 at 10 49 19 PM" src="https://github.com/elastic/cloudbeat/assets/1380039/9be3ec81-eea6-4d68-bcfc-2b1695cbb793">

As we can see in the screenshot (column `process.command_line`), rules `1.3.3` and `1.3.3` evaluated both `kube-controller-manager` (the originally intended) and `/usr/bin/kube-controllers` which is the callico controller (not intended).


**Solution**
To fix this issue the name handling based on which cloudbeat filters out processes changed and `/proc/<pid>/cmdline` is used to identify the full name of the running process. The map `vanillaRequiredProcesses` got updated with the full name as well. 


### Screenshot/Data
<img width="1841" alt="Screenshot 2024-01-19 at 12 41 47 AM" src="https://github.com/elastic/cloudbeat/assets/1380039/1534c247-0905-44ad-8434-18b3b20a5a11">
<img width="1981" alt="Screenshot 2024-01-19 at 12 43 24 AM" src="https://github.com/elastic/cloudbeat/assets/1380039/1feaeb00-9723-4195-90c2-a3c3813e696c">
<img width="1954" alt="Screenshot 2024-01-19 at 12 43 37 AM" src="https://github.com/elastic/cloudbeat/assets/1380039/46a9b060-08ce-4ea7-8a64-9cc3311d84bc">


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
Fixes: https://github.com/elastic/security-team/issues/8351

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
