### PR TITLE
CIS Azure 5.1.5

### DIFF
--- a/internal/resources/fetching/fetchers/azure/assets_fetcher_test.go
+++ b/internal/resources/fetching/fetchers/azure/assets_fetcher_test.go
@@ -139,6 +139,9 @@ func (s *AzureAssetsFetcherTestSuite) TestFetcher_Fetch() {
 		mockProvider.EXPECT().
 			ListKeyVaultSecrets(mock.Anything, v).
 			Return(nil, nil)
+		mockProvider.EXPECT().
+			ListKeyVaultDiagnosticSettings(mock.Anything, v).
+			Return(nil, nil)
 	}
 
 	// since we have app service asset we need to mock the enricher

--- a/internal/resources/providers/azurelib/inventory/asset.go
+++ b/internal/resources/providers/azurelib/inventory/asset.go
@@ -77,6 +77,7 @@ const (
 	ExtensionQueueDiagnosticSettings             = "queueDiagnosticSettings"
 	ExtensionKeyVaultKeys                        = "vaultKeys"
 	ExtensionKeyVaultSecrets                     = "vaultSecrets"
+	ExtensionKeyVaultDiagnosticSettings          = "vaultDiagnosticSettings"
 
 	// AssetLocation
 	assetLocationGlobal = "global"

--- a/internal/resources/providers/azurelib/inventory/mock_key_vault_provider_api.go
+++ b/internal/resources/providers/azurelib/inventory/mock_key_vault_provider_api.go
@@ -38,6 +38,61 @@ func (_m *MockKeyVaultProviderAPI) EXPECT() *MockKeyVaultProviderAPI_Expecter {
 	return &MockKeyVaultProviderAPI_Expecter{mock: &_m.Mock}
 }
 
+// ListKeyVaultDiagnosticSettings provides a mock function with given fields: ctx, vault
+func (_m *MockKeyVaultProviderAPI) ListKeyVaultDiagnosticSettings(ctx context.Context, vault AzureAsset) ([]AzureAsset, error) {
+	ret := _m.Called(ctx, vault)
+
+	var r0 []AzureAsset
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, AzureAsset) ([]AzureAsset, error)); ok {
+		return rf(ctx, vault)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, AzureAsset) []AzureAsset); ok {
+		r0 = rf(ctx, vault)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]AzureAsset)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, AzureAsset) error); ok {
+		r1 = rf(ctx, vault)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockKeyVaultProviderAPI_ListKeyVaultDiagnosticSettings_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListKeyVaultDiagnosticSettings'
+type MockKeyVaultProviderAPI_ListKeyVaultDiagnosticSettings_Call struct {
+	*mock.Call
+}
+
+// ListKeyVaultDiagnosticSettings is a helper method to define mock.On call
+//   - ctx context.Context
+//   - vault AzureAsset
+func (_e *MockKeyVaultProviderAPI_Expecter) ListKeyVaultDiagnosticSettings(ctx interface{}, vault interface{}) *MockKeyVaultProviderAPI_ListKeyVaultDiagnosticSettings_Call {
+	return &MockKeyVaultProviderAPI_ListKeyVaultDiagnosticSettings_Call{Call: _e.mock.On("ListKeyVaultDiagnosticSettings", ctx, vault)}
+}
+
+func (_c *MockKeyVaultProviderAPI_ListKeyVaultDiagnosticSettings_Call) Run(run func(ctx context.Context, vault AzureAsset)) *MockKeyVaultProviderAPI_ListKeyVaultDiagnosticSettings_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(AzureAsset))
+	})
+	return _c
+}
+
+func (_c *MockKeyVaultProviderAPI_ListKeyVaultDiagnosticSettings_Call) Return(_a0 []AzureAsset, _a1 error) *MockKeyVaultProviderAPI_ListKeyVaultDiagnosticSettings_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockKeyVaultProviderAPI_ListKeyVaultDiagnosticSettings_Call) RunAndReturn(run func(context.Context, AzureAsset) ([]AzureAsset, error)) *MockKeyVaultProviderAPI_ListKeyVaultDiagnosticSettings_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListKeyVaultKeys provides a mock function with given fields: ctx, vault
 func (_m *MockKeyVaultProviderAPI) ListKeyVaultKeys(ctx context.Context, vault AzureAsset) ([]AzureAsset, error) {
 	ret := _m.Called(ctx, vault)

--- a/internal/resources/providers/azurelib/mock_provider_api.go
+++ b/internal/resources/providers/azurelib/mock_provider_api.go
@@ -603,6 +603,61 @@ func (_c *MockProviderAPI_ListFlexiblePostgresFirewallRules_Call) RunAndReturn(r
 	return _c
 }
 
+// ListKeyVaultDiagnosticSettings provides a mock function with given fields: ctx, vault
+func (_m *MockProviderAPI) ListKeyVaultDiagnosticSettings(ctx context.Context, vault inventory.AzureAsset) ([]inventory.AzureAsset, error) {
+	ret := _m.Called(ctx, vault)
+
+	var r0 []inventory.AzureAsset
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, inventory.AzureAsset) ([]inventory.AzureAsset, error)); ok {
+		return rf(ctx, vault)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, inventory.AzureAsset) []inventory.AzureAsset); ok {
+		r0 = rf(ctx, vault)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]inventory.AzureAsset)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, inventory.AzureAsset) error); ok {
+		r1 = rf(ctx, vault)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockProviderAPI_ListKeyVaultDiagnosticSettings_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListKeyVaultDiagnosticSettings'
+type MockProviderAPI_ListKeyVaultDiagnosticSettings_Call struct {
+	*mock.Call
+}
+
+// ListKeyVaultDiagnosticSettings is a helper method to define mock.On call
+//   - ctx context.Context
+//   - vault inventory.AzureAsset
+func (_e *MockProviderAPI_Expecter) ListKeyVaultDiagnosticSettings(ctx interface{}, vault interface{}) *MockProviderAPI_ListKeyVaultDiagnosticSettings_Call {
+	return &MockProviderAPI_ListKeyVaultDiagnosticSettings_Call{Call: _e.mock.On("ListKeyVaultDiagnosticSettings", ctx, vault)}
+}
+
+func (_c *MockProviderAPI_ListKeyVaultDiagnosticSettings_Call) Run(run func(ctx context.Context, vault inventory.AzureAsset)) *MockProviderAPI_ListKeyVaultDiagnosticSettings_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(inventory.AzureAsset))
+	})
+	return _c
+}
+
+func (_c *MockProviderAPI_ListKeyVaultDiagnosticSettings_Call) Return(_a0 []inventory.AzureAsset, _a1 error) *MockProviderAPI_ListKeyVaultDiagnosticSettings_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockProviderAPI_ListKeyVaultDiagnosticSettings_Call) RunAndReturn(run func(context.Context, inventory.AzureAsset) ([]inventory.AzureAsset, error)) *MockProviderAPI_ListKeyVaultDiagnosticSettings_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListKeyVaultKeys provides a mock function with given fields: ctx, vault
 func (_m *MockProviderAPI) ListKeyVaultKeys(ctx context.Context, vault inventory.AzureAsset) ([]inventory.AzureAsset, error) {
 	ret := _m.Called(ctx, vault)

--- a/internal/resources/providers/azurelib/provider.go
+++ b/internal/resources/providers/azurelib/provider.go
@@ -72,7 +72,7 @@ func (p *ProviderInitializer) Init(log *logp.Logger, azureConfig auth.AzureFacto
 	resourceGraphProvider := inventory.NewResourceGraphProvider(log, resourceGraphClientFactory)
 	return &provider{
 		AppServiceProviderAPI:       inventory.NewAppServiceProvider(log, azureConfig.Credentials),
-		KeyVaultProviderAPI:         inventory.NewKeyVaultProvider(log, azureConfig.Credentials),
+		KeyVaultProviderAPI:         inventory.NewKeyVaultProvider(log, diagnosticSettingsClient, azureConfig.Credentials),
 		MysqlProviderAPI:            inventory.NewMysqlProvider(log, azureConfig.Credentials),
 		PostgresqlProviderAPI:       inventory.NewPostgresqlProvider(log, azureConfig.Credentials),
 		ProviderAPI:                 governance.NewProvider(log, resourceGraphProvider),

--- a/security-policies/README.md
+++ b/security-policies/README.md
@@ -4,7 +4,7 @@
 [![CIS EKS](https://img.shields.io/badge/CIS-Amazon%20EKS%20(60%25)-FF9900?logo=Amazon+EKS)](RULES.md#eks-cis-benchmark)
 [![CIS AWS](https://img.shields.io/badge/CIS-AWS%20(87%25)-232F3E?logo=Amazon+AWS)](RULES.md#aws-cis-benchmark)
 [![CIS GCP](https://img.shields.io/badge/CIS-GCP%20(85%25)-4285F4?logo=Google+Cloud)](RULES.md#gcp-cis-benchmark)
-[![CIS AZURE](https://img.shields.io/badge/CIS-AZURE%20(47%25)-0078D4?logo=Microsoft+Azure)](RULES.md#azure-cis-benchmark)
+[![CIS AZURE](https://img.shields.io/badge/CIS-AZURE%20(48%25)-0078D4?logo=Microsoft+Azure)](RULES.md#azure-cis-benchmark)
 
 ![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/oren-zohar/a7160df46e48dff45b24096de9302d38/raw/csp-security-policies_coverage.json)
 

--- a/security-policies/RULES.md
+++ b/security-policies/RULES.md
@@ -404,7 +404,7 @@
 
 #### Manual rules: 0/74 (0%)
 
-#### Integration Tests Coverage: 98/302 (32%)
+#### Integration Tests Coverage: 100/302 (33%)
 
 <details><summary><h3>Full Table 📋</h3></summary>
 
@@ -512,7 +512,7 @@
 |  [5.1.2](bundle/compliance/cis_azure/rules/cis_5_1_2)  | Configuring Diagnostic Settings         | Ensure Diagnostic Setting captures appropriate categories                                                                                              | :white_check_mark: |        Passed :white_check_mark: / Failed :x:         | Automated |
 |  [5.1.3](bundle/compliance/cis_azure/rules/cis_5_1_3)  | Configuring Diagnostic Settings         | Ensure the Storage Container Storing the Activity Logs is not Publicly Accessible                                                                      | :white_check_mark: |                Passed :x: / Failed :x:                | Automated |
 |  [5.1.4](bundle/compliance/cis_azure/rules/cis_5_1_4)  | Configuring Diagnostic Settings         | Ensure the storage account containing the container with activity logs is encrypted with Customer Managed Key                                          | :white_check_mark: |                Passed :x: / Failed :x:                | Automated |
-|  [5.1.5](bundle/compliance/cis_azure/rules/cis_5_1_5)  | Configuring Diagnostic Settings         | Ensure that logging for Azure Key Vault is 'Enabled'                                                                                                   | :white_check_mark: |                Passed :x: / Failed :x:                | Automated |
+|  [5.1.5](bundle/compliance/cis_azure/rules/cis_5_1_5)  | Configuring Diagnostic Settings         | Ensure that logging for Azure Key Vault is 'Enabled'                                                                                                   | :white_check_mark: | Passed :white_check_mark: / Failed :white_check_mark: | Automated |
 |                         5.1.6                          | Configuring Diagnostic Settings         | Ensure that Network Security Group Flow logs are captured and sent to Log Analytics                                                                    |        :x:         |                Passed :x: / Failed :x:                | Manual    |
 |                         5.1.7                          | Configuring Diagnostic Settings         | Ensure that logging for Azure AppService 'HTTP logs' is enabled                                                                                        |        :x:         |                Passed :x: / Failed :x:                | Manual    |
 |  [5.2.1](bundle/compliance/cis_azure/rules/cis_5_2_1)  | Monitoring using Activity Log Alerts    | Ensure that Activity Log Alert exists for Create Policy Assignment                                                                                     | :white_check_mark: |        Passed :white_check_mark: / Failed :x:         | Automated |

--- a/security-policies/RULES.md
+++ b/security-policies/RULES.md
@@ -398,9 +398,9 @@
 
 ## AZURE CIS Benchmark
 
-### 71/151 implemented rules (47%)
+### 72/151 implemented rules (48%)
 
-#### Automated rules: 71/77 (92%)
+#### Automated rules: 72/77 (94%)
 
 #### Manual rules: 0/74 (0%)
 
@@ -512,7 +512,7 @@
 |  [5.1.2](bundle/compliance/cis_azure/rules/cis_5_1_2)  | Configuring Diagnostic Settings         | Ensure Diagnostic Setting captures appropriate categories                                                                                              | :white_check_mark: |        Passed :white_check_mark: / Failed :x:         | Automated |
 |  [5.1.3](bundle/compliance/cis_azure/rules/cis_5_1_3)  | Configuring Diagnostic Settings         | Ensure the Storage Container Storing the Activity Logs is not Publicly Accessible                                                                      | :white_check_mark: |                Passed :x: / Failed :x:                | Automated |
 |  [5.1.4](bundle/compliance/cis_azure/rules/cis_5_1_4)  | Configuring Diagnostic Settings         | Ensure the storage account containing the container with activity logs is encrypted with Customer Managed Key                                          | :white_check_mark: |                Passed :x: / Failed :x:                | Automated |
-|                         5.1.5                          | Configuring Diagnostic Settings         | Ensure that logging for Azure Key Vault is 'Enabled'                                                                                                   |        :x:         |                Passed :x: / Failed :x:                | Automated |
+|  [5.1.5](bundle/compliance/cis_azure/rules/cis_5_1_5)  | Configuring Diagnostic Settings         | Ensure that logging for Azure Key Vault is 'Enabled'                                                                                                   | :white_check_mark: |                Passed :x: / Failed :x:                | Automated |
 |                         5.1.6                          | Configuring Diagnostic Settings         | Ensure that Network Security Group Flow logs are captured and sent to Log Analytics                                                                    |        :x:         |                Passed :x: / Failed :x:                | Manual    |
 |                         5.1.7                          | Configuring Diagnostic Settings         | Ensure that logging for Azure AppService 'HTTP logs' is enabled                                                                                        |        :x:         |                Passed :x: / Failed :x:                | Manual    |
 |  [5.2.1](bundle/compliance/cis_azure/rules/cis_5_2_1)  | Monitoring using Activity Log Alerts    | Ensure that Activity Log Alert exists for Create Policy Assignment                                                                                     | :white_check_mark: |        Passed :white_check_mark: / Failed :x:         | Automated |

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_5_1_5/data.yaml
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_5_1_5/data.yaml
@@ -1,0 +1,133 @@
+metadata:
+  id: 66cdd4cc-5870-50e1-959c-91443716b87a
+  name: Ensure that logging for Azure Key Vault is 'Enabled'
+  profile_applicability: '* Level 1'
+  description: |-
+    Enable AuditEvent logging for key vault instances to ensure interactions with key vaults are logged and available.
+  rationale: |-
+    Monitoring how and when key vaults are accessed, and by whom, enables an audit trail of interactions with confidential information, keys, and certificates managed by Azure Keyvault.
+    Enabling logging for Key Vault saves information in an Azure storage account which the user provides.
+    This creates a new container named insights-logs-auditevent automatically for the specified storage account.
+    This same storage account can be used for collecting logs for multiple key vaults.
+  audit: |-
+    **From Azure Portal**
+
+    1. Go to `Key vaults`
+    2. For each Key vault
+    3. Go to `Diagnostic settings`
+    4. Click on `Edit Settings`
+    5. Ensure that `Archive to a storage account` is `Enabled`
+    6. Ensure that `AuditEvent` is checked, and the retention days is set to `180 days` or as appropriate
+
+    **From Azure CLI**
+
+    List all key vaults
+
+    ```
+    az keyvault list
+    ```
+
+    For each keyvault `id`
+    ```
+    az monitor diagnostic-settings list --resource <id>
+    ```
+
+    Ensure that `storageAccountId` is set as appropriate.
+    Also, ensure that `category` and `days` are set.
+    One of the sample outputs is as below.
+
+    ```
+    "logs": [
+     {
+        "category": "AuditEvent",
+        "enabled": true,
+        "retentionPolicy": {
+            "days": 180,
+            "enabled": true
+        }
+    }
+     ]
+    ```
+
+    **From PowerShell** 
+
+    List the key vault(s) in the subscription
+
+    ```
+    Get-AzKeyVault
+    ```
+
+    For each key vault, run the following: 
+
+    ```
+    Get-AzDiagnosticSetting -ResourceId <key vault resource ID>
+    ```
+
+    Ensure that `StorageAccountId`, `ServiceBusRuleId`, `MarketplacePartnerId`, or `WorkspaceId` is set as appropriate.
+    Also, ensure that `enabled` is set to `true`, and that `category` and `days` are set under the `Log` heading.
+  remediation: |-
+    **From Azure Portal**
+
+    1. Go to `Key vaults`
+    2. Select a Key vault
+    3. Select `Diagnostic settings`
+    4. Click on `Edit setting` against an existing diagnostic setting, or `Add diagnostic setting`
+    5. If creating a new diagnostic setting, provide a name
+    6. Check `Archive to a storage account`
+    7. Under Categories, check `Audit Logs`
+    8. Set an appropriate value for `Retention (days)`
+    9. Click `Save`
+
+    **From Azure CLI**
+
+    To update an existing `Diagnostic Settings`
+    ```
+    az monitor diagnostic-settings update --name "<diagnostics settings name>" --resource <key vault resource ID> --set retentionPolicy.days=90
+    ```
+
+    To create a new `Diagnostic Settings`
+
+    ```
+    az monitor diagnostic-settings create --name <diagnostic settings name> --resource <key vault resource ID> --logs "[{category:AuditEvents,enabled:true,retention-policy:{enabled:true,days:180}}]" --metrics "[{category:AllMetrics,enabled:true,retention-policy:{enabled:true,days:180}}]" <[--event-hub <event hub ID> --event-hub-rule <event hub auth rule ID> | --storage-account <storage account ID> |--workspace <log analytics workspace ID> | --marketplace-partner-id <full resource ID of third-party solution>]>
+    ```
+
+    **From PowerShell**
+
+    Create the `Log` settings object
+
+    ```
+    $logSettings = @()
+    $logSettings += New-AzDiagnosticSettingLogSettingsObject -Enabled $true -RetentionPolicyDay 180 -RetentionPolicyEnabled $true -Category AuditEvent
+    ```
+
+    Create the `Metric` settings object
+
+    ```
+    $metricSettings = @()
+    $metricSettings += New-AzDiagnosticSettingMetricSettingsObject -Enabled $true -RetentionPolicyDay 180 -RetentionPolicyEnabled $true -Category AllMetrics
+    ```
+
+    Create the `Diagnostic Settings` for each `Key Vault`
+
+    ```
+    New-AzDiagnosticSetting -Name "<diagnostic setting name>" -ResourceId <key vault resource ID> -Log $logSettings -Metric $metricSettings [-StorageAccountId <storage account ID> | -EventHubName <event hub name> -EventHubAuthorizationRuleId <event hub auth rule ID> | -WorkSpaceId <log analytics workspace ID> | -MarketPlacePartnerId <full resource ID for third-party solution>]
+    ```
+  impact: ''
+  default_value: ''
+  references: |-
+    1. https://docs.microsoft.com/en-us/azure/key-vault/general/howto-logging
+    2. https://docs.microsoft.com/en-us/security/benchmark/azure/security-controls-v3-data-protection#dp-8-ensure-security-of-key-and-certificate-repository
+    3. https://docs.microsoft.com/en-us/security/benchmark/azure/security-controls-v3-logging-threat-detection#lt-3-enable-logging-for-security-investigation
+  section: Configuring Diagnostic Settings
+  version: '1.0'
+  tags:
+  - CIS
+  - AZURE
+  - CIS 5.1.5
+  - Configuring Diagnostic Settings
+  benchmark:
+    name: CIS Microsoft Azure Foundations
+    version: v2.0.0
+    id: cis_azure
+    rule_number: 5.1.5
+    posture_type: cspm

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_5_1_5/rule.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_5_1_5/rule.rego
@@ -1,0 +1,31 @@
+package compliance.cis_azure.rules.cis_5_1_5
+
+import data.compliance.lib.common
+import data.compliance.policy.azure.data_adapter
+import future.keywords.if
+
+finding = result if {
+	# filter
+	data_adapter.is_vault
+
+	# set result
+	result := common.generate_result_without_expected(
+		common.calculate_result(is_vault_logging_enabled),
+		{"Resource": data_adapter.resource},
+	)
+}
+
+is_audit_category(i) if i.categoryGroup == "allLogs"
+
+is_audit_category(i) if i.categoryGroup == "audit"
+
+# AuditEvent category is in both categoryGroup "allLogs" and "audit"
+is_audit_category(i) if i.category == "AuditEvent"
+
+is_vault_logging_enabled if {
+	entry = data_adapter.resource.extension.vaultDiagnosticSettings[i].properties
+	entry.storageAccountId != null
+	logs := entry.logs[i]
+	logs.enabled == true
+	is_audit_category(logs)
+} else = false

--- a/security-policies/bundle/compliance/cis_azure/rules/cis_5_1_5/test.rego
+++ b/security-policies/bundle/compliance/cis_azure/rules/cis_5_1_5/test.rego
@@ -1,0 +1,73 @@
+package compliance.cis_azure.rules.cis_5_1_5
+
+import data.cis_azure.test_data
+import data.compliance.policy.azure.data_adapter
+import data.lib.test
+import future.keywords.if
+
+test_violation if {
+	# fail if storage account id not defined
+	eval_fail with input as test_data.generate_key_vault({}, {"vaultDiagnosticSettings": [{"properties": {"storageAccountId": null}}]})
+
+	# fail if logs category is not audit
+	eval_fail with input as test_data.generate_key_vault({}, {"vaultDiagnosticSettings": [{"properties": {
+		"storageAccountId": "/subscriptions/1",
+		"logs": [{
+			"category": "AzurePolicyEvaluationDetails",
+			"enabled": true,
+		}],
+	}}]})
+
+	# fail if logs category is audit, but not enabled
+	eval_fail with input as test_data.generate_key_vault({}, {"vaultDiagnosticSettings": [{"properties": {
+		"storageAccountId": "/subscriptions/1",
+		"logs": [{
+			"category": "AuditEvent",
+			"enabled": false,
+		}],
+	}}]})
+}
+
+test_pass if {
+	# pass if the diagnostic setting has:
+	# 1. a storage account id
+	# 2. logs category is "AuditEvent" or categoryGroup is "audit"/"allLogs"
+	# 3. said log category is enabled
+	eval_pass with input as test_data.generate_key_vault({}, {"vaultDiagnosticSettings": [{"properties": {
+		"storageAccountId": "/subscription/1",
+		"logs": [{
+			"category": "AuditEvent",
+			"enabled": true,
+		}],
+	}}]})
+	eval_pass with input as test_data.generate_key_vault({}, {"vaultDiagnosticSettings": [{"properties": {
+		"storageAccountId": "/subscription/1",
+		"logs": [{
+			"categoryGroup": "audit",
+			"enabled": true,
+		}],
+	}}]})
+	eval_pass with input as test_data.generate_key_vault({}, {"vaultDiagnosticSettings": [{"properties": {
+		"storageAccountId": "/subscription/1",
+		"logs": [{
+			"categoryGroup": "allLogs",
+			"enabled": true,
+		}],
+	}}]})
+}
+
+test_not_evaluated if {
+	not_eval with input as test_data.not_eval_non_exist_type
+}
+
+eval_fail if {
+	test.assert_fail(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+eval_pass if {
+	test.assert_pass(finding) with data.benchmark_data_adapter as data_adapter
+}
+
+not_eval if {
+	not finding with data.benchmark_data_adapter as data_adapter
+}

--- a/tests/product/tests/data/azure/azure_key_vault_test_cases.py
+++ b/tests/product/tests/data/azure/azure_key_vault_test_cases.py
@@ -9,6 +9,7 @@ from ..azure_test_case import AzureServiceCase
 from ..constants import RULE_PASS_STATUS, RULE_FAIL_STATUS
 
 CIS_8_5 = "CIS 8.5"
+CIS_5_1_5 = "CIS 5.1.5"
 
 cis_azure_8_5_pass = AzureServiceCase(
     rule_tag=CIS_8_5,
@@ -27,7 +28,24 @@ cis_azure_8_5 = {
     "8.5 Ensure the Key Vault is Recoverable expect: failed": cis_azure_8_5_fail,
 }
 
+cis_azure_5_1_5_pass = AzureServiceCase(
+    rule_tag=CIS_5_1_5,
+    case_identifier="test-key-vault-diag-pass",
+    expected=RULE_PASS_STATUS,
+)
+cis_azure_5_1_5_fail = AzureServiceCase(
+    rule_tag=CIS_5_1_5,
+    case_identifier="test-key-vault-diag-fail",
+    expected=RULE_FAIL_STATUS,
+)
+
+cis_azure_5_1_5 = {
+    "5.1.5 Ensure that logging for Azure Key Vault is 'Enabled' expect: passed": cis_azure_5_1_5_pass,
+    "5.1.5 Ensure that logging for Azure Key Vault is 'Enabled' expect: failed": cis_azure_5_1_5_fail,
+}
+
 # The name of this variable needs to be `tests_cases` in order to CIS Rules coverage stats to be generated
 test_cases = {
     **cis_azure_8_5,
+    **cis_azure_5_1_5,
 }


### PR DESCRIPTION
### Summary of your changes

adds CIS Azure 5.1.5: 
> Ensure that logging for Azure Key Vault is 'Enabled'

specifically - 

> Ensure that `storageAccountId` is set as appropriate. 

this is assumed to be some id and not `null`

> Ensure that `AuditEvent` is checked

this is assumed to be that `category` is `AuditEvent` or `categoryGroup` is `audit`/`allLogs` 

> ... and the retention days is set to 180 days or as appropriate

this is up for discussion with product, currently not implemented as it can't be audited as the original CIS intention given this feature is now deprecated. 

### Screenshot/Data
![Screenshot 2024-01-25 at 20 51 05](https://github.com/elastic/cloudbeat/assets/20814186/77b7d09f-02f5-4be1-878c-2372fa5555d5)



### Related Issues
 - closes https://github.com/elastic/cloudbeat/issues/1757

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [x] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [x] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
