### PR TITLE
[Cloud Security] Select the Environment Url for Create Environment

### DIFF
--- a/.github/workflows/destroy-environment.yml
+++ b/.github/workflows/destroy-environment.yml
@@ -12,6 +12,14 @@ on:
       ignore-prefix:
         type: string
         description: "Ignore all environments starting with `ignore-prefix`"
+      ec-url:
+        required: true
+        default: "https://cloud.elastic.co/"
+        type: choice
+        description: Select the Environment URL to delete
+        options:
+          - https://cloud.elastic.co/
+          - https://console.qa.cld.elstc.co/
       ec-api-key:
         type: string
         description: "**Optional** To delete env environments on your own organization, enter your Elastic Cloud API key."
@@ -31,8 +39,8 @@ jobs:
     timeout-minutes: 120
     # Add "id-token" with the intended permissions.
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -45,8 +53,10 @@ jobs:
         if: ${{ inputs.ec-api-key != '' }}
         run: |
           ec_api_key=$(jq -r '.inputs["ec-api-key"]' $GITHUB_EVENT_PATH)
+          ec_url=$(jq -r '.inputs["ec-url"]' $GITHUB_EVENT_PATH)
           echo "::add-mask::$ec_api_key"
           echo "TF_VAR_ec_api_key=$ec_api_key" >> $GITHUB_ENV
+          echo "TF_VAR_ec_url=$ec_url" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -15,6 +15,14 @@ on:
         type: boolean
         required: true
         default: false
+      ec-url:
+        required: true
+        default: "https://cloud.elastic.co/"
+        type: choice
+        description: Select the Environment URL
+        options:
+          - https://cloud.elastic.co/
+          - https://console.qa.cld.elstc.co/
       elk-stack-version:
         required: true
         description: "Stack version: For released version use 8.x.y, for BC use version with hash 8.x.y-hash, for SNAPSHOT use 8.x.y-SNAPSHOT"
@@ -30,9 +38,9 @@ on:
         description: "Provide the full Docker image path to override the default image (e.g. for testing BC/SNAPSHOT)"
         type: string
       run-sanity-tests:
-          description: "Run sanity tests after provision"
-          default: false
-          type: boolean
+        description: "Run sanity tests after provision"
+        default: false
+        type: boolean
       cleanup-env:
         description: "Cleanup resources after provision"
         default: false
@@ -52,6 +60,14 @@ on:
         type: boolean
         required: true
         default: false
+      ec-url:
+        required: true
+        default: "https://cloud.elastic.co/"
+        type: choice
+        description: Select the Environment URL
+        options:
+          - https://cloud.elastic.co/
+          - https://console.qa.cld.elstc.co/
       elk-stack-version:
         required: true
         description: "Stack version: For released version use 8.x.y, for BC use version with hash 8.x.y-hash, for SNAPSHOT use 8.x.y-SNAPSHOT"
@@ -95,6 +111,7 @@ env:
   AWS_DEFAULT_TAGS: "Key=division,Value=engineering Key=org,Value=security Key=team,Value=cloud-security-posture Key=project,Value=test-environments"
   GCP_DEFAULT_TAGS: "division=engineering,org=security,team=cloud-security-posture,project=test-environments"
   TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
+  TF_VAR_ec_url: ${{ secrets.EC_URL }}
 
 jobs:
   Deploy:
@@ -114,8 +131,8 @@ jobs:
       CNVM_STACK_NAME: "${{ inputs.deployment_name }}-cnvm-sanity-test-stack"
     # Add "id-token" with the intended permissions.
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     outputs:
       deploy-s3-bucket: ${{ steps.upload-state.outputs.s3-bucket-folder }}
       aws-cnvm-stack-name: ${{ steps.upload-state.outputs.aws-cnvm-stack }}
@@ -192,7 +209,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: "3.9"
 
       - name: Install Poetry
         run: |

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -63,11 +63,8 @@ on:
       ec-url:
         required: true
         default: "https://cloud.elastic.co/"
-        type: choice
-        description: Select the Environment URL
-        options:
-          - https://cloud.elastic.co/
-          - https://console.qa.cld.elstc.co/
+        type: string
+        description: Environment URL
       elk-stack-version:
         required: true
         description: "Stack version: For released version use 8.x.y, for BC use version with hash 8.x.y-hash, for SNAPSHOT use 8.x.y-SNAPSHOT"

--- a/.github/workflows/test-gcp-dm.yml
+++ b/.github/workflows/test-gcp-dm.yml
@@ -15,6 +15,7 @@ on:
 env:
   WORKING_DIR: deploy/test-environments
   TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
+  TF_VAR_ec_url: ${{ secrets.EC_URL }}
   TF_VAR_ess_region: gcp-us-west2 # default region for testing deployments
 
 jobs:

--- a/.github/workflows/upgrade-environment.yml
+++ b/.github/workflows/upgrade-environment.yml
@@ -32,6 +32,7 @@ env:
   TF_VAR_stack_version: ${{ inputs.target-elk-stack-version }}
   TF_VAR_ess_region: gcp-us-west2
   TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
+  TF_VAR_ec_url: ${{ secrets.EC_URL }}
   DOCKER_IMAGE: ${{ inputs.docker-image-override }}
 
 jobs:
@@ -73,8 +74,8 @@ jobs:
     needs: init
     # Required for the 'Deploy' job in the 'test-environment.yml' to authenticate with Google Cloud (gcloud).
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     with:
       deployment_name: ${{ inputs.deployment_name }}
       elk-stack-version: ${{ needs.init.outputs.base-stack-version }}
@@ -90,8 +91,8 @@ jobs:
       run:
         working-directory: ${{ env.WORKING_DIR }}
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -103,7 +104,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: "3.9"
 
       - name: Install Poetry
         run: |
@@ -193,7 +194,7 @@ jobs:
       - name: Set Docker Image version
         if: ${{ ! inputs.docker-image-override }}
         env:
-          VERSION: 'docker.elastic.co/beats/elastic-agent:${{ inputs.target-elk-stack-version }}'
+          VERSION: "docker.elastic.co/beats/elastic-agent:${{ inputs.target-elk-stack-version }}"
         run: |
           echo "DOCKER_IMAGE=${{ env.VERSION }}" >> $GITHUB_ENV
 

--- a/.github/workflows/weekly-enviroment.yml
+++ b/.github/workflows/weekly-enviroment.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Environment to deploy'
+        description: "Environment to deploy"
         type: choice
         options:
           - weekly environment
       logLevel:
-        description: 'Log level'
+        description: "Log level"
         required: true
-        default: 'INFO'
+        default: "INFO"
         type: choice
         options:
           - TRACE
@@ -24,6 +24,7 @@ env:
   WORKING_DIR: deploy/weekly-environment
   SCRIPTS_DIR: deploy/weekly-environment/scripts/benchmarks/kspm_vanilla
   TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
+  TF_VAR_ec_url: ${{ secrets.EC_URL }}
   TF_VAR_environment: ${{ github.event.inputs.logLevel }}
   TF_LOG: ${{ github.event.inputs.logLevel }}
   TF_VAR_stack_version: 8.7.0-SNAPSHOT

--- a/deploy/cloud/main.tf
+++ b/deploy/cloud/main.tf
@@ -1,5 +1,6 @@
 provider "ec" {
   apikey = var.ec_api_key
+  url = var.ec_url
 }
 
 module "ec_deployment" {

--- a/deploy/cloud/modules/ec/variables.tf
+++ b/deploy/cloud/modules/ec/variables.tf
@@ -2,6 +2,10 @@ variable "ec_api_key" {
   type = string
 }
 
+variable "ec_url" {
+  type = string
+}
+
 variable "stack_version" {
   description = "Optional version of the Elastic Cloud deployment"
   type        = string

--- a/deploy/cloud/variables.tf
+++ b/deploy/cloud/variables.tf
@@ -5,6 +5,11 @@ variable "ec_api_key" {
   type        = string
 }
 
+variable "ec_url" {
+  description = "Elastic cloud Environment URL"
+  type        = string
+}
+
 variable "ess_region" {
   default     = "gcp-us-central1"
   description = "Optional ESS region where the deployment will be created. Defaults to gcp-us-west2"

--- a/deploy/test-environments/README.md
+++ b/deploy/test-environments/README.md
@@ -3,7 +3,6 @@
 **Motivation**
 To provide an easy and deterministic way to set up the latest cloud environment, ensuring proper monitoring and usability
 
-
 **Prerequisite**
 
 This project utilizes AWS and Elastic Cloud accounts. To ensure proper deployment and usage, it is essential to obtain appropriate licenses in compliance with the licensing terms and conditions provided by the respective service providers.
@@ -20,17 +19,16 @@ To generate an Elastic Cloud token, you have two options:
 
 Choose the method that is most convenient for you to obtain the Elastic Cloud token required for deployment.
 
-
 Ensure that the following AWS credentials are defined:
 
 - `AWS_ACCESS_KEY_ID`: Your AWS access key ID.
 - `AWS_SECRET_ACCESS_KEY`: Your AWS secret access key.
 
-
 To successfully deploy the environment, ensure that the following variables are provided as deployment parameters or exported as environment variables:
 
 ```bash
 export TF_VAR_ec_api_key={TOKEN} # <-- should be replaced by Elastic Cloud TOKEN
+export TF_VAR_ec_url=https://cloud.elastic.co # <-- should be replaced by Elastic Cloud TOKEN
 export TF_VAR_stack_version=8.7.2-SNAPSHOT
 export TF_VAR_ess_region=gcp-us-west2
 ```
@@ -49,22 +47,20 @@ Please note that the customized image is currently available in the following re
 
 **Module variables (CSPM / KSPM)**
 
-| Variable  | Default Value | Comment |
-|:-------------:|:-------------:|:------------|
-| region      |   eu-west-1   | AWS EC2 deployment region |
-
-
+| Variable | Default Value | Comment                   |
+| :------: | :-----------: | :------------------------ |
+|  region  |   eu-west-1   | AWS EC2 deployment region |
 
 ### Elastic Cloud
 
 **ec_deployment** - This module facilitates the deployment of Elastic Cloud instance.
 
-| Variable  | Default Value | Comment |
-|:-------------:|:-------------:|:------------|
-| ec_api_key    |   None   | The API key for Elastic Cloud can also be defined using the `TF_VAR_ec_api_key` environment variable |
-| ess_region    | gcp-us-west2 | The ESS deployment region can also be defined using the `TF_VAR_stack_version` environment variable|
-| stack_version | latest | The ELK stack version can also be defined using the `TF_VAR_stack_version` environment variable |
-| pin_version   | None | Optional: The ELK pin version (docker tag override) can also be defined using the `TF_VAR_pin_version` environment variable |
+|   Variable    | Default Value | Comment                                                                                                                     |
+| :-----------: | :-----------: | :-------------------------------------------------------------------------------------------------------------------------- |
+|  ec_api_key   |     None      | The API key for Elastic Cloud can also be defined using the `TF_VAR_ec_api_key` environment variable                        |
+|  ess_region   | gcp-us-west2  | The ESS deployment region can also be defined using the `TF_VAR_stack_version` environment variable                         |
+| stack_version |    latest     | The ELK stack version can also be defined using the `TF_VAR_stack_version` environment variable                             |
+|  pin_version  |     None      | Optional: The ELK pin version (docker tag override) can also be defined using the `TF_VAR_pin_version` environment variable |
 
 ## Execution
 
@@ -111,7 +107,6 @@ BC version
 terraform apply --auto-approve -var="stack_version=8.12.0" -var="pin_version=8.12.0-9f05a310" -target "module.ec_deployment"
 ```
 
-
 - EKS Deployment
 
 ```bash
@@ -122,10 +117,9 @@ terraform apply --auto-approve -target "module.eks"
 
 To destroy local environment use
 
-``` bash
+```bash
 terraform destroy -var="region=eu-west-1"
 ```
-
 
 To destroy the environment provisioned using the Sanity job, follow these steps:
 
@@ -133,6 +127,6 @@ To destroy the environment provisioned using the Sanity job, follow these steps:
 2. Rename the state file, for example, `terraform-sanity.tfstate`.
 3. Run the following command:
 
-``` bash
+```bash
 terraform destroy -var="region=eu-west-1" -state terraform-sanity.tfstate
 ```

--- a/deploy/test-environments/delete_env.sh
+++ b/deploy/test-environments/delete_env.sh
@@ -88,6 +88,7 @@ done
 # Ensure required environment variables and parameters are set
 : "${ENV_PREFIX:?$(echo "Missing -p|--prefix. Please provide an environment prefix to delete" && usage && exit 1)}"
 : "${TF_VAR_ec_api_key:?Please set TF_VAR_ec_api_key with an Elastic Cloud API Key}"
+: "${TF_VAR_ec_url:?Please set TF_VAR_url with an Elastic Cloud Environment URL}"
 
 BUCKET=s3://tf-state-bucket-test-infra
 ALL_ENVS=$(aws s3 ls $BUCKET/"$ENV_PREFIX" | awk '{print $2}' | sed 's/\///g')

--- a/deploy/test-environments/main.tf
+++ b/deploy/test-environments/main.tf
@@ -10,7 +10,7 @@ locals {
     project  = "${var.project}"
     owner    = "${var.owner}"
   }
-  ec_url = "https://cloud.elastic.co"
+  ec_url = "${var.ec_url}"
   ec_headers = {
     Content-type  = "application/json"
     Authorization = "ApiKey ${var.ec_api_key}"
@@ -44,11 +44,12 @@ resource "random_string" "suffix" {
 
 provider "ec" {
   apikey = var.ec_api_key
+  url    = var.ec_url
 }
 
 provider "restapi" {
   alias                = "ec"
-  uri                  = local.ec_url
+  uri                  = var.ec_url
   write_returns_object = true
   headers              = local.ec_headers
 }
@@ -88,7 +89,7 @@ module "ec_project" {
   count        = var.serverless_mode ? 1 : 0
   source       = "../cloud/modules/serverless"
   ec_apikey    = var.ec_api_key
-  ec_url       = local.ec_url
+  ec_url       = var.ec_url
   project_name = "${var.deployment_name}-${random_string.suffix.result}"
   region_id    = "aws-us-east-1" # TODO: replace with var.ess_region when more regions are supported
 }

--- a/deploy/test-environments/variables.tf
+++ b/deploy/test-environments/variables.tf
@@ -18,6 +18,12 @@ variable "ami_map" {
 
 # Elastic Cloud variables
 # ===========================================
+variable "ec_url" {
+  default     = "https://cloud.elastic.co"
+  description = "Optional Elastic Cloud Environment URL, use export TF_VAR_ec_url={URL}, it defaults to https://cloud.elastic.co"
+  type        = string
+}
+
 variable "ec_api_key" {
   description = "Provide Elastic Cloud API key or use export TF_VAR_ec_api_key={TOKEN}"
   type        = string

--- a/deploy/weekly-environment/main.tf
+++ b/deploy/weekly-environment/main.tf
@@ -1,6 +1,7 @@
 provider "ec" {
   apikey   = var.ec_api_key
   endpoint = var.endpoint
+  url      = var.ec_url
 }
 
 module "ec_deployment" {

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -18,49 +18,50 @@ Follow these steps to run the workflow:
 
 3. Complete the required parameters:
 
-    - **`deployment_name`**: Name your environment (Allowed characters: a-zA-Z0-9 and `-`). For
-      instance: `john-8-7-2-June01`.
+   - **`deployment_name`**: Name your environment (Allowed characters: a-zA-Z0-9 and `-`). For
+     instance: `john-8-7-2-June01`.
 
-    - **`elk-stack-version`**: Specify the version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC)
-      version. Check the available versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
-      For BC, enter version with additions/commit sha, e.g. `8.12.0-61156bc6`.
-      For SNAPSHOT, enter the full version, e.g. `8.13.0-SNAPSHOT`.
+   - **`elk-stack-version`**: Specify the version of Elastic Cloud stack, either a SNAPSHOT or a build candidate (BC)
+     version. Check the available versions [here](https://artifacts-staging.elastic.co/dra-info/index.html).
+     For BC, enter version with additions/commit sha, e.g. `8.12.0-61156bc6`.
+     For SNAPSHOT, enter the full version, e.g. `8.13.0-SNAPSHOT`.
 
-    - **`ess-region`**: Indicate the Elastic Cloud deployment region. The default value is `gcp-us-west2`, which
-      supports
-      snapshot and build candidate (BC) versions. Specify a different region only if necessary.
+   - **`ess-region`**: Indicate the Elastic Cloud deployment region. The default value is `gcp-us-west2`, which
+     supports
+     snapshot and build candidate (BC) versions. Specify a different region only if necessary.
 
    ![Required Parameters](https://github.com/oren-zohar/cloudbeat/assets/85433724/6159129e-6d4d-46b1-97a1-f0d3859500fd)
 
 4. Optionally, modify other parameters if required:
 
-    - **`docker-image-override`** (**optional**): Use this to replace the default agent Docker image for build candidate (BC) or
-      SNAPSHOT versions.
-      Provide the full image path. Leave this field blank for snapshot versions. Follow this format for the image
-      path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.8.1-9ac7eb02`. If you're not sure where to get this
-      image path from, look for message like [this](https://elastic.slack.com/archives/C0JFN9HJL/p1689227472876399) in
-      #mission-control channel, you can see it specify the stack version and the BC commit sha in the first line,
-      e.g. `elastic / unified-release - staging # 8.9 - 11 - 8.9.0-c6bb8f7a Success after 4 hr 58 min`. Now just copy it
-      and replace it the image path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.9.0-c6bb8f7a`.
+   - **`docker-image-override`** (**optional**): Use this to replace the default agent Docker image for build candidate (BC) or
+     SNAPSHOT versions.
+     Provide the full image path. Leave this field blank for snapshot versions. Follow this format for the image
+     path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.8.1-9ac7eb02`. If you're not sure where to get this
+     image path from, look for message like [this](https://elastic.slack.com/archives/C0JFN9HJL/p1689227472876399) in
+     #mission-control channel, you can see it specify the stack version and the BC commit sha in the first line,
+     e.g. `elastic / unified-release - staging # 8.9 - 11 - 8.9.0-c6bb8f7a Success after 4 hr 58 min`. Now just copy it
+     and replace it the image path: `docker.elastic.co/cloud-release/elastic-agent-cloud:8.9.0-c6bb8f7a`.
 
-    - **`run-sanity-tests`** (**optional**): Set to `true` to run sanity tests after the environment is set up. Default: `false`
+   - **`run-sanity-tests`** (**optional**): Set to `true` to run sanity tests after the environment is set up. Default: `false`
 
-    - **`cleanup-env`** (**optional**): Set to `true` if you want the resources to automatically be cleaned up after
-      provisioning - useful if you don't want to test the env manually after deployment.
-      Default: `false`.
+   - **`cleanup-env`** (**optional**): Set to `true` if you want the resources to automatically be cleaned up after
+     provisioning - useful if you don't want to test the env manually after deployment.
+     Default: `false`.
 
-    - **`ec-api-key`** (**optional**): By default, all the new environments will be created in our EC Cloud Security organization.
-      If you want to create the environment on your personal org (`@elastic.co`) you can enter
-      your private [Elastic Cloud](https://cloud.elastic.co/home) API key. Follow the
-      [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for
-      step-by-step instructions on generating the token.
+   - **`ec-url`** (**optional**): By default, all the new environments will be created in the Production environment (https://cloud.elastic.co/). If you want to create the environment others environment you can enter other Environment URL.
+
+   - **`ec-api-key`** (**optional**): By default, all the new environments will be created in our EC Cloud Security organization.
+     If you want to create the environment on your personal org (`@elastic.co`) you can enter
+     your private [Elastic Cloud](https://cloud.elastic.co/home) API key. Follow the
+     [Cloud API Keys](https://www.elastic.co/guide/en/cloud/current/ec-api-authentication.html) documentation for
+     step-by-step instructions on generating the token.
 
    ![Optional Parameters](https://github.com/oren-zohar/cloudbeat/assets/85433724/17933589-ee0e-4181-a244-f501f54bda6c)
 
 5. Click the `Run workflow` button to start.
 
    ![Run Workflow](https://github.com/oren-zohar/cloudbeat/assets/85433724/7b05bf58-cc0b-4ec9-8e49-55d117673df8)
-
 
 ## Tracking Workflow Execution
 
@@ -121,7 +122,7 @@ Follow these steps to connect to your Amazon Elastic Kubernetes Service (EKS) cl
 
    To configure kubectl to communicate with your EKS cluster, replace `<cluster_name>` with your EKS cluster's name and run the following command:
 
-   ```aws eks update-kubeconfig --region eu-west-1 --name <cluster_name>```
+   `aws eks update-kubeconfig --region eu-west-1 --name <cluster_name>`
 
    This command updates your ~/.kube/config file with the necessary cluster configuration.
 
@@ -129,10 +130,9 @@ Follow these steps to connect to your Amazon Elastic Kubernetes Service (EKS) cl
 
    To verify your connectivity to the EKS cluster, run the following kubectl command:
 
-   ```kubectl get po -n kube-system```
+   `kubectl get po -n kube-system`
 
    This command should list the pods in the kube-system namespace, confirming that you have successfully connected to your EKS cluster.
-
 
 ## Cleanup Procedure
 
@@ -158,14 +158,14 @@ Follow these steps to run the workflow:
 
 3. Complete the required input fields:
 
-    - `prefix` (required): The prefix used to identify the environments to be deleted.
+   - `prefix` (required): The prefix used to identify the environments to be deleted.
 
    <img width="411" alt="Enter Inputs" src="https://github.com/elastic/cloudbeat/assets/99176494/04973b00-5411-4ace-ab3a-534371877c91">
 
 4. Optionally, modify other input value if required:
 
-    - `ignore-prefix` (optional): The prefix used to identify environments that should be excluded from deletion.
-    - `ec-api-key` (required): Use your own [Elastic Cloud](https://cloud.elastic.co/home) API key if you want to delete environments from your Elastic Cloud account.
+   - `ignore-prefix` (optional): The prefix used to identify environments that should be excluded from deletion.
+   - `ec-api-key` (required): Use your own [Elastic Cloud](https://cloud.elastic.co/home) API key if you want to delete environments from your Elastic Cloud account.
 
    <img width="411" alt="Optional Inputs" src="https://github.com/elastic/cloudbeat/assets/99176494/aa89ad4e-fd32-461d-ab2d-3fee28094a9d">
 


### PR DESCRIPTION
### Summary

This PR adds the option to select the Select the Environment URL to the Create Environment Github action workflow, that allows to create instances on the Production or on the QA environment


###  Screenshot

![image](https://github.com/elastic/cloudbeat/assets/19270322/07263070-3e35-4a9b-be6e-15e930071793)
