### PR TITLE
Fetch AWS Management Account resources only when explicitly selected

### DIFF
--- a/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
@@ -93,8 +93,6 @@ Resources:
                 Action:
                   - sts:AssumeRole
                 Resource: '*'
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/SecurityAudit
 
   # Instance profile to attach to EC2 instance
   ElasticAgentInstanceProfile:

--- a/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
@@ -86,6 +86,13 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                  - iam:ListAccountAliases
+                  - iam:ListGroup
+                  - iam:ListRoles
+                  - iam:ListUsers
+                Resource: '*'
+              - Effect: Allow
+                Action:
                   - organizations:List*
                   - organizations:Describe*
                 Resource: '*'

--- a/internal/flavors/benchmark/aws_org.go
+++ b/internal/flavors/benchmark/aws_org.go
@@ -114,17 +114,17 @@ func (a *AWSOrg) getAwsAccounts(ctx context.Context, log *logp.Logger, initialCf
 
 	accounts := make([]preset.AwsAccount, 0, len(accountIdentities))
 	for _, identity := range accountIdentities {
-		var memberCfg awssdk.Config
-		if identity.Account == rootIdentity.Account {
-			memberCfg = rootCfg
-		} else {
-			memberCfg = assumeRole(
-				stsClient,
-				rootCfg,
-				fmtIAMRole(identity.Account, memberRole),
-			)
-		}
-
+		// TODO(kuba): Add a comment explaining role assumption:
+		// - we're logged in into the main account, we use "cloudbeat-root" role
+		// - "cloudbeat-root" has limited permissions - account listing and role assumption
+		// - CF StackSets will install "cloudbeat-securityaudit" role where applicable
+		// - we try to assume "cloudbeat-securityaudit" to fetch resources
+		// - if there is no "cloudbeat-securityaudit", we fail silently
+		memberCfg := assumeRole(
+			stsClient,
+			rootCfg,
+			fmtIAMRole(identity.Account, memberRole),
+		)
 		accounts = append(accounts, preset.AwsAccount{
 			Identity: identity,
 			Config:   memberCfg,


### PR DESCRIPTION
🚧 WIP 🚧

- TODO: replace TODO with description of how role assumption works

### Summary of your changes

- do not attach SecurityAudit policy to `cloudbeat-root`
- force cloudbeat to always assume `cloudbeat-securityaudit` role
- add `iam:List*` capabilities to `cloudbeat-root` policy

### Related Issues

Fixes https://github.com/elastic/security-team/issues/8672

### Checklist
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

No.
