### PR TITLE
add aws provider name to org scan

### DIFF
--- a/internal/flavors/benchmark/aws_org.go
+++ b/internal/flavors/benchmark/aws_org.go
@@ -103,7 +103,7 @@ func (a *AWSOrg) initialize(ctx context.Context, log *logp.Logger, cfg *config.C
 			return m, nil
 		}))
 
-	return reg, cloud.NewDataProvider(), nil, nil
+	return reg, cloud.NewDataProvider(cloud.WithAccount(*awsIdentity)), nil, nil
 }
 
 func (a *AWSOrg) getAwsAccounts(ctx context.Context, log *logp.Logger, initialCfg awssdk.Config, rootIdentity *cloud.Identity) ([]preset.AwsAccount, error) {


### PR DESCRIPTION
### Summary of your changes

initializes `cloud.NewDataProvider` with `awsIdentity` account so the `cloud.provider.name` is included 

### Screenshot/Data
| before 	| after 	|   	
|-------------------	|------------------------------	|
|![Screenshot 2024-03-18 at 16 01 19](https://github.com/elastic/cloudbeat/assets/20814186/4ca549a6-3695-42cf-bd8a-37ca79968dc8)              	|                              ![Screenshot 2024-03-18 at 16 00 58](https://github.com/elastic/cloudbeat/assets/20814186/b2ba7c51-9aa2-4480-9351-063ca20650a4)	|   




### Related Issues
- fixes https://github.com/elastic/kibana/issues/178772

