### PR TITLE
Revert AWS account tag workaround

### DIFF
--- a/deploy/cloudformation/.gitignore
+++ b/deploy/cloudformation/.gitignore
@@ -1,3 +1,4 @@
 elastic-agent-ec2-dev-*.yml
+*generated.yml
 config.env
 config.json

--- a/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
@@ -33,11 +33,6 @@ Parameters:
     Description: The version of elastic-agent to install
     Type: String
 
-Conditions:
-  UseElasticTags: !Equals
-    - !Ref "AWS::AccountId"
-    - 704479110758
-
 Resources:
 
   # Security Group for EC2 instance
@@ -139,26 +134,6 @@ Resources:
                   - !Ref "AWS::StackId"
         - Key: Task
           Value: Vulnerability Management Scanner
-        - Key: division
-          Value: !If
-            - UseElasticTags
-            - engineering
-            - AWS::NoValue
-        - Key: org
-          Value: !If
-            - UseElasticTags
-            - security
-            - AWS::NoValue
-        - Key: team
-          Value: !If
-            - UseElasticTags
-            - cloud-security
-            - AWS::NoValue
-        - Key: project
-          Value: !If
-            - UseElasticTags
-            - cloudformation
-            - AWS::NoValue
       ImageId: !Ref LatestAmiId
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref ElasticAgentInstanceProfile

--- a/deploy/cloudformation/elastic-agent-ec2-cspm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm.yml
@@ -33,11 +33,6 @@ Parameters:
     Description: The version of elastic-agent to install
     Type: String
 
-Conditions:
-  UseElasticTags: !Equals
-    - !Ref "AWS::AccountId"
-    - 704479110758
-
 Resources:
 
   # Security Group for EC2 instance
@@ -107,26 +102,6 @@ Resources:
                   - !Ref "AWS::StackId"
         - Key: Task
           Value: Cloud Security Posture Management Scanner
-        - Key: division
-          Value: !If
-            - UseElasticTags
-            - engineering
-            - AWS::NoValue
-        - Key: org
-          Value: !If
-            - UseElasticTags
-            - security
-            - AWS::NoValue
-        - Key: team
-          Value: !If
-            - UseElasticTags
-            - cloud-security
-            - AWS::NoValue
-        - Key: project
-          Value: !If
-            - UseElasticTags
-            - cloudformation
-            - AWS::NoValue
       ImageId: !Ref LatestAmiId
       InstanceType: !Ref InstanceType
       IamInstanceProfile: !Ref ElasticAgentInstanceProfile


### PR DESCRIPTION
### Summary of your changes
Changes the golang deployment script to generate a yaml file with the tags for our AWS account even if those are not necessary. This allows long running environments to run for more than 30 days.

This reverts commit d4ad5d46cd8ac89d6bee232cbc70f07b595f0aff.

### Screenshot/Data
**Without SSH key**
![image](https://github.com/elastic/cloudbeat/assets/5778622/0f7af5eb-0fb6-41d6-8694-b91129bca3bf)

**With SSH key**
![image](https://github.com/elastic/cloudbeat/assets/5778622/eb79b58a-9d1a-4c22-9ee3-85e9d4b8dbf5)
![image](https://github.com/elastic/cloudbeat/assets/5778622/dfa614ff-8b26-4f09-a469-bd6d92478a58)


### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)