### PR TITLE
Cloud Watch Comparison Algorithm

### DIFF
--- a/internal/resources/providers/aws_cis/monitoring/filter_pattern_parser.go
+++ b/internal/resources/providers/aws_cis/monitoring/filter_pattern_parser.go
@@ -1,0 +1,275 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package monitoring
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const maxDepth = 5
+
+type logicalOperator string
+type comparisonOperator string
+
+const (
+	loAnd logicalOperator = "&&"
+	loOr  logicalOperator = "||"
+
+	coEqual     comparisonOperator = "="
+	coNotEqual  comparisonOperator = "!="
+	coNotExists comparisonOperator = "NOT EXISTS"
+)
+
+func listLogicalOperators() []logicalOperator {
+	return []logicalOperator{loAnd, loOr}
+}
+
+func listComparisonOperator() []comparisonOperator {
+	// This order must be kept because we need to check first different and then equals
+	return []comparisonOperator{coNotExists, coNotEqual, coEqual}
+}
+
+// MetricFilterPattern is a union between simpleExpression and complexExpression
+//
+//	because it can be either one or the other
+type MetricFilterPattern struct {
+	simpleExpression  //nolint:unused
+	complexExpression //nolint:unused
+}
+
+type simpleExpression struct {
+	Simple   bool
+	Left     string
+	Operator comparisonOperator
+	Right    string
+}
+
+func newSimpleExpression(left string, op comparisonOperator, right string) MetricFilterPattern {
+	return MetricFilterPattern{
+		simpleExpression: simpleExpression{
+			Simple:   true,
+			Left:     left,
+			Operator: op,
+			Right:    right,
+		},
+	}
+}
+
+type complexExpression struct {
+	Complex     bool
+	Operator    logicalOperator
+	Expressions []MetricFilterPattern
+}
+
+func newComplexExpression(op logicalOperator, exps ...MetricFilterPattern) MetricFilterPattern {
+	return MetricFilterPattern{
+		complexExpression: complexExpression{
+			Complex:     true,
+			Operator:    op,
+			Expressions: exps,
+		},
+	}
+}
+
+// parseFilterPattern receives a string with CloudWatch FilterPattern syntax and parses to an expressions
+// Known limitations:
+//   - It parses only 5 levels deep expressions. You can increase with maxDepth const. But we don't have that use case
+//   - It doesn't properly handle reserved characters (=, !=, NOT EXISTS, &&, ||) inside strings. We don't have that use case yet
+func parseFilterPattern(s string) (MetricFilterPattern, error) {
+	// remove trailing spaces and { }
+	cleanS := strings.TrimSpace(strings.TrimRight(strings.TrimLeft(strings.TrimSpace(s), "{"), "}"))
+
+	if strings.Count(s, "(") != strings.Count(s, ")") {
+		return MetricFilterPattern{}, errors.New("broken parenthesis")
+	}
+
+	return safeParse(cleanS, 0)
+}
+
+func safeParse(s string, depth int) (MetricFilterPattern, error) {
+	if depth > maxDepth {
+		return MetricFilterPattern{}, errors.New("max depth reached, can't parse this expression")
+	}
+
+	var logicalOp logicalOperator
+	expressions := make([]MetricFilterPattern, 0, 10)
+
+	buf := strings.Builder{}
+	buf.Grow(len(s))
+
+	pointer := 0
+	for len(s) > pointer {
+		r := rune(s[pointer])
+		i := pointer
+		pointer++
+
+		if r == '(' { // If it's a parenthesis opening, resolve the parenthesis
+			exp, closingParenthesisPos, err := resolveParenthesis(s, depth, i)
+			if err != nil {
+				return MetricFilterPattern{}, err
+			}
+			expressions = append(expressions, exp)
+			pointer = closingParenthesisPos + i + 1 // move pointer to the end of what has been already processed
+			continue
+		}
+
+		if _, err := buf.WriteRune(r); err != nil {
+			return MetricFilterPattern{}, fmt.Errorf("could not write rune %v", err)
+		}
+
+		tmpString := buf.String()
+		if contains, op := hasSuffixLogicalOp(tmpString); contains { // && or || marks the end of a Simple MetricFilterPattern
+			if logicalOp == "" { // set the Operator of the MetricFilterPattern without overriding it
+				logicalOp = op
+			}
+
+			if logicalOp != op {
+				return MetricFilterPattern{}, errors.New("not supported comparison with alternating logical operators")
+			}
+
+			cleanSimpleExpression := strings.TrimSuffix(tmpString, string(op))
+
+			var err error
+			expressions, err = appendSimpleExpression(cleanSimpleExpression, expressions)
+			if err != nil {
+				return MetricFilterPattern{}, err
+			}
+
+			buf.Reset()
+			buf.Grow(len(s) - i)
+		}
+	}
+
+	expressions, err := appendSimpleExpression(buf.String(), expressions)
+	if err != nil {
+		return MetricFilterPattern{}, err
+	}
+
+	if len(expressions) == 1 { // unwrap Simple Expressions
+		return expressions[0], nil
+	}
+
+	return newComplexExpression(logicalOp, expressions...), nil
+}
+
+func appendSimpleExpression(s string, expressions []MetricFilterPattern) ([]MetricFilterPattern, error) {
+	expStr := strings.TrimSpace(s)
+	// if the length is zero it means we had an already processed Complex Expressions (between parenthesis)
+	if len(expStr) > 0 {
+		exp, err := parseSimpleStatement(expStr)
+		if err != nil {
+			return nil, err
+		}
+
+		expressions = append(expressions, exp)
+	}
+	return expressions, nil
+}
+
+func resolveParenthesis(s string, depth int, i int) (MetricFilterPattern, int, error) {
+	closingParenthesisPos := matchingParenthesisPos(s[i:])
+	if closingParenthesisPos < 0 {
+		return MetricFilterPattern{}, -1, errors.New("broken parenthesis")
+	}
+
+	subS := s[i+1 : closingParenthesisPos+i] // take what is inside matching parenthesis
+	exp, err := safeParse(subS, depth+1)     // safe sub MetricFilterPattern
+	if err != nil {
+		return MetricFilterPattern{}, -1, err
+	}
+	return exp, closingParenthesisPos, nil
+}
+
+func matchingParenthesisPos(s string) int {
+	parenthesisStack := 0
+	for i, r := range s {
+		if r == '(' {
+			parenthesisStack++
+		}
+
+		if r == ')' {
+			parenthesisStack--
+		}
+
+		if parenthesisStack == 0 {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func parseSimpleStatement(s string) (MetricFilterPattern, error) {
+	buf := strings.Builder{}
+	buf.Grow(len(s))
+
+	var left string
+	var operator comparisonOperator
+	foundOp := false
+
+	for i, r := range s {
+		if buf.Len() == 0 && (r == ' ' || r == '(') { // ignore trailing spaces and (
+			continue
+		}
+
+		if _, err := buf.WriteRune(r); err != nil {
+			return MetricFilterPattern{}, fmt.Errorf("could not write rune %v", err)
+		}
+
+		tmpString := buf.String()
+		if contains, op := hasSuffixComparisonOp(tmpString); contains {
+			if foundOp {
+				return MetricFilterPattern{}, errors.New("got multiple comparison operators")
+			}
+
+			left = strings.TrimSpace(strings.TrimSuffix(tmpString, string(op)))
+			operator = op
+			foundOp = true
+			buf.Reset()
+			buf.Grow(len(s) - i)
+		}
+	}
+
+	if !foundOp {
+		return MetricFilterPattern{}, errors.New("could not find a Operator for this MetricFilterPattern")
+	}
+
+	// Trim trailing spaces and )
+	right := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(buf.String()), ")"))
+	return newSimpleExpression(left, operator, right), nil
+}
+
+func hasSuffixComparisonOp(s string) (bool, comparisonOperator) {
+	for _, op := range listComparisonOperator() {
+		if strings.HasSuffix(s, string(op)) {
+			return true, op
+		}
+	}
+	return false, ""
+}
+
+func hasSuffixLogicalOp(s string) (bool, logicalOperator) {
+	for _, op := range listLogicalOperators() {
+		if strings.HasSuffix(s, string(op)) {
+			return true, op
+		}
+	}
+	return false, ""
+}

--- a/internal/resources/providers/aws_cis/monitoring/filter_pattern_parser_test.go
+++ b/internal/resources/providers/aws_cis/monitoring/filter_pattern_parser_test.go
@@ -200,6 +200,8 @@ Regex replaces    	   16062	     78596 ns/op	   45002 B/op	     147 allocs/op
 func BenchmarkParseFilterPattern(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_, err := parseFilterPattern("{ ($.eventSource = organizations.amazonaws.com) && (($.eventName = \"AttachPolicy\") || ($.eventName = \"CreateAccount\") || ($.eventName = \"CreateOrganizationalUnit\") || ($.eventName = \"CreatePolicy\") || ($.eventName = \"DeclineHandshake\") || ($.eventName = \"DeleteOrganization\") || ($.eventName = \"DeleteOrganizationalUnit\") || ($.eventName = \"DeletePolicy\") || ($.eventName = \"DetachPolicy\") || ($.eventName = \"DisablePolicyType\") || ($.eventName = \"EnablePolicyType\") || ($.eventName = \"InviteAccountToOrganization\") || ($.eventName = \"LeaveOrganization\") || ($.eventName = \"MoveAccount\") || ($.eventName = \"RemoveAccountFromOrganization\") || ($.eventName = \"AcceptHandshake\") ||  ($.eventName = \"UpdatePolicy\") || ($.eventName = \"UpdateOrganizationalUnit\")) }")
-		require.NoError(b, err)
+		if err != nil {
+			b.Fail()
+		}
 	}
 }

--- a/internal/resources/providers/aws_cis/monitoring/filter_pattern_parser_test.go
+++ b/internal/resources/providers/aws_cis/monitoring/filter_pattern_parser_test.go
@@ -1,0 +1,205 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package monitoring
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseFilterPattern(t *testing.T) {
+	cases := map[string]struct {
+		in  string
+		out MetricFilterPattern
+		err error
+	}{
+		"simple expression": {
+			in:  "{$.eventName=DeleteGroupPolicy}",
+			out: newSimpleExpression("$.eventName", coEqual, "DeleteGroupPolicy"),
+		},
+		"simple expression with spaces": {
+			in:  "{   $.eventName = DeleteGroupPolicy   }",
+			out: newSimpleExpression("$.eventName", coEqual, "DeleteGroupPolicy"),
+		},
+		"simple expression with spaces in the middle": {
+			in:  "{   $. eventName = DeleteGroupPolicy   }",
+			out: newSimpleExpression("$. eventName", coEqual, "DeleteGroupPolicy"),
+		},
+		"simple expression with string": {
+			in:  "{   $. eventName = \" String string string  \" }",
+			out: newSimpleExpression("$. eventName", coEqual, "\" String string string  \""),
+		},
+		"simple expression 'different' comparator": {
+			in:  "{   $. eventName != \" String string string  \" }",
+			out: newSimpleExpression("$. eventName", coNotEqual, "\" String string string  \""),
+		},
+		"simple expression 'notExists' comparator": {
+			in:  "{   $.eventName NOT EXISTS }",
+			out: newSimpleExpression("$.eventName", coNotExists, ""),
+		},
+		"simple expression with parenthesis": {
+			in:  "{($.eventName=DeleteGroupPolicy)}",
+			out: newSimpleExpression("$.eventName", coEqual, "DeleteGroupPolicy"),
+		},
+		"simple expression with multiple parenthesis": {
+			in:  "{(((($.eventName=DeleteGroupPolicy))))}",
+			out: newSimpleExpression("$.eventName", coEqual, "DeleteGroupPolicy"),
+		},
+		"simple expression with parenthesis and spaces": {
+			in:  "{   (   $.eventName  =   DeleteGroupPolicy )   }",
+			out: newSimpleExpression("$.eventName", coEqual, "DeleteGroupPolicy"),
+		},
+		"error on broken parenthesis and spaces": {
+			in:  "{   (   $.eventName  =   DeleteGroupPolicy ))   }",
+			err: errors.New("broken parenthesis"),
+		},
+		"error on double operators (double equals)": {
+			in:  "{   $.eventName == a }",
+			err: errors.New("got multiple comparison operators"),
+		},
+		"error on double operators (different and equals)": {
+			in:  "{   $.eventName !== a }",
+			err: errors.New("got multiple comparison operators"),
+		},
+		"error on double operators (after expression)": {
+			in:  "{   $.eventName != a !=}",
+			err: errors.New("got multiple comparison operators"),
+		},
+		"complex expression 2 expressions": {
+			in: "{$.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS}",
+			out: newComplexExpression(loAnd,
+				newSimpleExpression("$.userIdentity.type", coEqual, "\"Root\""),
+				newSimpleExpression("$.userIdentity.invokedBy", coNotExists, "")),
+		},
+		"complex expression 2 expressions with outer parenthesis": {
+			in: "{($.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS)}",
+			out: newComplexExpression(loAnd,
+				newSimpleExpression("$.userIdentity.type", coEqual, "\"Root\""),
+				newSimpleExpression("$.userIdentity.invokedBy", coNotExists, "")),
+		},
+		"complex expression with parenthesis per simple expression": {
+			in: "{($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }",
+			out: newComplexExpression(loOr,
+				newSimpleExpression("$.errorCode", coEqual, "\"*UnauthorizedOperation\""),
+				newSimpleExpression("$.errorCode", coEqual, "\"AccessDenied*\""),
+				newSimpleExpression("$.sourceIPAddress", coNotEqual, "\"delivery.logs.amazonaws.com\""),
+				newSimpleExpression("$.eventName", coNotEqual, "\"HeadBucket\""),
+			),
+		},
+		"complex expression 3 expressions": {
+			in: "{$.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }",
+			out: newComplexExpression(loAnd,
+				newSimpleExpression("$.userIdentity.type", coEqual, "\"Root\""),
+				newSimpleExpression("$.userIdentity.invokedBy", coNotExists, ""),
+				newSimpleExpression("$.eventType", coNotEqual, "\"AwsServiceEvent\""),
+			),
+		},
+		"complex expression 2 logical operators": {
+			in: "{($.eventSource = kms.amazonaws.com) && (($.eventName=DisableKey)||($.eventName=ScheduleKeyDeletion)) }",
+			out: newComplexExpression(loAnd,
+				newSimpleExpression("$.eventSource", coEqual, "kms.amazonaws.com"),
+				newComplexExpression(loOr,
+					newSimpleExpression("$.eventName", coEqual, "DisableKey"),
+					newSimpleExpression("$.eventName", coEqual, "ScheduleKeyDeletion"),
+				),
+			),
+		},
+		"sub expression first": {
+			in: "{ (($.eventName=DisableKey)||($.eventName=ScheduleKeyDeletion)) && ($.eventSource = kms.amazonaws.com) }",
+			out: newComplexExpression(loAnd,
+				newComplexExpression(loOr,
+					newSimpleExpression("$.eventName", coEqual, "DisableKey"),
+					newSimpleExpression("$.eventName", coEqual, "ScheduleKeyDeletion"),
+				),
+				newSimpleExpression("$.eventSource", coEqual, "kms.amazonaws.com"),
+			),
+		},
+		"error on complex expression alternating logical operators": {
+			in:  "{($.eventSource = kms.amazonaws.com) && ($.eventName=DisableKey) || ($.eventName=ScheduleKeyDeletion)}",
+			err: errors.New("not supported comparison with alternating logical operators"),
+		},
+		"4 layers deep expression": {
+			in: "{((a=b) && ((c=d) || ((e=f) && (g!=h || (i=j)))))}",
+			out: newComplexExpression(loAnd,
+				newSimpleExpression("a", coEqual, "b"),
+				newComplexExpression(loOr,
+					newSimpleExpression("c", coEqual, "d"),
+					newComplexExpression(loAnd,
+						newSimpleExpression("e", coEqual, "f"),
+						newComplexExpression(loOr,
+							newSimpleExpression("g", coNotEqual, "h"),
+							newSimpleExpression("i", coEqual, "j"),
+						),
+					),
+				),
+			),
+		},
+		"error on too deep expression": {
+			in:  "{((((((((((((a=b)&&(a=b))&&(a=b))&&(a=b))&&(a=b))&&(a=b))&&(a=b))&&(a=b))&&(a=b))&&(a=b))&&(a=b))&&(a=b))}",
+			err: errors.New("max depth reached, can't parse this expression"),
+		},
+
+		"Long expression": {
+			in: "{ ($.eventSource = organizations.amazonaws.com) && (($.eventName = \"AttachPolicy\") || ($.eventName = \"CreateAccount\") || ($.eventName = \"CreateOrganizationalUnit\") || ($.eventName = \"CreatePolicy\") || ($.eventName = \"DeclineHandshake\") || ($.eventName = \"DeleteOrganization\") || ($.eventName = \"DeleteOrganizationalUnit\") || ($.eventName = \"DeletePolicy\") || ($.eventName = \"DetachPolicy\") || ($.eventName = \"DisablePolicyType\") || ($.eventName = \"EnablePolicyType\") || ($.eventName = \"InviteAccountToOrganization\") || ($.eventName = \"LeaveOrganization\") || ($.eventName = \"MoveAccount\") || ($.eventName = \"RemoveAccountFromOrganization\") || ($.eventName = \"AcceptHandshake\") ||  ($.eventName = \"UpdatePolicy\") || ($.eventName = \"UpdateOrganizationalUnit\")) }",
+			out: newComplexExpression(loAnd,
+				newSimpleExpression("$.eventSource", coEqual, "organizations.amazonaws.com"),
+				newComplexExpression(loOr,
+					newSimpleExpression("$.eventName", coEqual, "\"AttachPolicy\""),
+					newSimpleExpression("$.eventName", coEqual, "\"CreateAccount\""),
+					newSimpleExpression("$.eventName", coEqual, "\"CreateOrganizationalUnit\""),
+					newSimpleExpression("$.eventName", coEqual, "\"CreatePolicy\""),
+					newSimpleExpression("$.eventName", coEqual, "\"DeclineHandshake\""),
+					newSimpleExpression("$.eventName", coEqual, "\"DeleteOrganization\""),
+					newSimpleExpression("$.eventName", coEqual, "\"DeleteOrganizationalUnit\""),
+					newSimpleExpression("$.eventName", coEqual, "\"DeletePolicy\""),
+					newSimpleExpression("$.eventName", coEqual, "\"DetachPolicy\""),
+					newSimpleExpression("$.eventName", coEqual, "\"DisablePolicyType\""),
+					newSimpleExpression("$.eventName", coEqual, "\"EnablePolicyType\""),
+					newSimpleExpression("$.eventName", coEqual, "\"InviteAccountToOrganization\""),
+					newSimpleExpression("$.eventName", coEqual, "\"LeaveOrganization\""),
+					newSimpleExpression("$.eventName", coEqual, "\"MoveAccount\""),
+					newSimpleExpression("$.eventName", coEqual, "\"RemoveAccountFromOrganization\""),
+					newSimpleExpression("$.eventName", coEqual, "\"AcceptHandshake\""),
+					newSimpleExpression("$.eventName", coEqual, "\"UpdatePolicy\""),
+					newSimpleExpression("$.eventName", coEqual, "\"UpdateOrganizationalUnit\""),
+				),
+			),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			s, err := parseFilterPattern(tc.in)
+			require.Equal(t, tc.err, err)
+			require.Equal(t, tc.out, s)
+		})
+	}
+}
+
+/*
+Simple replaces    	   36765	     31604 ns/op	   37096 B/op	      99 allocs/op
+Regex replaces    	   16062	     78596 ns/op	   45002 B/op	     147 allocs/op
+*/
+func BenchmarkParseFilterPattern(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := parseFilterPattern("{ ($.eventSource = organizations.amazonaws.com) && (($.eventName = \"AttachPolicy\") || ($.eventName = \"CreateAccount\") || ($.eventName = \"CreateOrganizationalUnit\") || ($.eventName = \"CreatePolicy\") || ($.eventName = \"DeclineHandshake\") || ($.eventName = \"DeleteOrganization\") || ($.eventName = \"DeleteOrganizationalUnit\") || ($.eventName = \"DeletePolicy\") || ($.eventName = \"DetachPolicy\") || ($.eventName = \"DisablePolicyType\") || ($.eventName = \"EnablePolicyType\") || ($.eventName = \"InviteAccountToOrganization\") || ($.eventName = \"LeaveOrganization\") || ($.eventName = \"MoveAccount\") || ($.eventName = \"RemoveAccountFromOrganization\") || ($.eventName = \"AcceptHandshake\") ||  ($.eventName = \"UpdatePolicy\") || ($.eventName = \"UpdateOrganizationalUnit\")) }")
+		require.NoError(b, err)
+	}
+}

--- a/internal/resources/providers/aws_cis/monitoring/monitoring.go
+++ b/internal/resources/providers/aws_cis/monitoring/monitoring.go
@@ -51,9 +51,14 @@ type (
 		Items []MonitoringItem
 	}
 
+	MetricFilter struct {
+		cloudwatchlogs_types.MetricFilter
+		ParsedFilterPattern MetricFilterPattern
+	}
+
 	MonitoringItem struct {
 		TrailInfo          cloudtrail.TrailInfo
-		MetricFilters      []cloudwatchlogs_types.MetricFilter
+		MetricFilters      []MetricFilter
 		MetricTopicBinding map[string][]string
 	}
 )
@@ -75,12 +80,12 @@ func (p *Provider) AggregateResources(ctx context.Context) (*Resource, error) {
 		return nil, err
 	}
 
-	items := []MonitoringItem{}
+	items := make([]MonitoringItem, 0, len(trails))
 	for _, info := range trails {
 		if info.Trail.CloudWatchLogsLogGroupArn == nil {
 			items = append(items, MonitoringItem{
 				TrailInfo:          info,
-				MetricFilters:      []cloudwatchlogs_types.MetricFilter{},
+				MetricFilters:      []MetricFilter{},
 				MetricTopicBinding: map[string][]string{},
 			})
 			continue
@@ -96,11 +101,13 @@ func (p *Provider) AggregateResources(ctx context.Context) (*Resource, error) {
 			continue
 		}
 
+		parsedMetrics := p.parserMetrics(metrics)
 		names := filterNamesFromMetrics(metrics)
+
 		if len(names) == 0 {
 			items = append(items, MonitoringItem{
 				TrailInfo:          info,
-				MetricFilters:      metrics,
+				MetricFilters:      parsedMetrics,
 				MetricTopicBinding: map[string][]string{},
 			})
 			continue
@@ -117,12 +124,39 @@ func (p *Provider) AggregateResources(ctx context.Context) (*Resource, error) {
 		}
 		items = append(items, MonitoringItem{
 			TrailInfo:          info,
-			MetricFilters:      metrics,
+			MetricFilters:      parsedMetrics,
 			MetricTopicBinding: bindings,
 		})
 	}
 
 	return &Resource{Items: items}, nil
+}
+
+func (p *Provider) parserMetrics(metrics []cloudwatchlogs_types.MetricFilter) []MetricFilter {
+	parsedMetrics := make([]MetricFilter, 0, len(metrics))
+	for _, m := range metrics {
+		if m.FilterPattern == nil {
+			parsedMetrics = append(parsedMetrics, MetricFilter{
+				MetricFilter: m,
+			})
+			continue
+		}
+
+		exp, err := parseFilterPattern(*m.FilterPattern)
+		if err != nil {
+			p.Log.Errorf("failed to parse metric filter pattern: %v (pattern: %s)", err, *m.FilterPattern)
+			parsedMetrics = append(parsedMetrics, MetricFilter{
+				MetricFilter: m,
+			})
+			continue
+		}
+
+		parsedMetrics = append(parsedMetrics, MetricFilter{
+			MetricFilter:        m,
+			ParsedFilterPattern: exp,
+		})
+	}
+	return parsedMetrics
 }
 
 func (p *Provider) getSubscriptionForAlarms(ctx context.Context, region *string, alarms []cloudwatch_types.MetricAlarm) []string {

--- a/internal/resources/providers/aws_cis/monitoring/monitoring_test.go
+++ b/internal/resources/providers/aws_cis/monitoring/monitoring_test.go
@@ -47,7 +47,7 @@ var (
 	filter                         = "metric-filter-name"
 	metricFilterWithExpectedFilter = cloudwatchlogs_types.MetricFilter{
 		FilterName:    aws.String(filter),
-		FilterPattern: aws.String("some-filter-pattern"),
+		FilterPattern: aws.String("{a = b}"),
 	}
 	metricFilterWithoutFilter = cloudwatchlogs_types.MetricFilter{
 		FilterName: aws.String(filter),
@@ -157,8 +157,10 @@ func TestProvider_AggregateResources(t *testing.T) {
 							Status:         expectedCommonTrailStatus,
 							EventSelectors: expectedCommonTrailEventSelector,
 						},
-						MetricFilters: []cloudwatchlogs_types.MetricFilter{
-							metricFilterWithExpectedFilter,
+						MetricFilters: []MetricFilter{
+							{
+								MetricFilter:        metricFilterWithExpectedFilter,
+								ParsedFilterPattern: newSimpleExpression("a", coEqual, "b")},
 						},
 
 						MetricTopicBinding: map[string][]string{
@@ -187,7 +189,9 @@ func TestProvider_AggregateResources(t *testing.T) {
 							EventSelectors: expectedCommonTrailEventSelector,
 						},
 						MetricTopicBinding: map[string][]string{},
-						MetricFilters:      []cloudwatchlogs_types.MetricFilter{metricFilterWithoutFilter},
+						MetricFilters: []MetricFilter{
+							{MetricFilter: metricFilterWithoutFilter},
+						},
 					},
 				},
 			},

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_1/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_1/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_1
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,12 @@ finding = result if {
 	)
 }
 
-required_pattern = "{ ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"
+# { ($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }
+required_pattern = pattern.complex_expression("||", [
+	pattern.simple_expression("$.errorCode", "=", "\"*UnauthorizedOperation\""),
+	pattern.simple_expression("$.errorCode", "=", "\"AccessDenied*\""),
+	pattern.simple_expression("$.sourceIPAddress", "!=", "\"delivery.logs.amazonaws.com\""),
+	pattern.simple_expression("$.eventName", "!=", "\"HeadBucket\""),
+])
 
 rule_evaluation = trail.at_least_one_trail_satisfied([required_pattern])

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_10/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_10/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_10
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,14 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{ ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup) }"]
+# { ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup) }
+required_patterns = [pattern.complex_expression("||", [
+	pattern.simple_expression("$.eventName", "=", "AuthorizeSecurityGroupIngress"),
+	pattern.simple_expression("$.eventName", "=", "AuthorizeSecurityGroupEgress"),
+	pattern.simple_expression("$.eventName", "=", "RevokeSecurityGroupIngress"),
+	pattern.simple_expression("$.eventName", "=", "RevokeSecurityGroupEgress"),
+	pattern.simple_expression("$.eventName", "=", "CreateSecurityGroup"),
+	pattern.simple_expression("$.eventName", "=", "DeleteSecurityGroup"),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_10/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_10/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_10
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +13,18 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup) }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup) }",
+			"ParsedFilterPattern": pattern.complex_expression("||", [
+				pattern.simple_expression("$.eventName", "=", "AuthorizeSecurityGroupEgress"),
+				pattern.simple_expression("$.eventName", "=", "RevokeSecurityGroupEgress"),
+				pattern.simple_expression("$.eventName", "=", "DeleteSecurityGroup"),
+				pattern.simple_expression("$.eventName", "=", "RevokeSecurityGroupIngress"),
+				pattern.simple_expression("$.eventName", "=", "AuthorizeSecurityGroupIngress"),
+				pattern.simple_expression("$.eventName", "=", "CreateSecurityGroup"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_11/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_11/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_11
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,14 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) || ($.eventName = DeleteNetworkAcl) || ($.eventName = DeleteNetworkAclEntry) || ($.eventName = ReplaceNetworkAclEntry) || ($.eventName = ReplaceNetworkAclAssociation) }"]
+# { ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) || ($.eventName = DeleteNetworkAcl) || ($.eventName = DeleteNetworkAclEntry) || ($.eventName = ReplaceNetworkAclEntry) || ($.eventName = ReplaceNetworkAclAssociation) }
+required_patterns = [pattern.complex_expression("||", [
+	pattern.simple_expression("$.eventName", "=", "CreateNetworkAcl"),
+	pattern.simple_expression("$.eventName", "=", "CreateNetworkAclEntry"),
+	pattern.simple_expression("$.eventName", "=", "DeleteNetworkAcl"),
+	pattern.simple_expression("$.eventName", "=", "DeleteNetworkAclEntry"),
+	pattern.simple_expression("$.eventName", "=", "ReplaceNetworkAclEntry"),
+	pattern.simple_expression("$.eventName", "=", "ReplaceNetworkAclAssociation"),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_11/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_11/test.rego
@@ -2,6 +2,8 @@ package compliance.cis_aws.rules.cis_4_11
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
+
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +14,18 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) || ($.eventName = DeleteNetworkAcl) || ($.eventName = DeleteNetworkAclEntry) || ($.eventName = ReplaceNetworkAclEntry) || ($.eventName = ReplaceNetworkAclAssociation) }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventName = CreateNetworkAcl) || ($.eventName = CreateNetworkAclEntry) || ($.eventName = DeleteNetworkAcl) || ($.eventName = DeleteNetworkAclEntry) || ($.eventName = ReplaceNetworkAclEntry) || ($.eventName = ReplaceNetworkAclAssociation) }",
+			"ParsedFilterPattern": pattern.complex_expression("||", [
+				pattern.simple_expression("$.eventName", "=", "CreateNetworkAcl"),
+				pattern.simple_expression("$.eventName", "=", "CreateNetworkAclEntry"),
+				pattern.simple_expression("$.eventName", "=", "DeleteNetworkAcl"),
+				pattern.simple_expression("$.eventName", "=", "DeleteNetworkAclEntry"),
+				pattern.simple_expression("$.eventName", "=", "ReplaceNetworkAclEntry"),
+				pattern.simple_expression("$.eventName", "=", "ReplaceNetworkAclAssociation"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_12/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_12/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_12
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,14 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{ ($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway) }"]
+# { ($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway) }
+required_patterns = [pattern.complex_expression("||", [
+	pattern.simple_expression("$.eventName", "=", "CreateCustomerGateway"),
+	pattern.simple_expression("$.eventName", "=", "DeleteCustomerGateway"),
+	pattern.simple_expression("$.eventName", "=", "AttachInternetGateway"),
+	pattern.simple_expression("$.eventName", "=", "CreateInternetGateway"),
+	pattern.simple_expression("$.eventName", "=", "DeleteInternetGateway"),
+	pattern.simple_expression("$.eventName", "=", "DetachInternetGateway"),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_12/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_12/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_12
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +13,18 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway) }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventName = CreateCustomerGateway) || ($.eventName = DeleteCustomerGateway) || ($.eventName = AttachInternetGateway) || ($.eventName = CreateInternetGateway) || ($.eventName = DeleteInternetGateway) || ($.eventName = DetachInternetGateway) }",
+			"ParsedFilterPattern": pattern.complex_expression("||", [
+				pattern.simple_expression("$.eventName", "=", "AttachInternetGateway"),
+				pattern.simple_expression("$.eventName", "=", "CreateInternetGateway"),
+				pattern.simple_expression("$.eventName", "=", "CreateCustomerGateway"),
+				pattern.simple_expression("$.eventName", "=", "DeleteInternetGateway"),
+				pattern.simple_expression("$.eventName", "=", "DeleteCustomerGateway"),
+				pattern.simple_expression("$.eventName", "=", "DetachInternetGateway"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_13/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_13/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_13
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,15 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{ ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) }"]
+# { ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) }
+required_patterns = [pattern.complex_expression("||", [
+	pattern.simple_expression("$.eventName", "=", "CreateRoute"),
+	pattern.simple_expression("$.eventName", "=", "CreateRouteTable"),
+	pattern.simple_expression("$.eventName", "=", "ReplaceRoute"),
+	pattern.simple_expression("$.eventName", "=", "ReplaceRouteTableAssociation"),
+	pattern.simple_expression("$.eventName", "=", "DeleteRouteTable"),
+	pattern.simple_expression("$.eventName", "=", "DeleteRoute"),
+	pattern.simple_expression("$.eventName", "=", "DisassociateRouteTable"),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_13/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_13/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_13
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +13,19 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) || ($.eventName = ReplaceRoute) || ($.eventName = ReplaceRouteTableAssociation) || ($.eventName = DeleteRouteTable) || ($.eventName = DeleteRoute) || ($.eventName = DisassociateRouteTable) }",
+			"ParsedFilterPattern": pattern.complex_expression("||", [
+				pattern.simple_expression("$.eventName", "=", "CreateRouteTable"),
+				pattern.simple_expression("$.eventName", "=", "DeleteRoute"),
+				pattern.simple_expression("$.eventName", "=", "DisassociateRouteTable"),
+				pattern.simple_expression("$.eventName", "=", "ReplaceRouteTableAssociation"),
+				pattern.simple_expression("$.eventName", "=", "ReplaceRoute"),
+				pattern.simple_expression("$.eventName", "=", "CreateRoute"),
+				pattern.simple_expression("$.eventName", "=", "DeleteRouteTable"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_14/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_14/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_14
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,19 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{ ($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink) }"]
+# { ($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink) }
+required_patterns = [pattern.complex_expression("||", [
+	pattern.simple_expression("$.eventName", "=", "CreateVpc"),
+	pattern.simple_expression("$.eventName", "=", "DeleteVpc"),
+	pattern.simple_expression("$.eventName", "=", "ModifyVpcAttribute"),
+	pattern.simple_expression("$.eventName", "=", "AcceptVpcPeeringConnection"),
+	pattern.simple_expression("$.eventName", "=", "CreateVpcPeeringConnection"),
+	pattern.simple_expression("$.eventName", "=", "DeleteVpcPeeringConnection"),
+	pattern.simple_expression("$.eventName", "=", "RejectVpcPeeringConnection"),
+	pattern.simple_expression("$.eventName", "=", "AttachClassicLinkVpc"),
+	pattern.simple_expression("$.eventName", "=", "DetachClassicLinkVpc"),
+	pattern.simple_expression("$.eventName", "=", "DisableVpcClassicLink"),
+	pattern.simple_expression("$.eventName", "=", "EnableVpcClassicLink"),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_14/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_14/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_14
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +13,23 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink) }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventName = CreateVpc) || ($.eventName = DeleteVpc) || ($.eventName = ModifyVpcAttribute) || ($.eventName = AcceptVpcPeeringConnection) || ($.eventName = CreateVpcPeeringConnection) || ($.eventName = DeleteVpcPeeringConnection) || ($.eventName = RejectVpcPeeringConnection) || ($.eventName = AttachClassicLinkVpc) || ($.eventName = DetachClassicLinkVpc) || ($.eventName = DisableVpcClassicLink) || ($.eventName = EnableVpcClassicLink) }",
+			"ParsedFilterPattern": pattern.complex_expression("||", [
+				pattern.simple_expression("$.eventName", "=", "RejectVpcPeeringConnection"),
+				pattern.simple_expression("$.eventName", "=", "DeleteVpc"),
+				pattern.simple_expression("$.eventName", "=", "ModifyVpcAttribute"),
+				pattern.simple_expression("$.eventName", "=", "CreateVpcPeeringConnection"),
+				pattern.simple_expression("$.eventName", "=", "DisableVpcClassicLink"),
+				pattern.simple_expression("$.eventName", "=", "CreateVpc"),
+				pattern.simple_expression("$.eventName", "=", "AttachClassicLinkVpc"),
+				pattern.simple_expression("$.eventName", "=", "DetachClassicLinkVpc"),
+				pattern.simple_expression("$.eventName", "=", "DeleteVpcPeeringConnection"),
+				pattern.simple_expression("$.eventName", "=", "AcceptVpcPeeringConnection"),
+				pattern.simple_expression("$.eventName", "=", "EnableVpcClassicLink"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_15/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_15/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_15
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,29 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{ ($.eventSource = organizations.amazonaws.com) && (($.eventName = \"AcceptHandshake\") || ($.eventName = \"AttachPolicy\") || ($.eventName = \"CreateAccount\") || ($.eventName = \"CreateOrganizationalUnit\") || ($.eventName = \"CreatePolicy\") || ($.eventName = \"DeclineHandshake\") || ($.eventName = \"DeleteOrganization\") || ($.eventName = \"DeleteOrganizationalUnit\") || ($.eventName = \"DeletePolicy\") || ($.eventName = \"DetachPolicy\") || ($.eventName = \"DisablePolicyType\") || ($.eventName = \"EnablePolicyType\") || ($.eventName = \"InviteAccountToOrganization\") || ($.eventName = \"LeaveOrganization\") || ($.eventName = \"MoveAccount\") || ($.eventName = \"RemoveAccountFromOrganization\") || ($.eventName = \"UpdatePolicy\") || ($.eventName = \"UpdateOrganizationalUnit\")) }"]
+# { ($.eventSource = organizations.amazonaws.com) && (($.eventName = \"AcceptHandshake\") || ($.eventName = \"AttachPolicy\") || ($.eventName = \"CreateAccount\") || ($.eventName = \"CreateOrganizationalUnit\") || ($.eventName = \"CreatePolicy\") || ($.eventName = \"DeclineHandshake\") || ($.eventName = \"DeleteOrganization\") || ($.eventName = \"DeleteOrganizationalUnit\") || ($.eventName = \"DeletePolicy\") || ($.eventName = \"DetachPolicy\") || ($.eventName = \"DisablePolicyType\") || ($.eventName = \"EnablePolicyType\") || ($.eventName = \"InviteAccountToOrganization\") || ($.eventName = \"LeaveOrganization\") || ($.eventName = \"MoveAccount\") || ($.eventName = \"RemoveAccountFromOrganization\") || ($.eventName = \"UpdatePolicy\") || ($.eventName = \"UpdateOrganizationalUnit\")) }
+required_patterns = [pattern.complex_expression("&", [
+	pattern.simple_expression("$.eventSource", "=", "organizations.amazonaws.com"),
+	pattern.complex_expression("||", [
+		pattern.simple_expression("$.eventName", "=", "\"AcceptHandshake\""),
+		pattern.simple_expression("$.eventName", "=", "\"AttachPolicy\""),
+		pattern.simple_expression("$.eventName", "=", "\"CreateAccount\""),
+		pattern.simple_expression("$.eventName", "=", "\"CreateOrganizationalUnit\""),
+		pattern.simple_expression("$.eventName", "=", "\"CreatePolicy\""),
+		pattern.simple_expression("$.eventName", "=", "\"DeclineHandshake\""),
+		pattern.simple_expression("$.eventName", "=", "\"DeleteOrganization\""),
+		pattern.simple_expression("$.eventName", "=", "\"DeleteOrganizationalUnit\""),
+		pattern.simple_expression("$.eventName", "=", "\"DeletePolicy\""),
+		pattern.simple_expression("$.eventName", "=", "\"DetachPolicy\""),
+		pattern.simple_expression("$.eventName", "=", "\"DisablePolicyType\""),
+		pattern.simple_expression("$.eventName", "=", "\"EnablePolicyType\""),
+		pattern.simple_expression("$.eventName", "=", "\"InviteAccountToOrganization\""),
+		pattern.simple_expression("$.eventName", "=", "\"LeaveOrganization\""),
+		pattern.simple_expression("$.eventName", "=", "\"MoveAccount\""),
+		pattern.simple_expression("$.eventName", "=", "\"RemoveAccountFromOrganization\""),
+		pattern.simple_expression("$.eventName", "=", "\"UpdatePolicy\""),
+		pattern.simple_expression("$.eventName", "=", "\"UpdateOrganizationalUnit\""),
+	]),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_15/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_15/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_15
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +13,33 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventSource = organizations.amazonaws.com) && (($.eventName = \"AcceptHandshake\") || ($.eventName = \"AttachPolicy\") || ($.eventName = \"CreateAccount\") || ($.eventName = \"CreateOrganizationalUnit\") || ($.eventName = \"CreatePolicy\") || ($.eventName = \"DeclineHandshake\") || ($.eventName = \"DeleteOrganization\") || ($.eventName = \"DeleteOrganizationalUnit\") || ($.eventName = \"DeletePolicy\") || ($.eventName = \"DetachPolicy\") || ($.eventName = \"DisablePolicyType\") || ($.eventName = \"EnablePolicyType\") || ($.eventName = \"InviteAccountToOrganization\") || ($.eventName = \"LeaveOrganization\") || ($.eventName = \"MoveAccount\") || ($.eventName = \"RemoveAccountFromOrganization\") || ($.eventName = \"UpdatePolicy\") || ($.eventName = \"UpdateOrganizationalUnit\")) }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventSource = organizations.amazonaws.com) && (($.eventName = \"AcceptHandshake\") || ($.eventName = \"AttachPolicy\") || ($.eventName = \"CreateAccount\") || ($.eventName = \"CreateOrganizationalUnit\") || ($.eventName = \"CreatePolicy\") || ($.eventName = \"DeclineHandshake\") || ($.eventName = \"DeleteOrganization\") || ($.eventName = \"DeleteOrganizationalUnit\") || ($.eventName = \"DeletePolicy\") || ($.eventName = \"DetachPolicy\") || ($.eventName = \"DisablePolicyType\") || ($.eventName = \"EnablePolicyType\") || ($.eventName = \"InviteAccountToOrganization\") || ($.eventName = \"LeaveOrganization\") || ($.eventName = \"MoveAccount\") || ($.eventName = \"RemoveAccountFromOrganization\") || ($.eventName = \"UpdatePolicy\") || ($.eventName = \"UpdateOrganizationalUnit\")) }",
+			"ParsedFilterPattern": pattern.complex_expression("&", [
+				pattern.complex_expression("||", [
+					pattern.simple_expression("$.eventName", "=", "\"CreateAccount\""),
+					pattern.simple_expression("$.eventName", "=", "\"DeleteOrganizationalUnit\""),
+					pattern.simple_expression("$.eventName", "=", "\"CreateOrganizationalUnit\""),
+					pattern.simple_expression("$.eventName", "=", "\"CreatePolicy\""),
+					pattern.simple_expression("$.eventName", "=", "\"DeclineHandshake\""),
+					pattern.simple_expression("$.eventName", "=", "\"DeleteOrganization\""),
+					pattern.simple_expression("$.eventName", "=", "\"AttachPolicy\""),
+					pattern.simple_expression("$.eventName", "=", "\"DeletePolicy\""),
+					pattern.simple_expression("$.eventName", "=", "\"DetachPolicy\""),
+					pattern.simple_expression("$.eventName", "=", "\"DisablePolicyType\""),
+					pattern.simple_expression("$.eventName", "=", "\"EnablePolicyType\""),
+					pattern.simple_expression("$.eventName", "=", "\"AcceptHandshake\""),
+					pattern.simple_expression("$.eventName", "=", "\"InviteAccountToOrganization\""),
+					pattern.simple_expression("$.eventName", "=", "\"LeaveOrganization\""),
+					pattern.simple_expression("$.eventName", "=", "\"MoveAccount\""),
+					pattern.simple_expression("$.eventName", "=", "\"RemoveAccountFromOrganization\""),
+					pattern.simple_expression("$.eventName", "=", "\"UpdatePolicy\""),
+					pattern.simple_expression("$.eventName", "=", "\"UpdateOrganizationalUnit\""),
+				]),
+				pattern.simple_expression("$.eventSource", "=", "organizations.amazonaws.com"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_2/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_2/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_2
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -19,8 +20,18 @@ finding = result if {
 }
 
 required_patterns = [
-	"{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }",
-	"{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.type = \"IAMUser\") && ($.responseElements.ConsoleLogin = \"Success\") }",
+	# { ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }
+	pattern.complex_expression("&&", [
+		pattern.simple_expression("$.eventName", "=", "\"ConsoleLogin\""),
+		pattern.simple_expression("$.additionalEventData.MFAUsed", "!=", "\"Yes\""),
+	]),
+	# { ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.type = \"IAMUser\") && ($.responseElements.ConsoleLogin = \"Success\") }
+	pattern.complex_expression("&&", [
+		pattern.simple_expression("$.eventName", "=", "\"ConsoleLogin\""),
+		pattern.simple_expression("$.additionalEventData.MFAUsed", "!=", "\"Yes\""),
+		pattern.simple_expression("$.userIdentity.type", "=", "\"IAMUser\""),
+		pattern.simple_expression("$.responseElements.ConsoleLogin", "=", "\"Success\""),
+	]),
 ]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_2/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_2/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_2
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +13,14 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") }",
+			"ParsedFilterPattern": pattern.complex_expression("&&", [
+				pattern.simple_expression("$.additionalEventData.MFAUsed", "!=", "\"Yes\""),
+				pattern.simple_expression("$.eventName", "=", "\"ConsoleLogin\""),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 
@@ -22,7 +30,16 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.type = \"IAMUser\") && ($.responseElements.ConsoleLogin = \"Success\") }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventName = \"ConsoleLogin\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.type = \"IAMUser\") && ($.responseElements.ConsoleLogin = \"Success\") }",
+			"ParsedFilterPattern": pattern.complex_expression("&&", [
+				pattern.simple_expression("$.eventName", "=", "\"ConsoleLogin\""),
+				pattern.simple_expression("$.responseElements.ConsoleLogin", "=", "\"Success\""),
+				pattern.simple_expression("\"Yes\"", "!=", "$.additionalEventData.MFAUsed"),
+				pattern.simple_expression("$.userIdentity.type", "=", "\"IAMUser\""),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_3/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_3/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_3
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,11 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }"]
+# { $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }
+required_patterns = [pattern.complex_expression("&&", [
+	pattern.simple_expression("$.userIdentity.type", "=", "\"Root\""),
+	pattern.simple_expression("$.userIdentity.invokedBy", "NOT EXISTS", ""),
+	pattern.simple_expression("$.eventType", "!=", "\"AwsServiceEvent\""),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_3/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_3/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_3
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,11 +13,20 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }",
+			"ParsedFilterPattern": pattern.complex_expression("&&", [
+				pattern.simple_expression("$.eventType", "!=", "\"AwsServiceEvent\""),
+				pattern.simple_expression("$.userIdentity.invokedBy", "NOT EXISTS", ""),
+				pattern.simple_expression("$.userIdentity.type", "=", "\"Root\""),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }
 
+# regal ignore:rule-length
 test_fail if {
 	# on the required filter alarm is not configured with sns topic
 	# and on irrelevant filter an alaram is configured
@@ -28,7 +38,45 @@ test_fail if {
 				"Status": {"IsLogging": true},
 				"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 			},
-			"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }"}],
+			"MetricFilters": [{
+				"FilterName": "filter_1",
+				"FilterPattern": "{ $.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }",
+				"ParsedFilterPattern": pattern.complex_expression("&&", [
+					pattern.simple_expression("$.userIdentity.type", "=", "\"Root\""),
+					pattern.simple_expression("$.userIdentity.invokedBy", "NOT EXISTS", ""),
+					pattern.simple_expression("$.eventType", "!=", "\"AwsServiceEvent\""),
+				]),
+			}],
+			"MetricTopicBinding": {},
+		},
+		{
+			"TrailInfo": {
+				"Trail": {"IsMultiRegionTrail": true},
+				"Status": {"IsLogging": true},
+				"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
+			},
+			"MetricFilters": [{"FilterName": "filter_2", "FilterPattern": "{ pattern_not_matched: true }"}],
+			"MetricTopicBinding": {"filter_2": ["arn:aws:...sns"]},
+		},
+	])
+
+	# Different expression
+	eval_fail with input as rule_input([
+		{
+			"TrailInfo": {
+				"Trail": {"IsMultiRegionTrail": true},
+				"Status": {"IsLogging": true},
+				"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
+			},
+			"MetricFilters": [{
+				"FilterName": "filter_1",
+				"FilterPattern": "{ $.userIdentity.type = \"Non Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }",
+				"ParsedFilterPattern": pattern.complex_expression("&&", [
+					pattern.simple_expression("$.userIdentity.type", "=", "\"Non Root\""),
+					pattern.simple_expression("$.userIdentity.invokedBy", "NOT EXISTS", ""),
+					pattern.simple_expression("$.eventType", "!=", "\"AwsServiceEvent\""),
+				]),
+			}],
 			"MetricTopicBinding": {},
 		},
 		{

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_4/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_4/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_4
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,24 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.eventName=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)||($.eventName=DetachGroupPolicy)}"]
+# {($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.eventName=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)||($.eventName=DetachGroupPolicy)}
+required_patterns = [pattern.complex_expression("&&", [
+	pattern.simple_expression("$.eventName", "=", "DeleteGroupPolicy"),
+	pattern.simple_expression("$.eventName", "=", "DeleteRolePolicy"),
+	pattern.simple_expression("$.eventName", "=", "DeleteUserPolicy"),
+	pattern.simple_expression("$.eventName", "=", "PutGroupPolicy"),
+	pattern.simple_expression("$.eventName", "=", "PutRolePolicy"),
+	pattern.simple_expression("$.eventName", "=", "PutUserPolicy"),
+	pattern.simple_expression("$.eventName", "=", "CreatePolicy"),
+	pattern.simple_expression("$.eventName", "=", "DeletePolicy"),
+	pattern.simple_expression("$.eventName", "=", "CreatePolicyVersion"),
+	pattern.simple_expression("$.eventName", "=", "DeletePolicyVersion"),
+	pattern.simple_expression("$.eventName", "=", "AttachRolePolicy"),
+	pattern.simple_expression("$.eventName", "=", "DetachRolePolicy"),
+	pattern.simple_expression("$.eventName", "=", "AttachUserPolicy"),
+	pattern.simple_expression("$.eventName", "=", "DetachUserPolicy"),
+	pattern.simple_expression("$.eventName", "=", "AttachGroupPolicy"),
+	pattern.simple_expression("$.eventName", "=", "DetachGroupPolicy"),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_4/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_4/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_4
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -15,7 +16,27 @@ test_violation if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterPattern": "{($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.event Name=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)||($.eventName=DetachGroupPolicy)}"}],
+		"MetricFilters": [{
+			"FilterPattern": "{($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.event Name=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)}",
+			"ParsedFilterPattern": pattern.complex_expression("&&", [
+				pattern.simple_expression("$.eventName", "=", "DeleteGroupPolicy"),
+				pattern.simple_expression("$.eventName", "=", "DeleteRolePolicy"),
+				pattern.simple_expression("$.eventName", "=", "DeleteUserPolicy"),
+				pattern.simple_expression("$.eventName", "=", "PutGroupPolicy"),
+				pattern.simple_expression("$.eventName", "=", "PutRolePolicy"),
+				pattern.simple_expression("$.eventName", "=", "PutUserPolicy"),
+				pattern.simple_expression("$.eventName", "=", "CreatePolicy"),
+				pattern.simple_expression("$.eventName", "=", "DeletePolicy"),
+				pattern.simple_expression("$.eventName", "=", "CreatePolicyVersion"),
+				pattern.simple_expression("$.eventName", "=", "DeletePolicyVersion"),
+				pattern.simple_expression("$.eventName", "=", "AttachRolePolicy"),
+				pattern.simple_expression("$.eventName", "=", "DetachRolePolicy"),
+				pattern.simple_expression("$.eventName", "=", "AttachUserPolicy"),
+				pattern.simple_expression("$.eventName", "=", "DetachUserPolicy"),
+				pattern.simple_expression("$.eventName", "=", "AttachGroupPolicy"),
+				# One is missing
+			]),
+		}],
 		"Topics": ["arn:aws:...sns"],
 	}])
 }
@@ -27,7 +48,28 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.eventName=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)||($.eventName=DetachGroupPolicy)}"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.eventName=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)||($.eventName=DetachGroupPolicy)}",
+			"ParsedFilterPattern": pattern.complex_expression("&&", [
+				pattern.simple_expression("$.eventName", "=", "DeleteGroupPolicy"),
+				pattern.simple_expression("$.eventName", "=", "DeleteRolePolicy"),
+				pattern.simple_expression("$.eventName", "=", "DeleteUserPolicy"),
+				pattern.simple_expression("$.eventName", "=", "PutGroupPolicy"),
+				pattern.simple_expression("$.eventName", "=", "PutRolePolicy"),
+				pattern.simple_expression("$.eventName", "=", "PutUserPolicy"),
+				pattern.simple_expression("$.eventName", "=", "CreatePolicy"),
+				pattern.simple_expression("$.eventName", "=", "DeletePolicy"),
+				pattern.simple_expression("$.eventName", "=", "CreatePolicyVersion"),
+				pattern.simple_expression("$.eventName", "=", "DeletePolicyVersion"),
+				pattern.simple_expression("$.eventName", "=", "AttachRolePolicy"),
+				pattern.simple_expression("$.eventName", "=", "DetachRolePolicy"),
+				pattern.simple_expression("$.eventName", "=", "AttachUserPolicy"),
+				pattern.simple_expression("$.eventName", "=", "DetachUserPolicy"),
+				pattern.simple_expression("$.eventName", "=", "AttachGroupPolicy"),
+				pattern.simple_expression("$.eventName", "=", "DetachGroupPolicy"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_5/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_5/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_5
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,13 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{ ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) }"]
+# { ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) }
+required_patterns = [pattern.complex_expression("||", [
+	pattern.simple_expression("$.eventName", "=", "CreateTrail"),
+	pattern.simple_expression("$.eventName", "=", "UpdateTrail"),
+	pattern.simple_expression("$.eventName", "=", "DeleteTrail"),
+	pattern.simple_expression("$.eventName", "=", "StartLogging"),
+	pattern.simple_expression("$.eventName", "=", "StopLogging"),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_5/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_5/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_5
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +13,17 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventName = CreateTrail) || ($.eventName = UpdateTrail) || ($.eventName = DeleteTrail) || ($.eventName = StartLogging) || ($.eventName = StopLogging) }",
+			"ParsedFilterPattern": pattern.complex_expression("||", [
+				pattern.simple_expression("StartLogging", "=", "$.eventName"),
+				pattern.simple_expression("$.eventName", "=", "DeleteTrail"),
+				pattern.simple_expression("$.eventName", "=", "UpdateTrail"),
+				pattern.simple_expression("$.eventName", "=", "CreateTrail"),
+				pattern.simple_expression("StopLogging", "=", "$.eventName"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_6/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_6/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_6
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,10 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{ ($.eventName = ConsoleLogin) && ($.errorMessage = \"Failed authentication\") }"]
+# { ($.eventName = ConsoleLogin) && ($.errorMessage = \"Failed authentication\") }
+required_patterns = [pattern.complex_expression("&&", [
+	pattern.simple_expression("$.eventName", "=", "ConsoleLogin"),
+	pattern.simple_expression("$.errorMessage", "=", "\"Failed authentication\""),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_6/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_6/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_6
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +13,14 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventName = ConsoleLogin) && ($.errorMessage = \"Failed authentication\") }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventName = ConsoleLogin) && ($.errorMessage = \"Failed authentication\") }",
+			"ParsedFilterPattern": pattern.complex_expression("&&", [
+				pattern.simple_expression("$.errorMessage", "=", "\"Failed authentication\""),
+				pattern.simple_expression("$.eventName", "=", "ConsoleLogin"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_7/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_7/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_7
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,13 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{($.eventSource = kms.amazonaws.com) && (($.eventName=DisableKey)||($.eventName=ScheduleKeyDeletion)) }"]
+# {($.eventSource = kms.amazonaws.com) && (($.eventName=DisableKey)||($.eventName=ScheduleKeyDeletion)) }
+required_patterns = [pattern.complex_expression("&&", [
+	pattern.simple_expression("$.eventSource", "=", "kms.amazonaws.com"),
+	pattern.complex_expression("||", [
+		pattern.simple_expression("$.eventName", "=", "DisableKey"),
+		pattern.simple_expression("$.eventName", "=", "ScheduleKeyDeletion"),
+	]),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_7/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_7/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_7
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +13,17 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{($.eventSource = kms.amazonaws.com) && (($.eventName=DisableKey)||($.eventName=ScheduleKeyDeletion)) }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{($.eventSource = kms.amazonaws.com) && (($.eventName=DisableKey)||($.eventName=ScheduleKeyDeletion)) }",
+			"ParsedFilterPattern": pattern.complex_expression("&&", [
+				pattern.complex_expression("||", [
+					pattern.simple_expression("$.eventName", "=", "ScheduleKeyDeletion"),
+					pattern.simple_expression("$.eventName", "=", "DisableKey"),
+				]),
+				pattern.simple_expression("$.eventSource", "=", "kms.amazonaws.com"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_8/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_8/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_8
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,20 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{ ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }"]
+# { ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }
+required_patterns = [pattern.complex_expression("&&", [
+	pattern.simple_expression("$.eventSource", "=", "s3.amazonaws.com"),
+	pattern.complex_expression("||", [
+		pattern.simple_expression("$.eventName", "=", "PutBucketAcl"),
+		pattern.simple_expression("$.eventName", "=", "PutBucketPolicy"),
+		pattern.simple_expression("$.eventName", "=", "PutBucketCors"),
+		pattern.simple_expression("$.eventName", "=", "PutBucketLifecycle"),
+		pattern.simple_expression("$.eventName", "=", "PutBucketReplication"),
+		pattern.simple_expression("$.eventName", "=", "DeleteBucketPolicy"),
+		pattern.simple_expression("$.eventName", "=", "DeleteBucketCors"),
+		pattern.simple_expression("$.eventName", "=", "DeleteBucketLifecycle"),
+		pattern.simple_expression("$.eventName", "=", "DeleteBucketReplication"),
+	]),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_8/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_8/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_8
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +13,24 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventSource = s3.amazonaws.com) && (($.eventName = PutBucketAcl) || ($.eventName = PutBucketPolicy) || ($.eventName = PutBucketCors) || ($.eventName = PutBucketLifecycle) || ($.eventName = PutBucketReplication) || ($.eventName = DeleteBucketPolicy) || ($.eventName = DeleteBucketCors) || ($.eventName = DeleteBucketLifecycle) || ($.eventName = DeleteBucketReplication)) }",
+			"ParsedFilterPattern": pattern.complex_expression("&&", [
+				pattern.complex_expression("||", [
+					pattern.simple_expression("$.eventName", "=", "PutBucketPolicy"),
+					pattern.simple_expression("$.eventName", "=", "PutBucketCors"),
+					pattern.simple_expression("$.eventName", "=", "DeleteBucketReplication"),
+					pattern.simple_expression("$.eventName", "=", "DeleteBucketPolicy"),
+					pattern.simple_expression("$.eventName", "=", "PutBucketLifecycle"),
+					pattern.simple_expression("$.eventName", "=", "DeleteBucketLifecycle"),
+					pattern.simple_expression("$.eventName", "=", "PutBucketAcl"),
+					pattern.simple_expression("$.eventName", "=", "DeleteBucketCors"),
+					pattern.simple_expression("$.eventName", "=", "PutBucketReplication"),
+				]),
+				pattern.simple_expression("$.eventSource", "=", "s3.amazonaws.com"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_9/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_9/rule.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_9
 
 import data.compliance.lib.common
 import data.compliance.policy.aws_cloudtrail.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.compliance.policy.aws_cloudtrail.trail
 import future.keywords.if
 
@@ -18,6 +19,15 @@ finding = result if {
 	)
 }
 
-required_patterns = ["{ ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)||($.eventName=DeleteDeliveryChannel) ||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) }"]
+# { ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)($.eventName=DeleteDeliveryChannel) ||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) }
+required_patterns = [pattern.complex_expression("&&", [
+	pattern.simple_expression("$.eventSource", "=", "config.amazonaws.com"),
+	pattern.complex_expression("||", [
+		pattern.simple_expression("$.eventName", "=", "StopConfigurationRecorder"),
+		pattern.simple_expression("$.eventName", "=", "DeleteDeliveryChannel"),
+		pattern.simple_expression("$.eventName", "=", "PutDeliveryChannel"),
+		pattern.simple_expression("$.eventName", "=", "PutConfigurationRecorder"),
+	]),
+])]
 
 rule_evaluation = trail.at_least_one_trail_satisfied(required_patterns)

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_9/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_9/test.rego
@@ -2,6 +2,7 @@ package compliance.cis_aws.rules.cis_4_9
 
 import data.cis_aws.test_data
 import data.compliance.cis_aws.data_adapter
+import data.compliance.policy.aws_cloudtrail.pattern
 import data.lib.test
 import future.keywords.if
 
@@ -12,7 +13,19 @@ test_pass if {
 			"Status": {"IsLogging": true},
 			"EventSelectors": [{"IncludeManagementEvents": true, "ReadWriteType": "All"}],
 		},
-		"MetricFilters": [{"FilterName": "filter_1", "FilterPattern": "{ ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)||($.eventName=DeleteDeliveryChannel) ||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) }"}],
+		"MetricFilters": [{
+			"FilterName": "filter_1",
+			"FilterPattern": "{ ($.eventSource = config.amazonaws.com) && (($.eventName=StopConfigurationRecorder)||($.eventName=DeleteDeliveryChannel) ||($.eventName=PutDeliveryChannel)||($.eventName=PutConfigurationRecorder)) }",
+			"ParsedFilterPattern": pattern.complex_expression("&&", [
+				pattern.complex_expression("||", [
+					pattern.simple_expression("$.eventName", "=", "PutDeliveryChannel"),
+					pattern.simple_expression("$.eventName", "=", "PutConfigurationRecorder"),
+					pattern.simple_expression("$.eventName", "=", "StopConfigurationRecorder"),
+					pattern.simple_expression("$.eventName", "=", "DeleteDeliveryChannel"),
+				]),
+				pattern.simple_expression("$.eventSource", "=", "config.amazonaws.com"),
+			]),
+		}],
 		"MetricTopicBinding": {"filter_1": ["arn:aws:...sns"]},
 	}])
 }

--- a/security-policies/bundle/compliance/policy/aws_cloudtrail/pattern.rego
+++ b/security-policies/bundle/compliance/policy/aws_cloudtrail/pattern.rego
@@ -1,6 +1,8 @@
 package compliance.policy.aws_cloudtrail.pattern
 
+import future.keywords.every
 import future.keywords.if
+import future.keywords.in
 
 # get a filter from a trail has at least one metric filter pattern that matches at least one pattern
 get_filter_matched_to_pattern(trail, patterns) = name if {
@@ -10,3 +12,334 @@ get_filter_matched_to_pattern(trail, patterns) = name if {
 	filter.FilterPattern == pattern
 	name := filter.FilterName
 } else = ""
+
+default parse_expression(s) = {"error": "Could not parse expression"}
+
+parse_expression(s) = expression if { # handle simple expression
+	# Filter
+	is_simple_expression(s)
+
+	# Clean
+	clean_s = clean_full_expression(s)
+
+	# Parse
+	expression = parse_simple_expression(clean_s)
+}
+
+parse_expression(s) = expression if { # handle complex one level deep AND only complex expression
+	# Filter
+	is_complex_expression(s)
+	has_and_operator(s)
+	not has_or_operator(s)
+
+	# Clean and Parse
+	expression = parse_one_level_one_operator_complex_expression(s, "&&")
+}
+
+parse_expression(s) = expression if { # handle complex one level deep OR only complex expression
+	# Filter
+	is_complex_expression(s)
+	not has_and_operator(s)
+	has_or_operator(s)
+
+	# Clean and Parse
+	expression = parse_one_level_one_operator_complex_expression(s, "||")
+}
+
+parse_expression(s) = expression if { # handle complex 2 operator (&& as main operator)
+	# Filter
+	is_complex_expression(s)
+	has_and_operator(s)
+	has_or_operator(s)
+
+	# Clean
+	clean_s = clean_full_expression(s)
+
+	# Filter once it's clean
+	is_main_operator_and(clean_s)
+
+	# Process
+	expression = parse_two_operators_expression(clean_s, "&&")
+}
+
+parse_expression(s) = expression if { # handle complex 2 operator (|| as main operator)
+	# Filter
+	is_complex_expression(s)
+	has_and_operator(s)
+	has_or_operator(s)
+
+	# Clean
+	clean_s = clean_full_expression(s)
+
+	# Filter once it's clean
+	is_main_operator_or(clean_s)
+
+	# Process
+	expression = parse_two_operators_expression(clean_s, "||")
+}
+
+parse_two_operators_expression(clean_s, main_op) = expression if {
+	broken_s = split(clean_s, main_op)
+	expressions = [
+	mapped |
+		original := broken_s[_]
+		mapped := parse_second_level(original)
+	]
+
+	expression = complex_expression(main_op, expressions)
+}
+
+default is_main_operator_and(s) = false
+
+is_main_operator_and(s) if { # if it has no outer parenthesis every sub expression must be either simple or valid or
+	split(s, "")[0] != "("
+	sub_expressions = split(s, "&&")
+	every exp in sub_expressions {
+		is_sub_expression_simple_or_has_or_operator(exp)
+	}
+}
+
+is_main_operator_and(s) if { # if its has outer unwrap it and all sub expessions
+	split(s, "")[0] == "("
+	unwrapped = substring(s, 1, count(s) - 2)
+	is_parenthesis_balanced(unwrapped)
+	sub_expressions = split(unwrapped, "&&")
+	every exp in sub_expressions {
+		is_sub_expression_simple_or_has_or_operator(exp)
+	}
+}
+
+is_main_operator_and(s) if { # try to process with everything is good already in the first place
+	sub_expressions = split(s, "&&")
+	every exp in sub_expressions {
+		is_sub_expression_simple_or_has_or_operator(exp)
+	}
+}
+
+is_sub_expression_simple_or_has_or_operator(s) if {
+	is_parenthesis_balanced(s)
+	has_or_operator(s)
+}
+
+is_sub_expression_simple_or_has_or_operator(s) if {
+	is_simple_expression(s)
+}
+
+default is_main_operator_or(s) = false
+
+is_main_operator_or(s) if { # if it has no outer parenthesis every sub expression must be either simple or valid or
+	split(s, "")[0] != "("
+	sub_expressions = split(s, "||")
+	every exp in sub_expressions {
+		is_sub_expression_simple_or_has_and_operator(exp)
+	}
+}
+
+is_main_operator_or(s) if { # if its has outer unwrap it and all sub expessions
+	split(s, "")[0] == "("
+	unwrapped = substring(s, 1, count(s) - 2)
+	is_parenthesis_balanced(unwrapped)
+	sub_expressions = split(unwrapped, "||")
+	every exp in sub_expressions {
+		is_sub_expression_simple_or_has_and_operator(exp)
+	}
+}
+
+is_main_operator_or(s) if { # try to process with everything is good already in the first place
+	sub_expressions = split(s, "||")
+	every exp in sub_expressions {
+		is_sub_expression_simple_or_has_and_operator(exp)
+	}
+}
+
+is_sub_expression_simple_or_has_and_operator(s) if {
+	is_parenthesis_balanced(s)
+	has_and_operator(s)
+}
+
+is_sub_expression_simple_or_has_and_operator(s) if {
+	is_simple_expression(s)
+}
+
+parse_second_level(s) = expression if {
+	# Filter
+	is_simple_expression(s)
+
+	# Clean
+	clean_s = clean_full_expression(s)
+
+	# Parse
+	expression = parse_simple_expression(clean_s)
+}
+
+parse_second_level(s) = expression if { # handle complex one level deep AND only complex expression
+	# Filter
+	is_complex_expression(s)
+	has_and_operator(s)
+	not has_or_operator(s)
+
+	# Clean and Parse
+	expression = parse_one_level_one_operator_complex_expression(s, "&&")
+}
+
+parse_second_level(s) = expression if { # handle complex one level deep OR only complex expression
+	# Filter
+	is_complex_expression(s)
+	not has_and_operator(s)
+	has_or_operator(s)
+
+	# Clean and Parse
+	expression = parse_one_level_one_operator_complex_expression(s, "||")
+}
+
+parse_second_level(s) = expression if {
+	# Filter
+	is_simple_expression(s)
+
+	# Clean
+	clean_s = clean_full_expression(s)
+
+	# Parse
+	expression = parse_simple_expression(clean_s)
+}
+
+parse_one_level_one_operator_complex_expression(s, op) = expression if {
+	# Clean
+	clean_s = clean_full_expression(s)
+
+	# Parse
+	subStrings = split(clean_s, op)
+	expressions = [
+	mapped |
+		original := subStrings[_]
+		mapped := parse_simple_expression(original)
+	]
+
+	expression = complex_expression(op, expressions)
+}
+
+has_and_operator(s) if {
+	contains(s, "&&")
+}
+
+has_or_operator(s) if {
+	contains(s, "||")
+}
+
+is_simple_expression(s) if {
+	not is_complex_expression(s)
+}
+
+is_complex_expression(s) if {
+	has_and_operator(s)
+}
+
+is_complex_expression(s) if {
+	has_or_operator(s)
+}
+
+parse_simple_expression(s) = expression if { # not equals
+	op := "!="
+	indexof(s, op) > 0
+	parts := split(s, op)
+	count(parts) == 2
+	expression := simple_expression(clean_left(parts[0]), op, clean_right(parts[1]))
+}
+
+parse_simple_expression(s) = expression if { # equals
+	indexof(s, "!=") == -1 # safety to not collide with different implementation
+	op := "="
+	indexof(s, op) > 0
+	parts := split(s, op)
+	count(parts) == 2
+	expression := simple_expression(clean_left(parts[0]), op, clean_right(parts[1]))
+}
+
+parse_simple_expression(s) = expression if { # not exists
+	op := "NOT EXISTS"
+	indexof(s, op) > 0
+	parts := split(s, op)
+	count(parts) > 1
+	expression := simple_expression(clean_left(parts[0]), op, "")
+}
+
+clean_full_expression(s) = clean if {
+	clean = remove_spaces_between_parenthesis(remove_trailing_brackets(s))
+}
+
+remove_trailing_brackets(s) = clean if {
+	no_space = trim_space(s)
+	no_left = trim_left(no_space, "{")
+	no_right = trim_right(no_left, "}")
+	clean = trim_space(no_right)
+}
+
+clean_left(s) = clean if {
+	no_space = trim_space(s)
+	no_parenthesis = trim_left(no_space, "(")
+	clean = trim_space(no_parenthesis)
+}
+
+clean_right(s) = clean if {
+	no_space = trim_space(s)
+	no_parenthesis = trim_right(no_space, ")")
+	clean = trim_space(no_parenthesis)
+}
+
+remove_spaces_between_parenthesis(s) = new_string if {
+	new_string = regex.replace(regex.replace(s, "\\)\\s+\\)", "))"), "\\(\\s+\\(", "((")
+} else = s
+
+complex_expression(op, expressions) = {
+	"operator": op,
+	"expressions": expressions,
+}
+
+simple_expression(left, op, right) = {
+	"left": left,
+	"operator": op,
+	"right": right,
+}
+
+count_parenthesis(l) = val if {
+	l == "("
+	val = 1
+}
+
+count_parenthesis(l) = val if {
+	l == ")"
+	val = -1
+}
+
+count_parenthesis(l) = val if {
+	l != "("
+	l != ")"
+	val = 0
+}
+
+is_parenthesis_balanced(s) if {
+	symbols = split(s, "")
+
+	# First convert everything to 1, 0 or -1
+	values = [vals |
+		symbol := symbols[_]
+		vals := count_parenthesis(symbol)
+	]
+
+	# Then sum every sequential sub set of the array
+	# so for an array of [1, 0, -1], it wil check the sums of:
+	#   [1]
+	#   [1, 0]
+	#   [1, 0, -1]
+	every index, _ in values {
+		subset = [sub |
+			values[i]
+			i <= index # Filter by only indexes lesser than i
+			sub = values[i]
+		]
+
+		sum(subset) >= 0
+	}
+
+	sum(values) == 0 # the total sum must be 0
+} else = false

--- a/security-policies/bundle/compliance/policy/aws_cloudtrail/pattern.rego
+++ b/security-policies/bundle/compliance/policy/aws_cloudtrail/pattern.rego
@@ -9,65 +9,59 @@ get_filter_matched_to_pattern(trail, patterns) = name if {
 	some i, j
 	filter := trail.MetricFilters[i]
 	pattern := patterns[j]
-	expressions_equivalent(filter.FilterPattern, pattern)
+	expressions_equivalent(filter.ParsedFilterPattern, pattern)
 	name := filter.FilterName
 } else = ""
 
 complex_expression(op, expressions) = {
-	"complex": true,
-	"operator": op,
-	"expressions": expressions,
+	"Complex": true,
+	"Operator": op,
+	"Expressions": expressions,
 }
 
 simple_expression(left, op, right) = {
-	"simple": true,
-	"left": left,
-	"operator": op,
-	"right": right,
+	"Simple": true,
+	"Left": left,
+	"Operator": op,
+	"Right": right,
 }
 
-default expressions_equivalent(expression1, expression2) = false
+# Known limitations on checking expressions equivalence:
+#   - It supports only two levels deep expressions (2 levels are as deep as our uses cases go)
+default expressions_equivalent(_, _) = false
 
-expressions_equivalent(str1, str2) if {
-	exp1 = parse_expression(str1)
-	not exp1.error
-	exp2 = parse_expression(str2)
-	not exp2.error
+expressions_equivalent(exp1, exp2) if {
 	compare_simple_expressions(exp1, exp2)
 }
 
-expressions_equivalent(str1, str2) if {
-	exp1 = parse_expression(str1)
-	not exp1.error
-	exp2 = parse_expression(str2)
-	not exp2.error
+expressions_equivalent(exp1, exp2) if {
 	compare_complex_expressions(exp1, exp2)
 }
 
 compare_simple_expressions(exp1, exp2) if {
-	exp1.simple
-	exp2.simple
-	exp1.left == exp2.left
-	exp1.operator == exp2.operator
-	exp1.right == exp2.right
+	exp1.Simple
+	exp2.Simple
+	exp1.Left == exp2.Left
+	exp1.Operator == exp2.Operator
+	exp1.Right == exp2.Right
 }
 
 compare_simple_expressions(exp1, exp2) if {
-	exp1.simple
-	exp2.simple
-	exp1.left == exp2.right
-	exp1.operator == exp2.operator
-	exp1.right == exp2.left
+	exp1.Simple
+	exp2.Simple
+	exp1.Left == exp2.Right
+	exp1.Operator == exp2.Operator
+	exp1.Right == exp2.Left
 }
 
 compare_complex_expressions(exp1, exp2) if {
-	exp1.complex
-	exp2.complex
-	exp1.operator == exp2.operator
-	count(exp1.expressions) == count(exp2.expressions)
+	exp1.Complex
+	exp2.Complex
+	exp1.Operator == exp2.Operator
+	count(exp1.Expressions) == count(exp2.Expressions)
 
-	every subExp1 in exp1.expressions {
-		some subExp2 in exp2.expressions
+	every subExp1 in exp1.Expressions {
+		some subExp2 in exp2.Expressions
 		compare_expressions_second_level(subExp1, subExp2)
 	}
 }
@@ -81,468 +75,13 @@ compare_expressions_second_level(exp1, exp2) if {
 }
 
 compare_complex_expressions_second_level(exp1, exp2) if {
-	exp1.complex
-	exp2.complex
-	exp1.operator == exp2.operator
-	count(exp1.expressions) == count(exp2.expressions)
+	exp1.Complex
+	exp2.Complex
+	exp1.Operator == exp2.Operator
+	count(exp1.Expressions) == count(exp2.Expressions)
 
-	every subExp1 in exp1.expressions {
-		some subExp2 in exp2.expressions
+	every subExp1 in exp1.Expressions {
+		some subExp2 in exp2.Expressions
 		compare_simple_expressions(subExp1, subExp2)
 	}
-}
-
-default parse_expression(s) = {"error": "Could not parse expression"}
-
-parse_expression(s) = expression if { # handle simple expression
-	# Filter
-	is_simple_expression(s)
-
-	# Clean
-	clean_s = clean_full_expression(s)
-
-	# Parse
-	expression = parse_simple_expression(clean_s)
-}
-
-parse_expression(s) = expression if { # handle complex one level deep AND only complex expression
-	# Filter
-	is_complex_expression(s)
-	has_and_operator(s)
-	not has_or_operator(s)
-
-	# Clean and Parse
-	expression = parse_one_level_one_operator_complex_expression(s, "&&")
-}
-
-parse_expression(s) = expression if { # handle complex one level deep OR only complex expression
-	# Filter
-	is_complex_expression(s)
-	not has_and_operator(s)
-	has_or_operator(s)
-
-	# Clean and Parse
-	expression = parse_one_level_one_operator_complex_expression(s, "||")
-}
-
-parse_expression(s) = expression if { # handle complex 2 operator (&& as main operator)
-	# Filter
-	is_complex_expression(s)
-	has_and_operator(s)
-	has_or_operator(s)
-	is_main_operator_and(s)
-
-	# Clean
-	clean_s = clean_full_expression(s)
-
-	# Process
-	expression = parse_two_operators_expression(clean_s, "&&")
-}
-
-parse_expression(s) = expression if { # handle complex 2 operator (|| as main operator)
-	# Filter
-	is_complex_expression(s)
-	has_and_operator(s)
-	has_or_operator(s)
-	is_main_operator_or(s)
-
-	# Clean
-	clean_s = clean_full_expression(s)
-
-	# Process
-	expression = parse_two_operators_expression(clean_s, "||")
-}
-
-is_simple_expression(s) if {
-	find_complexity(s) == "SIMPLE"
-}
-
-is_complex_expression(s) if {
-	find_complexity(s) == "COMPLEX"
-}
-
-parse_two_operators_expression(clean_s, main_op) = expression if {
-	broken_s = split(clean_s, main_op)
-	expressions = [
-	mapped |
-		original := broken_s[_]
-		mapped := parse_second_level(original)
-	]
-
-	expression = complex_expression(main_op, expressions)
-}
-
-is_sub_expression_simple_or_has_or_operator(s) if {
-	is_parenthesis_balanced(s)
-	has_or_operator(s)
-}
-
-is_sub_expression_simple_or_has_or_operator(s) if {
-	is_simple_expression(s)
-}
-
-is_sub_expression_simple_or_has_and_operator(s) if {
-	is_parenthesis_balanced(s)
-	has_and_operator(s)
-}
-
-is_sub_expression_simple_or_has_and_operator(s) if {
-	is_simple_expression(s)
-}
-
-parse_second_level(s) = expression if {
-	# Filter
-	is_simple_expression(s)
-
-	# Parse
-	expression = parse_simple_expression(s)
-}
-
-parse_second_level(s) = expression if { # handle complex one level deep AND only complex expression
-	# Filter
-	is_complex_expression(s)
-	has_and_operator(s)
-	not has_or_operator(s)
-
-	# Clean and Parse
-	expression = parse_one_level_one_operator_complex_expression(s, "&&")
-}
-
-parse_second_level(s) = expression if { # handle complex one level deep OR only complex expression
-	# Filter
-	is_complex_expression(s)
-	not has_and_operator(s)
-	has_or_operator(s)
-
-	# Clean and Parse
-	expression = parse_one_level_one_operator_complex_expression(s, "||")
-}
-
-parse_second_level(s) = expression if {
-	# Filter
-	is_simple_expression(s)
-
-	# Parse
-	expression = parse_simple_expression(s)
-}
-
-parse_one_level_one_operator_complex_expression(s, op) = expression if {
-	# Clean
-	clean_s = clean_full_expression(s)
-
-	# Parse
-	subStrings = split(clean_s, op)
-	expressions = [
-	mapped |
-		original := subStrings[_]
-		mapped := parse_simple_expression(original)
-	]
-
-	expression = complex_expression(op, expressions)
-}
-
-has_and_operator(s) if {
-	contains(s, "&&")
-}
-
-has_or_operator(s) if {
-	contains(s, "||")
-}
-
-parse_simple_expression(s) = expression if { # not equals
-	op := "!="
-	indexof(s, op) > 0
-	parts := split(s, op)
-	count(parts) == 2
-	expression := simple_expression(clean_left(parts[0]), op, clean_right(parts[1]))
-}
-
-parse_simple_expression(s) = expression if { # equals
-	indexof(s, "!=") == -1 # safety to not collide with different implementation
-	op := "="
-	indexof(s, op) > 0
-	parts := split(s, op)
-	count(parts) == 2
-	expression := simple_expression(clean_left(parts[0]), op, clean_right(parts[1]))
-}
-
-parse_simple_expression(s) = expression if { # not exists
-	op := "NOT EXISTS"
-	indexof(s, op) > 0
-	parts := split(s, op)
-	count(parts) > 1
-	expression := simple_expression(clean_left(parts[0]), op, "")
-}
-
-clean_full_expression(s) = clean if {
-	clean = remove_space_between_parenthesis(remove_trailing_brackets(s))
-}
-
-remove_space_between_parenthesis(s) = clean if {
-	clean_l = regex.replace(s, "(?:\\()\\s+\\(", "((")
-	clean = regex.replace(clean_l, "\\)\\s+\\)", "))")
-} else = s
-
-remove_trailing_brackets(s) = clean if {
-	no_space = trim_space(s)
-	no_left = trim_left(no_space, "{")
-	no_right = trim_right(no_left, "}")
-	clean = trim_space(no_right)
-}
-
-clean_left(s) = clean if {
-	no_space = trim_space(s)
-	no_parenthesis = trim_left(no_space, "(")
-	clean = trim_space(no_parenthesis)
-}
-
-clean_right(s) = clean if {
-	no_space = trim_space(s)
-	no_parenthesis = trim_right(no_space, ")")
-	clean = trim_space(no_parenthesis)
-}
-
-default count_parenthesis(l) = 0
-
-count_parenthesis(l) = val if {
-	l == "("
-	val = 1
-}
-
-count_parenthesis(l) = val if {
-	l == ")"
-	val = -1
-}
-
-default is_parenthesis_balanced(s) = false
-
-is_parenthesis_balanced(s) if {
-	symbols = split(s, "")
-
-	# First convert everything to 1, 0 or -1
-	values = [vals |
-		symbol := symbols[_]
-		vals := count_parenthesis(symbol)
-	]
-
-	# Then sum every sequential sub set of the array
-	# so for an array of [1, 0, -1], it wil check the sums of:
-	#   [1]
-	#   [1, 0]
-	#   [1, 0, -1]
-	every index, _ in values {
-		subset = [sub |
-			values[i]
-			i <= index # Filter by only indexes lesser than i
-			sub = values[i]
-		]
-
-		sum(subset) >= 0
-	}
-
-	sum(values) == 0 # the total sum must be 0
-}
-
-count_parenthesis_levels(s) = levels if {
-	symbols = split(s, "")
-
-	# First convert everything to 1, 0 or -1
-	values = [vals |
-		symbol := symbols[_]
-		vals := count_parenthesis(symbol)
-	]
-
-	# Sum subsets of values to find the levels. e.g
-	# Given the symbols
-	#   [ (, a, =, b, ) ]
-	# This is converted to values
-	#   [ 1, 0, 0, 0, -1 ]
-	# When performing the sum for each index of values from 0 until the index, we get the array
-	#   [ 1, 1, 1, 1, 0 ]
-	# That because for each index the following sum is performed:
-	#   idx 0 -> sum([ 1 ]) = 1
-	#   idx 1 -> sum([ 1, 0 ]) = 1
-	#   idx 2 -> sum([ 1, 0, 0 ]) = 1
-	#   idx 3 -> sum([ 1, 0, 0, 0 ]) = 1
-	#   idx 4 -> sum([ 1, 0, 0, 0, -1 ]) = 0
-
-	subset = [sub |
-		values[i]
-		sub = sum(array.slice(values, 0, i + 1))
-	]
-
-	levels = max(subset)
-}
-
-default count_complexity_symbols(l) = 0
-
-# We use prime numbers to make sure that the complexity division won't have colisions
-# We won't ever get there, but good to know, if we ever get to 23 levels, colisions will exist
-
-and_complexity_score := 29 # prime number
-
-count_complexity_symbols(l) = val if {
-	l == "&"
-	val = and_complexity_score
-}
-
-or_complexity_score := 23 # prime number
-
-count_complexity_symbols(l) = val if {
-	l == "|"
-	val = or_complexity_score
-}
-
-get_leveled_operators(s) = leveled_operators if {
-	symbols = split(s, "")
-
-	# First grab parentehsis
-	parenthesis = [vals |
-		symbol := symbols[_]
-		vals := count_parenthesis(symbol)
-	]
-
-	# Reduce parenthesis to levels
-	levels = [sub |
-		parenthesis[i]
-		sub = sum(array.slice(parenthesis, 0, i + 1))
-	]
-
-	# Then find symbols times their level (in a set for efficiency since order don't matter here)
-	leveled_operators = {vals |
-		symbol := symbols[i]
-		vals := count_complexity_symbols(symbol) * (levels[i] + 1)
-	}
-}
-
-default find_complexity(s) = "INVALID"
-
-max_allowed_complexity := 2
-
-find_complexity(s) = complexity if {
-	# Filter
-	count_complexity_levels(s) <= max_allowed_complexity
-	is_parenthesis_balanced(s)
-
-	leveled_operators = get_leveled_operators(s)
-
-	# There are no symbol
-	leveled_operators = {0}
-	complexity = "SIMPLE"
-}
-
-find_complexity(s) = complexity if {
-	# Filter
-	count_complexity_levels(s) <= max_allowed_complexity
-	is_parenthesis_balanced(s)
-
-	leveled_operators = get_leveled_operators(s)
-
-	# There are symbols
-	leveled_operators != {0}
-
-	# If in any level we have symbols twice it's invalid
-	every level in numbers.range(1, count_parenthesis_levels(s) + 1) {
-		level_not_contains_double_operators(level, leveled_operators)
-	}
-
-	complexity = "COMPLEX"
-}
-
-default level_not_contains_double_operators(level, leveled_operators) = false
-
-# doesn't contain at all
-level_not_contains_double_operators(level, leveled_operators) if {
-	not leveled_operators[level * and_complexity_score]
-	not leveled_operators[level * or_complexity_score]
-}
-
-# doesn't contain only AND
-level_not_contains_double_operators(level, leveled_operators) if {
-	leveled_operators[level * and_complexity_score]
-	not leveled_operators[level * or_complexity_score]
-}
-
-# doesn't contain only OR
-level_not_contains_double_operators(level, leveled_operators) if {
-	leveled_operators[level * or_complexity_score]
-	not leveled_operators[level * and_complexity_score]
-}
-
-default is_main_operator_and(s) = false
-
-is_main_operator_and(s) if {
-	leveled_operators = get_leveled_operators(s)
-	levels = numbers.range(1, count_parenthesis_levels(s) + 1)
-
-	# Check what is the operator of each level
-	main_operator_per_level = [main |
-		level = levels[_]
-		main = main_operator_in_level(level, leveled_operators)
-	]
-
-	levels_with_and_as_main = [level |
-		op = main_operator_per_level[level]
-		op == "AND"
-	]
-
-	levels_with_or_as_main = [level |
-		op = main_operator_per_level[level]
-		op == "OR"
-	]
-
-	min(levels_with_and_as_main) < min(levels_with_or_as_main)
-}
-
-default is_main_operator_or(s) = false
-
-is_main_operator_or(s) if {
-	leveled_operators = get_leveled_operators(s)
-	levels = numbers.range(1, count_parenthesis_levels(s) + 1)
-
-	# Check what is the operator of each level
-	main_operator_per_level = [main |
-		level = levels[_]
-		main = main_operator_in_level(level, leveled_operators)
-	]
-
-	levels_with_and_as_main = [level |
-		op = main_operator_per_level[level]
-		op == "AND"
-	]
-
-	levels_with_or_as_main = [level |
-		op = main_operator_per_level[level]
-		op == "OR"
-	]
-
-	min(levels_with_and_as_main) > min(levels_with_or_as_main)
-}
-
-default main_operator_in_level(level, leveled_operators) = ""
-
-main_operator_in_level(level, leveled_operators) = main if {
-	leveled_operators[level * and_complexity_score]
-	not leveled_operators[level * or_complexity_score]
-	main = "AND"
-}
-
-main_operator_in_level(level, leveled_operators) = main if {
-	leveled_operators[level * or_complexity_score]
-	not leveled_operators[level * and_complexity_score]
-	main = "OR"
-}
-
-count_complexity_levels(s) = valid_levels if {
-	leveled_operators = get_leveled_operators(s)
-	levels = numbers.range(1, count_parenthesis_levels(s) + 1)
-
-	# Check what is the operator of each level
-	main_operator_per_level = [main |
-		level = levels[_]
-		main = main_operator_in_level(level, leveled_operators)
-		main != ""
-	]
-
-	valid_levels = count(main_operator_per_level)
 }

--- a/security-policies/bundle/compliance/policy/aws_cloudtrail/pattern_test.rego
+++ b/security-policies/bundle/compliance/policy/aws_cloudtrail/pattern_test.rego
@@ -23,3 +23,239 @@ test_fail if {
 	get_filter_matched_to_pattern({"MetricFilters": [filter_1, filter_2]}, [pattern_never_match]) == ""
 	get_filter_matched_to_pattern({"MetricFilters": []}, []) == ""
 }
+
+test_parse if {
+	is_equal(
+		"simple expression",
+		parse_expression("{$.eventName=DeleteGroupPolicy}"),
+		simple_expression("$.eventName", "=", "DeleteGroupPolicy"),
+	)
+
+	is_equal(
+		"simple expression with spaces",
+		parse_expression("{   $.eventName = DeleteGroupPolicy   }"),
+		simple_expression("$.eventName", "=", "DeleteGroupPolicy"),
+	)
+
+	is_equal(
+		"simple expression with spaces in the middle",
+		parse_expression("{   $. eventName = DeleteGroupPolicy   }"),
+		simple_expression("$. eventName", "=", "DeleteGroupPolicy"),
+	)
+
+	is_equal(
+		"simple expression with string",
+		parse_expression("{   $. eventName = \" String string string  \" }"),
+		simple_expression("$. eventName", "=", "\" String string string  \""),
+	)
+
+	is_equal(
+		"simple expression 'different' comparator",
+		parse_expression("{   $. eventName != \" String string string  \" }"),
+		simple_expression("$. eventName", "!=", "\" String string string  \""),
+	)
+
+	is_equal(
+		"simple expression 'notExists' comparator",
+		parse_expression("{   $.eventName NOT EXISTS }"),
+		simple_expression("$.eventName", "NOT EXISTS", ""),
+	)
+
+	is_equal(
+		"simple expression with parenthesis",
+		parse_expression("{($.eventName=DeleteGroupPolicy)}"),
+		simple_expression("$.eventName", "=", "DeleteGroupPolicy"),
+	)
+
+	is_equal(
+		"simple expression with multiple parenthesis",
+		parse_expression("{(($.eventName=DeleteGroupPolicy))}"),
+		simple_expression("$.eventName", "=", "DeleteGroupPolicy"),
+	)
+
+	is_equal(
+		"simple expression with parenthesis and spaces",
+		parse_expression("{   (   $.eventName  =   DeleteGroupPolicy )   }"),
+		simple_expression("$.eventName", "=", "DeleteGroupPolicy"),
+	)
+
+	is_equal(
+		"complex expression 2 expressions AND operator",
+		parse_expression("{$.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS}"),
+		complex_expression("&&", [
+			simple_expression("$.userIdentity.type", "=", "\"Root\""),
+			simple_expression("$.userIdentity.invokedBy", "NOT EXISTS", ""),
+		]),
+	)
+
+	is_equal(
+		"complex expression 2 expressions OR operator",
+		parse_expression("{$.userIdentity.type = \"Root\" || $.userIdentity.invokedBy NOT EXISTS}"),
+		complex_expression("||", [
+			simple_expression("$.userIdentity.type", "=", "\"Root\""),
+			simple_expression("$.userIdentity.invokedBy", "NOT EXISTS", ""),
+		]),
+	)
+
+	is_equal(
+		"complex expression 2 expressions with outer parenthesis",
+		parse_expression("{($.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS)}"),
+		complex_expression("&&", [
+			simple_expression("$.userIdentity.type", "=", "\"Root\""),
+			simple_expression("$.userIdentity.invokedBy", "NOT EXISTS", ""),
+		]),
+	)
+
+	is_equal(
+		"complex expression with parenthesis per simple expression",
+		parse_expression("{($.errorCode = \"*UnauthorizedOperation\") || ($.errorCode = \"AccessDenied*\") || ($.sourceIPAddress!=\"delivery.logs.amazonaws.com\") || ($.eventName!=\"HeadBucket\") }"),
+		complex_expression("||", [
+			simple_expression("$.errorCode", "=", "\"*UnauthorizedOperation\""),
+			simple_expression("$.errorCode", "=", "\"AccessDenied*\""),
+			simple_expression("$.sourceIPAddress", "!=", "\"delivery.logs.amazonaws.com\""),
+			simple_expression("$.eventName", "!=", "\"HeadBucket\""),
+		]),
+	)
+
+	is_equal(
+		"complex expression 3 expressions",
+		parse_expression("{$.userIdentity.type = \"Root\" && $.userIdentity.invokedBy NOT EXISTS && $.eventType != \"AwsServiceEvent\" }"),
+		complex_expression("&&", [
+			simple_expression("$.userIdentity.type", "=", "\"Root\""),
+			simple_expression("$.userIdentity.invokedBy", "NOT EXISTS", ""),
+			simple_expression("$.eventType", "!=", "\"AwsServiceEvent\""),
+		]),
+	)
+
+	is_equal(
+		"complex expression 2 logical operators AND main OR sub",
+		parse_expression("{($.eventSource = kms.amazonaws.com) && (($.eventName=DisableKey)||($.eventName=ScheduleKeyDeletion)) }"),
+		complex_expression("&&", [
+			simple_expression("$.eventSource", "=", "kms.amazonaws.com"),
+			complex_expression("||", [
+				simple_expression("$.eventName", "=", "DisableKey"),
+				simple_expression("$.eventName", "=", "ScheduleKeyDeletion"),
+			]),
+		]),
+	)
+
+	is_equal(
+		"complex expression 2 logical operators || main OR sub",
+		parse_expression("{($.eventSource = kms.amazonaws.com) || (($.eventName=DisableKey)&&($.eventName=ScheduleKeyDeletion)) }"),
+		complex_expression("||", [
+			simple_expression("$.eventSource", "=", "kms.amazonaws.com"),
+			complex_expression("&&", [
+				simple_expression("$.eventName", "=", "DisableKey"),
+				simple_expression("$.eventName", "=", "ScheduleKeyDeletion"),
+			]),
+		]),
+	)
+
+	is_equal(
+		"complex expression 2 logical operators AND main AND sub",
+		parse_expression("{($.eventSource = kms.amazonaws.com) && (($.eventName=DisableKey)&&($.eventName=ScheduleKeyDeletion)) }"),
+		complex_expression("&&", [
+			simple_expression("$.eventSource", "=", "kms.amazonaws.com"),
+			simple_expression("$.eventName", "=", "DisableKey"),
+			simple_expression("$.eventName", "=", "ScheduleKeyDeletion"),
+		]),
+	)
+
+	is_equal(
+		"sub expression first",
+		parse_expression("{ (($.eventName=DisableKey)||($.eventName=ScheduleKeyDeletion)) && ($.eventSource = kms.amazonaws.com) }"),
+		complex_expression("&&", [
+			complex_expression("||", [
+				simple_expression("$.eventName", "=", "DisableKey"),
+				simple_expression("$.eventName", "=", "ScheduleKeyDeletion"),
+			]),
+			simple_expression("$.eventSource", "=", "kms.amazonaws.com"),
+		]),
+	)
+
+    # TODO BROKEN TEST NEED TO FIND A WAY TO INDENTIFY ALTERNATING LOGICAL OPERATORS
+	is_equal(
+		"error on expression alternating logical operators",
+		parse_expression("{($.eventSource = kms.amazonaws.com) && ($.eventName=DisableKey) || ($.eventName=ScheduleKeyDeletion)}"),
+		complex_expression("&&", [
+			simple_expression("$.eventSource", "=", "kms.amazonaws.com"),
+			complex_expression("||", [
+				simple_expression("$.eventName", "=", "DisableKey"),
+				simple_expression("$.eventName", "=", "ScheduleKeyDeletion"),
+			]),
+		]),
+	)
+}
+
+test_remove_spaces_between_parenthesis if {
+	is_equal("no parenthesis", remove_spaces_between_parenthesis("a=b"), "a=b")
+	is_equal("simple parenthesis", remove_spaces_between_parenthesis("(a=b)"), "(a=b)")
+	is_equal("double parenthesis", remove_spaces_between_parenthesis("((a=b))"), "((a=b))")
+	is_equal("double parenthesis with space", remove_spaces_between_parenthesis("( (a=b) )"), "((a=b))")
+	is_equal("double parenthesis with multiple spaces", remove_spaces_between_parenthesis("(\t    (a=b) )"), "((a=b))")
+	is_equal("double parenthesis with trailing spaces", remove_spaces_between_parenthesis("  (\t    (a=b) )  "), "  ((a=b))  ")
+}
+
+test_is_parenthesis_balanced if {
+	is_equal("simple parenthesis", is_parenthesis_balanced("()"), true)
+	is_equal("broken parenthesis", is_parenthesis_balanced(")("), false)
+	is_equal("broken parenthesis 2", is_parenthesis_balanced("())"), false)
+	is_equal("broken parenthesis 3", is_parenthesis_balanced(")())"), false)
+	is_equal("simple parenthesis with content", is_parenthesis_balanced("(a=b)"), true)
+	is_equal("sub parenthesis", is_parenthesis_balanced("(a=b (sadasdasd))"), true)
+	is_equal("broken sub parenthesis", is_parenthesis_balanced("(a=b (sadasdasd) ))"), false)
+	is_equal("multiple expressions", is_parenthesis_balanced("()()()"), true)
+	is_equal("multiple sub expressions", is_parenthesis_balanced("(()()(()()(())))"), true)
+	is_equal("only opening", is_parenthesis_balanced("("), false)
+	is_equal("only closing", is_parenthesis_balanced(")"), false)
+}
+
+test_is_main_operator_and if {
+	is_equal("TRUE no parenthesis", is_main_operator_and("a=b && (c=d || e=f)"), true)
+	is_equal("TRUE with parenthesis", is_main_operator_and("(a=b && (c=d || e=f))"), true)
+	is_equal("TRUE with double parenthesis", is_main_operator_and("(a=b && ((c=d) || (e=f)))"), true)
+	is_equal("TRUE with double parenthesis twice", is_main_operator_and("((a=b) && ((c=d) || (e=f)))"), true)
+	is_equal("TRUE with expressions on both sides", is_main_operator_and("((a=b) && ((c=d) || (e=f)) && g=h)"), true)
+	is_equal("TRUE with expressions on both sides and double parenthesis", is_main_operator_and("((a=b) && ((c=d) || (e=f)) && (g=h))"), true)
+	is_equal("TRUE main operator on the other side", is_main_operator_and("((c=d || e=f) && (a=b))"), true)
+	is_equal("TRUE non wrapped expression", is_main_operator_and("(a = b) && ((c=d)||(e=f))"), true)
+	is_equal("FALSE no parenthesis", is_main_operator_and("a=b || (c=d && e=f)"), false)
+	is_equal("FALSE with parenthesis", is_main_operator_and("(a=b || (c=d && e=f))"), false)
+	is_equal("FALSE with double parenthesis", is_main_operator_and("(a=b || ((c=d) && (e=f)))"), false)
+	is_equal("FALSE with double parenthesis twice", is_main_operator_and("((a=b) || ((c=d) && (e=f)))"), false)
+	is_equal("FALSE with expressions on both sides", is_main_operator_and("((a=b) || ((c=d) && (e=f)) && g=h)"), false)
+	is_equal("FALSE with expressions on both sides and double parenthesis", is_main_operator_and("((a=b) || ((c=d) && (e=f)) && (g=h))"), false)
+	is_equal("FALSE main operator on the other side", is_main_operator_and("((c=d && e=f) || (a=b))"), false)
+	is_equal("FALSE non wrapped expression", is_main_operator_and("(a = b) || ((c=d)&&(e=f))"), false)
+}
+
+test_is_main_operator_or if {
+	is_equal("TRUE no parenthesis", is_main_operator_or("a=b || (c=d && e=f)"), true)
+	is_equal("TRUE with parenthesis", is_main_operator_or("(a=b || (c=d && e=f))"), true)
+	is_equal("TRUE with double parenthesis", is_main_operator_or("(a=b || ((c=d) && (e=f)))"), true)
+	is_equal("TRUE with double parenthesis twice", is_main_operator_or("((a=b) || ((c=d) && (e=f)))"), true)
+	is_equal("TRUE with expressions on both sides", is_main_operator_or("((a=b) || ((c=d) && (e=f)) && g=h)"), true)
+	is_equal("TRUE with expressions on both sides and double parenthesis", is_main_operator_or("((a=b) || ((c=d) && (e=f)) && (g=h))"), true)
+	is_equal("TRUE non wrapped expression", is_main_operator_or("(a = b) || ((c=d)&&(e=f))"), true)
+	is_equal("TRUE main operator on the other side", is_main_operator_or("((c=d && e=f) || (a=b))"), true)
+	is_equal("FALSE no parenthesis", is_main_operator_or("a=b && (c=d || e=f)"), false)
+	is_equal("FALSE with parenthesis", is_main_operator_or("(a=b && (c=d || e=f))"), false)
+	is_equal("FALSE with double parenthesis", is_main_operator_or("(a=b && ((c=d) || (e=f)))"), false)
+	is_equal("FALSE with double parenthesis twice", is_main_operator_or("((a=b) && ((c=d) || (e=f)))"), false)
+	is_equal("FALSE with expressions on both sides", is_main_operator_or("((a=b) && ((c=d) || (e=f)) && g=h)"), false)
+	is_equal("FALSE with expressions on both sides and double parenthesis", is_main_operator_or("((a=b) && ((c=d) || (e=f)) && (g=h))"), false)
+	is_equal("FALSE main operator on the other side", is_main_operator_or("((c=d || e=f) && (a=b))"), false)
+	is_equal("FALSE non wrapped expression", is_main_operator_or("(a = b) && ((c=d)||(e=f))"), false)
+}
+
+is_equal(_, actual, want) if {
+	actual == want
+}
+
+is_equal(desc, actual, want) if {
+	actual != want
+	print("--- Test [", desc, "] failed because:")
+	print("WANT:    ", want)
+	print("ACTUAL:  ", actual)
+	false
+}


### PR DESCRIPTION
### Summary of your changes

Implement an advanced cloudwatch filter expressions comparison, were the order of the expressions doesn't matter.

First, once filters are fetched, the pattern is parsed to a structured format easy to compare on OPA layer. Then, in the OPA layer, the comparison between all the parsed filters against a desired pattern (manually written in the new format) happens.

For example the expressions are all the same, but in different formats: 

`{ ($.eventName = CreateRoute) || ($.eventName = CreateRouteTable) }`
`{($.eventName=CreateRoute) || ($.eventName=CreateRouteTable)}`
`{ $.eventName = CreateRoute || $.eventName = CreateRouteTable }`
`{ ($.eventName = CreateRouteTable)|| ($.eventName = CreateRoute) }`
`{ (CreateRouteTable = $.eventName)|| ($.eventName = CreateRoute) }`

There were 3 considered approaches:

- ❌ Full parsing and comparison implemented in go, add a go built in function to OPA and use in the OPA layer
  - Implemented, but it turned out to be too disruptive to the workflow. To actually add a new function to OPA Runtime you need to build a new binary which means update CI (easiest) and all the team adapt their local development workflow to use custom binary.
- ❌  Full parsing and comparison implemented in OPA layer
  - Implemented. It go unreadable and too slow.
- ✅ **Parsing in go and comparison in OPA**
  - it's a good middle ground when compared with the other solutions. Performs well, reads fine. The comprise is that OPA layer doesn't know how to parse expression, so instead of comparing strings, now you need to build the expression on the expect parsed format.

Working integration tests:

![image](https://github.com/elastic/cloudbeat/assets/5350001/417d59ee-45e6-41a2-8420-891afc6a3a2e)


### Related Issues
- Related https://github.com/elastic/cloudbeat/issues/1506

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works