### PR TITLE
Update dependabot pattern to ignore github actions update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,7 +55,7 @@ updates:
         - "actions/upload-artifact"
     ignore:
         # Skip versions 4.x upload-artifact and download-artifact due to this issue: https://github.com/actions/upload-artifact/issues/478
-      - dependency-name: "github.com/actions/download-artifact"
-        versions: ["4.x"]
+      - dependency-name: "actions/download-artifact"
+        versions: [">=4.0.0"]
       - dependency-name: "github.com/actions/upload-artifact"
-        versions: ["4.x"]
+        versions: [">=4.0.0"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,5 +57,5 @@ updates:
         # Skip versions 4.x upload-artifact and download-artifact due to this issue: https://github.com/actions/upload-artifact/issues/478
       - dependency-name: "actions/download-artifact"
         versions: [">=4.0.0"]
-      - dependency-name: "github.com/actions/upload-artifact"
+      - dependency-name: "actions/upload-artifact"
         versions: [">=4.0.0"]


### PR DESCRIPTION
### Summary of your changes
This PR fixes pattern to ignore upgrade of upload-artifact and download-artifact to v4

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
