### PR TITLE
Add flag to skip SSL verification and docs on how to run agains local ES

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -69,6 +69,29 @@ cd cloudbeat/tests
 poetry install
 ```
 
+### Running CSPM Tests from shell against local elastic
+
+1. Bring an ES instance up, e.g
+
+```shell
+  elastic-package stack up -v --version $ES_VERSION
+```
+
+2. Start cloudbeat locally and generate findings on the ES cluster
+3. From the `tests` dir, run the tests with desired rules, e.g.
+```bash
+USE_K8S=false \
+  ES_USER=elastic \
+  ES_USE_SSL=false \
+  ES_PROTOCOL=https \
+  poetry run pytest -m "azure_networking_rules" --alluredir=./allure/results/
+```
+  - `USE_K8S=false` skip k8s tests
+  - `ES_USER=elastic` configure the elastic user, default from elastic package is `elastic`
+  - `ES_USE_SSL=false` skip SSL verification
+  - `ES_PROTOCOL=https` use https protocol to connecto elastic
+
+
 ### Configuring IDE
 
 Tests development may be done using any IDE like [visual studio code](https://code.visualstudio.com/)

--- a/tests/commonlib/elastic_wrapper.py
+++ b/tests/commonlib/elastic_wrapper.py
@@ -10,12 +10,16 @@ class ElasticWrapper:
     Wrapper that uses elasticsearch official package
     """
 
-    def __init__(self, url: str, basic_auth: tuple, index: str):
+    def __init__(self, url: str, basic_auth: tuple, index: str, use_ssl: bool = True):
         self.index = index
+        verify_certs = use_ssl
+        ssl_show_warn = use_ssl
         self.es_client = Elasticsearch(
             hosts=url,
             basic_auth=basic_auth,
             retry_on_timeout=True,
+            verify_certs=verify_certs,
+            ssl_show_warn=ssl_show_warn,
         )
 
     def get_index_data(

--- a/tests/configuration.py
+++ b/tests/configuration.py
@@ -63,6 +63,7 @@ elasticsearch.password = os.getenv("ES_PASSWORD", "changeme")
 elasticsearch.basic_auth = (elasticsearch.user, elasticsearch.password)
 elasticsearch.port = os.getenv("ES_PORT", "9200")
 elasticsearch.protocol = os.getenv("ES_PROTOCOL", "http")
+elasticsearch.use_ssl = os.getenv("ES_USE_SSL", "true") == "true"
 elasticsearch.url = os.getenv("ES_URL", f"{elasticsearch.protocol}://{elasticsearch.hosts}:{elasticsearch.port}")
 elasticsearch.kibana_url = os.getenv("KIBANA_URL", "")
 elasticsearch.kspm_index = os.getenv("KSPM_INDEX", FINDINGS_INDEX_PATTERN)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,6 +276,7 @@ def create_es_client(index: str) -> ElasticWrapper:
         configuration.elasticsearch.url,
         configuration.elasticsearch.basic_auth,
         index,
+        configuration.elasticsearch.use_ssl,
     )
     logger.info(f"client with ElasticSearch url: {configuration.elasticsearch.url}")
     return es_client


### PR DESCRIPTION
### Summary of your changes

Connecting to a local ES instance brought up with elastic-package was failing due to SSL verification. This PR adds a flag to skip the verification when needed.