### PR TITLE
Enable post-merge k8s ci

### DIFF
--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -1,8 +1,6 @@
 name: K8s-CI
 
 on:
-  # Skipping pre-merge K8s tests for now
-  # https://github.com/elastic/cloudbeat/issues/1623
   pull_request:
     branches:
       - main
@@ -28,8 +26,6 @@ jobs:
     name: Build
     runs-on: ubuntu-20.04
     timeout-minutes: 40
-    # Skipping post-merge K8s tests until https://github:com/elastic/cloudbeat/issues/1638 is resolved
-    # if: false
     steps:
       # Disk cleanup
       - name: Free Disk Space (Ubuntu)
@@ -111,8 +107,6 @@ jobs:
   k8s_functional_tests:
     # Run only selected tests on PRs
     if: github.event_name == 'pull_request'
-    # Skipping post-merge K8s tests until https://github:com/elastic/cloudbeat/issues/1638 is resolved
-    # if: false
     name: ${{ matrix.test-target }}-tests
     needs: [ Build ]
     runs-on: ubuntu-22.04
@@ -196,9 +190,7 @@ jobs:
   k8s_functional_tests_full:
     # Run full test suit on post-merge
     name: ${{ matrix.test-target }}-${{ matrix.range }}-tests
-    # if: github.event_name == 'push'
-    # Skipping post-merge K8s tests until https://github:com/elastic/cloudbeat/issues/1638 is resolved
-    if: false
+    if: github.event_name == 'push'
     needs: [ Build ]
     runs-on: ubuntu-22.04
     timeout-minutes: 55


### PR DESCRIPTION
### Summary of your changes

This PR enables post merge k8s testing ci.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
