### PR TITLE
Revert upload artifact version from v4 to v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,4 +52,5 @@ updates:
       artifact:
         patterns:
         - "actions/download-artifact"
-        - "actions/upload-artifact"
+        # Skip upload-artifact due to this issue: https://github.com/actions/upload-artifact/issues/478
+        # - "actions/upload-artifact"

--- a/.github/workflows/eks-ci.yml
+++ b/.github/workflows/eks-ci.yml
@@ -211,7 +211,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: allure_results-${{ matrix.test-target}}
           path: ${{ env.REPORTS_DIR }}

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: allure_results-${{ matrix.test-target}}
           path: tests/allure/results/
@@ -413,7 +413,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: allure_results-${{ matrix.test-target}}
           path: tests/allure/results/

--- a/.github/workflows/periodic-ci.yml
+++ b/.github/workflows/periodic-ci.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: allure_results-${{ matrix.test-target}}
           path: tests/allure/results/


### PR DESCRIPTION
### Summary of your changes

The latest version of the upload-artifact action has revealed [this issue](https://github.com/actions/upload-artifact/issues/478), causing a break in the k8s CI. As mentioned in [this comment](https://github.com/actions/upload-artifact/issues/279#issuecomment-1859601387), this issue does not occur with actions/upload-artifact@v3. This PR reverts the upload-artifact action version from v4 to v3.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
