### PR TITLE
Add IT for CIS Azure 6.1, 6.2, 6.3, 6.4

### DIFF
--- a/tests/product/tests/data/azure/azure_networking_test_cases.py
+++ b/tests/product/tests/data/azure/azure_networking_test_cases.py
@@ -7,8 +7,80 @@ Networking identification is performed by resource name.
 from ..azure_test_case import AzureServiceCase
 from ..constants import RULE_PASS_STATUS, RULE_FAIL_STATUS
 
+CIS_6_1 = "CIS 6.1"
+CIS_6_2 = "CIS 6.2"
+CIS_6_3 = "CIS 6.3"
+CIS_6_4 = "CIS 6.4"
 CIS_6_6 = "CIS 6.6"
 CIS_6_5 = "CIS 6.5"
+
+cis_azure_6_1_pass = AzureServiceCase(
+    rule_tag=CIS_6_1,
+    case_identifier="test-vm-pass",
+    expected=RULE_PASS_STATUS,
+)
+
+cis_azure_6_1_fail = AzureServiceCase(
+    rule_tag=CIS_6_1,
+    case_identifier="test-vm-fail",
+    expected=RULE_FAIL_STATUS,
+)
+
+cis_azure_6_1 = {
+    "6.1 Ensure that RDP access from the Internet is evaluated and restricted expect: passed": cis_azure_6_1_pass,
+    "6.1 Ensure that RDP access from the Internet is evaluated and restricted expect: failed": cis_azure_6_1_fail,
+}
+
+cis_azure_6_2_pass = AzureServiceCase(
+    rule_tag=CIS_6_2,
+    case_identifier="test-vm-pass",
+    expected=RULE_PASS_STATUS,
+)
+
+cis_azure_6_2_fail = AzureServiceCase(
+    rule_tag=CIS_6_2,
+    case_identifier="test-vm-fail",
+    expected=RULE_FAIL_STATUS,
+)
+
+cis_azure_6_2 = {
+    "6.2 Ensure that SSH access from the Internet is evaluated and restricted expect: passed": cis_azure_6_2_pass,
+    "6.2 Ensure that SSH access from the Internet is evaluated and restricted expect: failed": cis_azure_6_2_fail,
+}
+
+cis_azure_6_3_pass = AzureServiceCase(
+    rule_tag=CIS_6_3,
+    case_identifier="test-vm-pass",
+    expected=RULE_PASS_STATUS,
+)
+
+cis_azure_6_3_fail = AzureServiceCase(
+    rule_tag=CIS_6_3,
+    case_identifier="test-vm-fail",
+    expected=RULE_FAIL_STATUS,
+)
+
+cis_azure_6_3 = {
+    "6.3 Ensure that UDP access from the Internet is evaluated and restricted expect: passed": cis_azure_6_3_pass,
+    "6.3 Ensure that UDP access from the Internet is evaluated and restricted expect: failed": cis_azure_6_3_fail,
+}
+
+cis_azure_6_4_pass = AzureServiceCase(
+    rule_tag=CIS_6_4,
+    case_identifier="test-vm-pass",
+    expected=RULE_PASS_STATUS,
+)
+
+cis_azure_6_4_fail = AzureServiceCase(
+    rule_tag=CIS_6_4,
+    case_identifier="test-vm-fail",
+    expected=RULE_FAIL_STATUS,
+)
+
+cis_azure_6_4 = {
+    "6.4 Ensure that HTTP(S) access from the Internet is evaluated and restricted expect: passed": cis_azure_6_4_pass,
+    "6.4 Ensure that HTTP(S) access from the Internet is evaluated and restricted expect: failed": cis_azure_6_4_fail,
+}
 
 cis_azure_6_6_pass = AzureServiceCase(
     rule_tag=CIS_6_6,
@@ -47,6 +119,10 @@ cis_azure_6_5 = {
 }
 
 cis_azure_networking_cases = {
+    **cis_azure_6_1,
+    **cis_azure_6_2,
+    **cis_azure_6_3,
+    **cis_azure_6_4,
     **cis_azure_6_6,
     **cis_azure_6_5,
 }


### PR DESCRIPTION
### Summary of your changes

Add integration tests for CIS Azure 6.1, 6.2, 6.3, 6.4


Based on:

- [test-vm-pass](https://portal.azure.com/#@elastic365.onmicrosoft.com/resource/subscriptions/ef111ee2-6c89-4b09-92c6-5c2321f888df/resourceGroups/AZURECLOUDBEATCITESTS/providers/Microsoft.Compute/virtualMachines/TEST-VM-PASS/overview)
- [test-vm-fail](https://portal.azure.com/#@elastic365.onmicrosoft.com/resource/subscriptions/ef111ee2-6c89-4b09-92c6-5c2321f888df/resourceGroups/AzureCloudbeatCITests/providers/Microsoft.Compute/virtualMachines/test-vm-fail/overview)

On the test-vm-pass no inbound port is open. On the test-vm-fail, [ports that fail the 4 rules are configured](https://portal.azure.com/#@elastic365.onmicrosoft.com/resource/subscriptions/ef111ee2-6c89-4b09-92c6-5c2321f888df/resourceGroups/AzureCloudbeatCITests/providers/Microsoft.Network/networkSecurityGroups/vm-cloudbeat-ci-test-fail-nsg/inboundSecurityRules)

### Screenshot/Data
![Screenshot 2024-01-29 at 13 43 52](https://github.com/elastic/cloudbeat/assets/5350001/a1ef768d-1653-432b-b82f-65bfd7c0d3e9)


### Related Issues
- Fixes https://github.com/elastic/cloudbeat/issues/1863

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works