### PR TITLE
Revert download artifacts from v4 to v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,5 +52,10 @@ updates:
       artifact:
         patterns:
         - "actions/download-artifact"
+        - "actions/upload-artifact"
+    ignore:
+      - dependency-name: "github.com/actions/download-artifact"
         # Skip upload-artifact due to this issue: https://github.com/actions/upload-artifact/issues/478
-        # - "actions/upload-artifact"
+        versions: ["4.x"]
+      - dependency-name: "github.com/actions/upload-artifact"
+        versions: ["4.x"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,8 +54,8 @@ updates:
         - "actions/download-artifact"
         - "actions/upload-artifact"
     ignore:
+        # Skip versions 4.x upload-artifact and download-artifact due to this issue: https://github.com/actions/upload-artifact/issues/478
       - dependency-name: "github.com/actions/download-artifact"
-        # Skip upload-artifact due to this issue: https://github.com/actions/upload-artifact/issues/478
         versions: ["4.x"]
       - dependency-name: "github.com/actions/upload-artifact"
         versions: ["4.x"]

--- a/.github/workflows/eks-ci.yml
+++ b/.github/workflows/eks-ci.yml
@@ -229,7 +229,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
 

--- a/.github/workflows/periodic-ci.yml
+++ b/.github/workflows/periodic-ci.yml
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: artifacts
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -43,7 +43,7 @@ jobs:
           cat cover.out.tmp | grep -v "mock_.*.go" > cover.out # remove mock files from coverage report
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: coverage-file
           path: cover.out
@@ -64,7 +64,7 @@ jobs:
         run: go install github.com/mattn/goveralls@latest
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: coverage-file
 


### PR DESCRIPTION
### Summary of your changes

This PR reverts download-artifact action from v4 to v3.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
