### PR TITLE
Fix confliciting fields and bugs on the rules

### DIFF
--- a/internal/resources/providers/aws_cis/monitoring/filter_pattern_parser.go
+++ b/internal/resources/providers/aws_cis/monitoring/filter_pattern_parser.go
@@ -55,35 +55,35 @@ type MetricFilterPattern struct {
 }
 
 type simpleExpression struct {
-	Simple   bool
-	Left     string
-	Operator comparisonOperator
-	Right    string
+	Simple             bool
+	Left               string
+	ComparisonOperator comparisonOperator
+	Right              string
 }
 
 func newSimpleExpression(left string, op comparisonOperator, right string) MetricFilterPattern {
 	return MetricFilterPattern{
 		simpleExpression: simpleExpression{
-			Simple:   true,
-			Left:     left,
-			Operator: op,
-			Right:    right,
+			Simple:             true,
+			Left:               left,
+			ComparisonOperator: op,
+			Right:              right,
 		},
 	}
 }
 
 type complexExpression struct {
-	Complex     bool
-	Operator    logicalOperator
-	Expressions []MetricFilterPattern
+	Complex         bool
+	LogicalOperator logicalOperator
+	Expressions     []MetricFilterPattern
 }
 
 func newComplexExpression(op logicalOperator, exps ...MetricFilterPattern) MetricFilterPattern {
 	return MetricFilterPattern{
 		complexExpression: complexExpression{
-			Complex:     true,
-			Operator:    op,
-			Expressions: exps,
+			Complex:         true,
+			LogicalOperator: op,
+			Expressions:     exps,
 		},
 	}
 }
@@ -153,7 +153,7 @@ func safeParse(s string, depth int) (MetricFilterPattern, error) {
 
 		tmpString := buf.String()
 		if contains, op := hasSuffixLogicalOp(tmpString); contains { // && or || marks the end of a Simple MetricFilterPattern
-			if logicalOp == "" { // set the Operator of the MetricFilterPattern without overriding it
+			if logicalOp == "" { // set the LogicalOperator of the MetricFilterPattern without overriding it
 				logicalOp = op
 			}
 
@@ -257,7 +257,7 @@ func parseSimpleExpression(s string) (MetricFilterPattern, error) {
 		}
 
 		tmpString := buf.String()
-		// If the current buffer value has a Comparison Operator as suffix, it means the right side of the expression
+		// If the current buffer value has a Comparison ComparisonOperator as suffix, it means the right side of the expression
 		// is finished
 		if contains, op := hasSuffixComparisonOp(tmpString); contains {
 			if foundOp { // if there was already a found operator for this simple expression, return error
@@ -274,7 +274,7 @@ func parseSimpleExpression(s string) (MetricFilterPattern, error) {
 	}
 
 	if !foundOp {
-		return MetricFilterPattern{}, errors.New("could not find a Operator for this MetricFilterPattern")
+		return MetricFilterPattern{}, errors.New("could not find a ComparisonOperator for this MetricFilterPattern")
 	}
 
 	// Trim trailing spaces

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_15/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_15/rule.rego
@@ -20,7 +20,7 @@ finding = result if {
 }
 
 # { ($.eventSource = organizations.amazonaws.com) && (($.eventName = \"AcceptHandshake\") || ($.eventName = \"AttachPolicy\") || ($.eventName = \"CreateAccount\") || ($.eventName = \"CreateOrganizationalUnit\") || ($.eventName = \"CreatePolicy\") || ($.eventName = \"DeclineHandshake\") || ($.eventName = \"DeleteOrganization\") || ($.eventName = \"DeleteOrganizationalUnit\") || ($.eventName = \"DeletePolicy\") || ($.eventName = \"DetachPolicy\") || ($.eventName = \"DisablePolicyType\") || ($.eventName = \"EnablePolicyType\") || ($.eventName = \"InviteAccountToOrganization\") || ($.eventName = \"LeaveOrganization\") || ($.eventName = \"MoveAccount\") || ($.eventName = \"RemoveAccountFromOrganization\") || ($.eventName = \"UpdatePolicy\") || ($.eventName = \"UpdateOrganizationalUnit\")) }
-required_patterns = [pattern.complex_expression("&", [
+required_patterns = [pattern.complex_expression("&&", [
 	pattern.simple_expression("$.eventSource", "=", "organizations.amazonaws.com"),
 	pattern.complex_expression("||", [
 		pattern.simple_expression("$.eventName", "=", "\"AcceptHandshake\""),

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_15/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_15/test.rego
@@ -16,7 +16,7 @@ test_pass if {
 		"MetricFilters": [{
 			"FilterName": "filter_1",
 			"FilterPattern": "{ ($.eventSource = organizations.amazonaws.com) && (($.eventName = \"AcceptHandshake\") || ($.eventName = \"AttachPolicy\") || ($.eventName = \"CreateAccount\") || ($.eventName = \"CreateOrganizationalUnit\") || ($.eventName = \"CreatePolicy\") || ($.eventName = \"DeclineHandshake\") || ($.eventName = \"DeleteOrganization\") || ($.eventName = \"DeleteOrganizationalUnit\") || ($.eventName = \"DeletePolicy\") || ($.eventName = \"DetachPolicy\") || ($.eventName = \"DisablePolicyType\") || ($.eventName = \"EnablePolicyType\") || ($.eventName = \"InviteAccountToOrganization\") || ($.eventName = \"LeaveOrganization\") || ($.eventName = \"MoveAccount\") || ($.eventName = \"RemoveAccountFromOrganization\") || ($.eventName = \"UpdatePolicy\") || ($.eventName = \"UpdateOrganizationalUnit\")) }",
-			"ParsedFilterPattern": pattern.complex_expression("&", [
+			"ParsedFilterPattern": pattern.complex_expression("&&", [
 				pattern.complex_expression("||", [
 					pattern.simple_expression("$.eventName", "=", "\"CreateAccount\""),
 					pattern.simple_expression("$.eventName", "=", "\"DeleteOrganizationalUnit\""),

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_4/rule.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_4/rule.rego
@@ -20,7 +20,7 @@ finding = result if {
 }
 
 # {($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.eventName=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)||($.eventName=DetachGroupPolicy)}
-required_patterns = [pattern.complex_expression("&&", [
+required_patterns = [pattern.complex_expression("||", [
 	pattern.simple_expression("$.eventName", "=", "DeleteGroupPolicy"),
 	pattern.simple_expression("$.eventName", "=", "DeleteRolePolicy"),
 	pattern.simple_expression("$.eventName", "=", "DeleteUserPolicy"),

--- a/security-policies/bundle/compliance/cis_aws/rules/cis_4_4/test.rego
+++ b/security-policies/bundle/compliance/cis_aws/rules/cis_4_4/test.rego
@@ -18,7 +18,7 @@ test_violation if {
 		},
 		"MetricFilters": [{
 			"FilterPattern": "{($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.event Name=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)}",
-			"ParsedFilterPattern": pattern.complex_expression("&&", [
+			"ParsedFilterPattern": pattern.complex_expression("||", [
 				pattern.simple_expression("$.eventName", "=", "DeleteGroupPolicy"),
 				pattern.simple_expression("$.eventName", "=", "DeleteRolePolicy"),
 				pattern.simple_expression("$.eventName", "=", "DeleteUserPolicy"),
@@ -51,7 +51,7 @@ test_pass if {
 		"MetricFilters": [{
 			"FilterName": "filter_1",
 			"FilterPattern": "{($.eventName=DeleteGroupPolicy)||($.eventName=DeleteRolePolicy)||($.eventName=DeleteUserPolicy)||($.eventName=PutGroupPolicy)||($.eventName=PutRolePolicy)||($.eventName=PutUserPolicy)||($.eventName=CreatePolicy)||($.eventName=DeletePolicy)||($.eventName=CreatePolicyVersion)||($.eventName=DeletePolicyVersion)||($.eventName=AttachRolePolicy)||($.eventName=DetachRolePolicy)||($.eventName=AttachUserPolicy)||($.eventName=DetachUserPolicy)||($.eventName=AttachGroupPolicy)||($.eventName=DetachGroupPolicy)}",
-			"ParsedFilterPattern": pattern.complex_expression("&&", [
+			"ParsedFilterPattern": pattern.complex_expression("||", [
 				pattern.simple_expression("$.eventName", "=", "DeleteGroupPolicy"),
 				pattern.simple_expression("$.eventName", "=", "DeleteRolePolicy"),
 				pattern.simple_expression("$.eventName", "=", "DeleteUserPolicy"),

--- a/security-policies/bundle/compliance/policy/aws_cloudtrail/pattern.rego
+++ b/security-policies/bundle/compliance/policy/aws_cloudtrail/pattern.rego
@@ -14,16 +14,23 @@ get_filter_matched_to_pattern(trail, patterns) = name if {
 } else = ""
 
 complex_expression(op, expressions) = {
+	"ComparisonOperator": "",
 	"Complex": true,
-	"Operator": op,
 	"Expressions": expressions,
+	"Left": "",
+	"LogicalOperator": op,
+	"Right": "",
+	"Simple": false,
 }
 
 simple_expression(left, op, right) = {
-	"Simple": true,
+	"ComparisonOperator": op,
+	"Complex": false,
+	"Expressions": null,
 	"Left": left,
-	"Operator": op,
+	"LogicalOperator": "",
 	"Right": right,
+	"Simple": true,
 }
 
 # Known limitations on checking expressions equivalence:
@@ -42,7 +49,7 @@ compare_simple_expressions(exp1, exp2) if {
 	exp1.Simple
 	exp2.Simple
 	exp1.Left == exp2.Left
-	exp1.Operator == exp2.Operator
+	exp1.ComparisonOperator == exp2.ComparisonOperator
 	exp1.Right == exp2.Right
 }
 
@@ -50,14 +57,14 @@ compare_simple_expressions(exp1, exp2) if {
 	exp1.Simple
 	exp2.Simple
 	exp1.Left == exp2.Right
-	exp1.Operator == exp2.Operator
+	exp1.ComparisonOperator == exp2.ComparisonOperator
 	exp1.Right == exp2.Left
 }
 
 compare_complex_expressions(exp1, exp2) if {
 	exp1.Complex
 	exp2.Complex
-	exp1.Operator == exp2.Operator
+	exp1.LogicalOperator == exp2.LogicalOperator
 	count(exp1.Expressions) == count(exp2.Expressions)
 
 	every subExp1 in exp1.Expressions {
@@ -77,7 +84,7 @@ compare_expressions_second_level(exp1, exp2) if {
 compare_complex_expressions_second_level(exp1, exp2) if {
 	exp1.Complex
 	exp2.Complex
-	exp1.Operator == exp2.Operator
+	exp1.LogicalOperator == exp2.LogicalOperator
 	count(exp1.Expressions) == count(exp2.Expressions)
 
 	every subExp1 in exp1.Expressions {


### PR DESCRIPTION
### Summary of your changes

Problems addressed with this PR

- Due to the strategy on  `MetricFilterPattern` embedding `simpleExpression` and `complexExpression` there was a conflicting field `Operator` which was not being marshalled to json.

- Rules 4.4 and 4.15 were failing due to bad manual parsing.

### Screenshot/Data

![image](https://github.com/elastic/cloudbeat/assets/5350001/90f9b923-ab01-41ef-81e5-2521ffaefa23)

![image](https://github.com/elastic/cloudbeat/assets/5350001/7e570d16-c7fe-4b8f-81d4-810f3f624b29)

### Related Issues
- Fixes https://github.com/elastic/cloudbeat/issues/1506