### PR TITLE
Add permissions for Azure CIS 9.1 rule

### DIFF
--- a/deploy/azure/ARM-for-single-account.dev.json
+++ b/deploy/azure/ARM-for-single-account.dev.json
@@ -257,7 +257,9 @@
                                 "permissions": [
                                     {
                                         "actions": [
-                                            "Microsoft.Web/sites/*/read"
+                                            "Microsoft.Web/sites/*/read",
+                                            "Microsoft.Web/sites/config/Read",
+                                            "Microsoft.Web/sites/config/list/Action"
                                         ],
                                         "dataActions": [],
                                         "notActions": [],

--- a/deploy/azure/ARM-for-single-account.json
+++ b/deploy/azure/ARM-for-single-account.json
@@ -262,7 +262,9 @@
                                 "permissions": [
                                     {
                                         "actions": [
-                                            "Microsoft.Web/sites/*/read"
+                                            "Microsoft.Web/sites/*/read",
+                                            "Microsoft.Web/sites/config/Read",
+                                            "Microsoft.Web/sites/config/list/Action"
                                         ],
                                         "dataActions": [],
                                         "notActions": [],


### PR DESCRIPTION
### Summary of your changes
Add `Microsoft.Web/sites/config/Read` and `Microsoft.Web/sites/config/list/Action` permissions. The permissions needed were indicated by the error message in `cloudbeat` logs:
```
ESPONSE 403: 403 Forbidden
ERROR CODE: AuthorizationFailed
--------------------------------------------------------------------------------
{
  "error": {
    "code": "AuthorizationFailed",
    "message": "The client '[REDACTED]' with object id '[REDACTED]' does not have authorization to perform action 'Microsoft.Web/sites/config/list/action' over scope '/subscriptions/[REDACTED]/resourceGroups/azurecloudbeatcitests/providers/Microsoft.Web/sites/test-app-service-pass/config/authsettings' or the scope is invalid. If access was recently granted, please refresh your credentials."
  }
}
--------------------------------------------------------------------------------
```

Related to https://github.com/elastic/cloudbeat/issues/1758#issuecomment-1994347236
