### PR TITLE
add rate limit to asset inventory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -476,13 +476,13 @@ require (
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/term v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	golang.org/x/time v0.5.0 // indirect
+	golang.org/x/time v0.5.0
 	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20240228224816-df926f6c8641 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240311132316-a219d84964c2 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240311132316-a219d84964c2 // indirect
-	google.golang.org/grpc v1.62.1 // indirect
+	google.golang.org/grpc v1.62.1
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/internal/flavors/benchmark/gcp.go
+++ b/internal/flavors/benchmark/gcp.go
@@ -49,6 +49,7 @@ func (g *GCP) NewBenchmark(ctx context.Context, log *logp.Logger, cfg *config.Co
 
 	return builder.New(
 		builder.WithBenchmarkDataProvider(bdp),
+		builder.WithManagerTimeout(cfg.Period),
 	).Build(ctx, log, cfg, resourceCh, reg)
 }
 

--- a/internal/resources/providers/gcplib/inventory/grpc_rate_limiter.go
+++ b/internal/resources/providers/gcplib/inventory/grpc_rate_limiter.go
@@ -62,7 +62,7 @@ func (rl *AssetsInventoryRateLimiter) Wait(ctx context.Context, method string, r
 	if limiter != nil {
 		err := limiter.Wait(ctx)
 		if err != nil {
-			rl.log.Errorf("Failed to wait for project quota on method: %s, request: %v, error: %w", method, req, err)
+			rl.log.Errorf("Failed to wait for project quota on method: %s, request: %v, error: %v", method, req, err)
 		}
 	}
 }

--- a/internal/resources/providers/gcplib/inventory/grpc_rate_limiter.go
+++ b/internal/resources/providers/gcplib/inventory/grpc_rate_limiter.go
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package inventory
+
+import (
+	"context"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/googleapis/gax-go/v2"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+// a gax.CallOption that defines a retry strategy which retries the request on ResourceExhausted error.
+var RetryOnResourceExhausted = gax.WithRetry(func() gax.Retryer {
+	return gax.OnCodes([]codes.Code{codes.ResourceExhausted}, gax.Backoff{
+		Initial:    1 * time.Second,
+		Max:        1 * time.Minute,
+		Multiplier: 1.2,
+	})
+})
+
+type AssetsInventoryRateLimiter struct {
+	methods map[string]*rate.Limiter
+	log     *logp.Logger
+}
+
+// a map of asset inventory client methods and their quotas.
+// see https://cloud.google.com/asset-inventory/docs/quota
+var methods = map[string]*rate.Limiter{
+	// using per-project quota suffices for both single-account and organization-account, because it's more restrictive.
+	"/google.cloud.asset.v1.AssetService/ListAssets": rate.NewLimiter(rate.Every(time.Minute/100), 1),
+}
+
+func NewAssetsInventoryRateLimiter(log *logp.Logger) *AssetsInventoryRateLimiter {
+	return &AssetsInventoryRateLimiter{
+		log:     log,
+		methods: methods,
+	}
+}
+
+// Limits the rate of the method calls defined in the methods map.
+func (rl *AssetsInventoryRateLimiter) Wait(ctx context.Context, method string, req any) {
+	limiter := rl.methods[method]
+	if limiter != nil {
+		err := limiter.Wait(ctx)
+		if err != nil {
+			rl.log.Errorf("Failed to wait for project quota on method: %s, request: %v, error: %w", method, req, err)
+		}
+	}
+}
+
+// Returns a grpc.DialOption that intercepts the unary RPCs and limits the rate of the method calls.
+func (rl *AssetsInventoryRateLimiter) GetInterceptorDialOption() grpc.DialOption {
+	return grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		rl.Wait(ctx, method, req)
+		return invoker(ctx, method, req, reply, cc, opts...)
+	})
+}

--- a/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
+++ b/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
@@ -19,7 +19,6 @@ package inventory
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -54,11 +53,10 @@ func (s *RateLimiterTestSuite) TestRateLimiterWait() {
 	startTime := time.Now()
 	for i := 0; i < totalRequests; i++ {
 		s.rateLimiter.Wait(ctx, "someMethod", nil)
-		fmt.Println("request", i)
 	}
 	endTime := time.Now()
 
 	actualDuration := endTime.Sub(startTime)
 	minDuration := duration * time.Duration((totalRequests - 1)) // 1st request is instant, 2nd and above wait 1duration each
-	s.Assert().True(actualDuration >= minDuration, fmt.Sprintf("expected %v to be greater or equal than %v", actualDuration, minDuration))
+	s.GreaterOrEqual(actualDuration, minDuration)
 }

--- a/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
+++ b/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package inventory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/time/rate"
+)
+
+type RateLimiterTestSuite struct {
+	suite.Suite
+	logger      *logp.Logger
+	rateLimiter *AssetsInventoryRateLimiter
+}
+
+func TestInventoryRateLimiterTestSuite(t *testing.T) {
+	suite.Run(t, new(RateLimiterTestSuite))
+}
+
+func (s *RateLimiterTestSuite) SetupTest() {
+	s.logger = logp.NewLogger("test")
+	s.rateLimiter = NewAssetsInventoryRateLimiter(s.logger)
+}
+
+func (s *RateLimiterTestSuite) TestRateLimiterWait() {
+	ctx := context.Background()
+	duration := time.Millisecond
+	s.rateLimiter.methods = map[string]*rate.Limiter{
+		"someMethod": rate.NewLimiter(rate.Every(duration/1), 1), // 1 request per duration
+	}
+
+	totalRequests := 5
+	startTime := time.Now()
+	for i := 0; i < totalRequests; i++ {
+		s.rateLimiter.Wait(ctx, "someMethod", nil)
+		fmt.Println("request", i)
+	}
+	endTime := time.Now()
+
+	actualDuration := endTime.Sub(startTime)
+	minDuration := duration * time.Duration((totalRequests - 1)) // 1st request is instant, 2nd and above wait 1duration each
+	s.Assert().True(actualDuration >= minDuration, fmt.Sprintf("expected %v to be greater or equal than %v", actualDuration, minDuration))
+}

--- a/internal/resources/providers/gcplib/inventory/map_cache.go
+++ b/internal/resources/providers/gcplib/inventory/map_cache.go
@@ -22,25 +22,19 @@ import (
 )
 
 type MapCache[T any] struct {
-	results map[string]T
-	mu      sync.Mutex
+	results sync.Map
 }
 
 func (c *MapCache[T]) Get(fn func() T, key string) T {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if value, ok := c.results[key]; ok {
-		return value
+	if value, ok := c.results.Load(key); ok {
+		return value.(T)
 	}
 
 	value := fn()
-	c.results[key] = value
+	c.results.Store(key, value)
 	return value
 }
 
 func NewMapCache[T any]() *MapCache[T] {
-	return &MapCache[T]{
-		results: make(map[string]T),
-	}
+	return &MapCache[T]{}
 }

--- a/internal/resources/providers/gcplib/inventory/map_cache.go
+++ b/internal/resources/providers/gcplib/inventory/map_cache.go
@@ -1,0 +1,46 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package inventory
+
+import (
+	"sync"
+)
+
+type MapCache[T any] struct {
+	results map[string]T
+	mu      sync.Mutex
+}
+
+func (c *MapCache[T]) Get(fn func() T, key string) T {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if value, ok := c.results[key]; ok {
+		return value
+	}
+
+	value := fn()
+	c.results[key] = value
+	return value
+}
+
+func NewMapCache[T any]() *MapCache[T] {
+	return &MapCache[T]{
+		results: make(map[string]T),
+	}
+}

--- a/internal/resources/providers/gcplib/inventory/map_cache_test.go
+++ b/internal/resources/providers/gcplib/inventory/map_cache_test.go
@@ -38,7 +38,7 @@ func TestMapCacheGet(t *testing.T) {
 	cache := NewMapCache[int]()
 
 	// Test getting existing value from cache
-	cache.results["key1"] = 42
+	cache.results.Store("key1", 42)
 	mockFunction := new(MockFunction)
 	result := cache.Get(mockFunction.GetSomeValue, "key1")
 	mockFunction.AssertNotCalled(t, "GetSomeValue")

--- a/internal/resources/providers/gcplib/inventory/map_cache_test.go
+++ b/internal/resources/providers/gcplib/inventory/map_cache_test.go
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package inventory
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockFunction struct {
+	mock.Mock
+}
+
+func (m *MockFunction) GetSomeValue() int {
+	m.Called()
+	return 0
+}
+
+func TestMapCacheGet(t *testing.T) {
+	cache := NewMapCache[int]()
+
+	// Test getting existing value from cache
+	cache.results["key1"] = 42
+	mockFunction := new(MockFunction)
+	result := cache.Get(mockFunction.GetSomeValue, "key1")
+	mockFunction.AssertNotCalled(t, "GetSomeValue")
+	assert.Equal(t, 42, result)
+
+	// Test getting non-existing value from cache
+	mockFunction.On("GetSomeValue").Return(mockFunction.GetSomeValue())
+	result = cache.Get(mockFunction.GetSomeValue, "key2")
+	mockFunction.AssertNumberOfCalls(t, "GetSomeValue", 2) // 1 by Return(), 2nd by cache.Get()
+	assert.Equal(t, 0, result)
+
+	// Test concurrent accesses
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cache.Get(func() int { return 1 }, "concurrent_key")
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/resources/providers/gcplib/inventory/provider.go
+++ b/internal/resources/providers/gcplib/inventory/provider.go
@@ -475,7 +475,7 @@ func (p *Provider) ListProjectsAncestorsPolicies(ctx context.Context) ([]*Projec
 
 func getAncestorsAssets(ctx context.Context, ancestorsPoliciesCache *MapCache[[]*ExtendedGcpAsset], p *Provider, ancestors []string) []*ExtendedGcpAsset {
 	return lo.Flatten(lo.Map(ancestors, func(parent string, _ int) []*ExtendedGcpAsset {
-		extendedAssets := ancestorsPoliciesCache.Get(func() []*ExtendedGcpAsset {
+		return ancestorsPoliciesCache.Get(func() []*ExtendedGcpAsset {
 			var assetType string
 			if strings.HasPrefix(parent, "folders") {
 				assetType = CrmFolderAssetType
@@ -489,7 +489,6 @@ func getAncestorsAssets(ctx context.Context, ancestorsPoliciesCache *MapCache[[]
 				AssetTypes:  []string{assetType},
 			}))
 		}, parent)
-		return extendedAssets
 	}))
 }
 

--- a/internal/resources/providers/gcplib/inventory/provider_test.go
+++ b/internal/resources/providers/gcplib/inventory/provider_test.go
@@ -89,7 +89,7 @@ func (s *ProviderTestSuite) TestListAllAssetTypesByName() {
 				return "OrganizationName"
 			},
 		},
-		crmCache: make(map[string]*fetching.CloudAccountMetadata),
+		cloudAccountMetadataCache: NewMapCache[*fetching.CloudAccountMetadata](),
 	}
 
 	s.mockedIterator.On("Next").Return(&assetpb.Asset{Name: "AssetName1", Resource: &assetpb.Resource{}, Ancestors: []string{"projects/1", "organizations/1"}}, nil).Once()
@@ -138,7 +138,7 @@ func (s *ProviderTestSuite) TestListMonitoringAssets() {
 				return "OrganizationName1"
 			},
 		},
-		crmCache: make(map[string]*fetching.CloudAccountMetadata),
+		cloudAccountMetadataCache: NewMapCache[*fetching.CloudAccountMetadata](),
 	}
 
 	expected := []*MonitoringAsset{
@@ -218,7 +218,7 @@ func (s *ProviderTestSuite) TestEnrichNetworkAssets() {
 				return "OrganizationName"
 			},
 		},
-		crmCache: make(map[string]*fetching.CloudAccountMetadata),
+		cloudAccountMetadataCache: NewMapCache[*fetching.CloudAccountMetadata](),
 	}
 
 	assets := []*ExtendedGcpAsset{
@@ -332,7 +332,7 @@ func (s *ProviderTestSuite) TestListServiceUsageAssets() {
 				return "OrganizationName1"
 			},
 		},
-		crmCache: make(map[string]*fetching.CloudAccountMetadata),
+		cloudAccountMetadataCache: NewMapCache[*fetching.CloudAccountMetadata](),
 	}
 
 	// asset's resource
@@ -421,7 +421,7 @@ func (s *ProviderTestSuite) TestListLoggingAssets() {
 				return "OrganizationName1"
 			},
 		},
-		crmCache: make(map[string]*fetching.CloudAccountMetadata),
+		cloudAccountMetadataCache: NewMapCache[*fetching.CloudAccountMetadata](),
 	}
 
 	// asset's resource
@@ -460,7 +460,7 @@ func (s *ProviderTestSuite) TestListProjectsAncestorsPolicies() {
 				return "OrganizationName"
 			},
 		},
-		crmCache: make(map[string]*fetching.CloudAccountMetadata),
+		cloudAccountMetadataCache: NewMapCache[*fetching.CloudAccountMetadata](),
 	}
 
 	s.mockedIterator.On("Next").Return(&assetpb.Asset{Name: "AssetName1", IamPolicy: &iampb.Policy{}, Ancestors: []string{"projects/1", "organizations/1"}}, nil).Once()


### PR DESCRIPTION
### Summary of your changes

1. adds rate limiting to the asset inventory client. our current usage is only for `ListAssets`
2. retries requests made by `ListAssets` client whenever they failed due to rate limiting
3. adds a cache to the policies fetcher (using a new cache utility, as we already have 3 caches in this file)

for `ListAssets`, we only use the per-project [quota](https://cloud.google.com/asset-inventory/docs/quota), which is `100 per minute per consumer project`. we do this because:
1. the consumer project (the one consuming the quota) is set by the user when they run `gcloud config set project <project_id>` before deploying the agent. (verified with `gcloud config get billing/quota_project`). 
2. in both our use cases: `single-account` and `organization-account`, we always use a single quota project. we never re-define it for the user
4. in anyway, the org quotas are `800 per minute per org` and `650,000 per day per org`. so the per-project quota is more restrictive than both of these, meaning we shouldn't exceed those either.
5. we don't account for multiple cloudbeat instances running together without being synced on the quotas each of them consume (this is assumed to be an unlikely edge case we accept for now)
 
### Screenshot/Data

<details>
<summary>test script</summary>

```go
package main

import (
	"context"
	"fmt"
	"log"
	"time"

	asset "cloud.google.com/go/asset/apiv1"
	"cloud.google.com/go/asset/apiv1/assetpb"
	"github.com/googleapis/gax-go"
	"golang.org/x/time/rate"
	"google.golang.org/api/iterator"
	"google.golang.org/api/option"
	"google.golang.org/grpc"
	"google.golang.org/grpc/codes"
)

type Iterator interface {
	Next() (*assetpb.Asset, error)
}

var RetryOnResourceExhausted = gax.WithRetry(func() gax.Retryer {
	return gax.OnCodes([]codes.Code{codes.ResourceExhausted}, gax.Backoff{
		Initial:    1 * time.Second,
		Max:        10 * time.Second,
		Multiplier: 1.2,
	})
})

type AssetsInventoryRateLimiter struct {
	methods map[string]*rate.Limiter
}

const projectQuota = 100

func NewAssetsInventoryRateLimiter() *AssetsInventoryRateLimiter {
	return &AssetsInventoryRateLimiter{
		methods: map[string]*rate.Limiter{
			"/google.cloud.asset.v1.AssetService/ListAssets": rate.NewLimiter(rate.Every(time.Minute/projectQuota), 1),
		},
	}
}

func (rl *AssetsInventoryRateLimiter) GetInterceptorDialOption() grpc.DialOption {
	return grpc.WithUnaryInterceptor(func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
		limiter := rl.methods[method]
		if limiter != nil {
			limiter.Wait(ctx)
		}
		return invoker(ctx, method, req, reply, cc, opts...)
	})
}

func main() {
	ctx := context.Background()
	limiter := NewAssetsInventoryRateLimiter()
	clientA, err := asset.NewClient(ctx, option.WithGRPCDialOption(limiter.GetInterceptorDialOption()))

	if err != nil {
		log.Fatalf("failed to create client: %v", err)
	}

	var totalGot int
	var totalLost int
	start := time.Now()
	// simulate 10x the project per-minute quota by requesting some assets multiple times
	var assets []*assetpb.Asset
	for i := 0; i < projectQuota*10; i++ {
		log.Printf("Iteration: %d \n", i)
		resp := getAllAssets(clientA.ListAssets(ctx, &assetpb.ListAssetsRequest{
			Parent:      fmt.Sprintf("organizations/%s", "693506308612"),
			AssetTypes:  []string{"logging.googleapis.com/LogBucket"},
			ContentType: assetpb.ContentType_RESOURCE,
		}, RetryOnResourceExhausted))
		if resp == nil {
			totalLost++
		} else {
			totalGot++
			assets = append(assets, resp...)
		}
	}
	end := time.Now()
	log.Println("-----------------------------------------")
	log.Printf("time: %v \n", end.Sub(start))
	log.Printf("assets: %d \n", len(assets))
	log.Printf("requests lost: %d \n", totalLost)
	log.Printf("requests got: %d \n", totalGot)
}

func getAllAssets(it Iterator) []*assetpb.Asset {
	results := make([]*assetpb.Asset, 0)
	for {
		response, err := it.Next()
		if err == iterator.Done {
			break
		}
		if err != nil {
			return nil
		}
		results = append(results, response)
	}
	return results
}

```
1. this is roughly the same code from the assets inventory provider that calls `ListAssets`
3. you can change the `Parent` param to a different organization. make sure to re-run `gcloud auth login` and `gcloud auth application-default login`
4. the script limits  requests to 100 per minute and retries failed ones. (you can adjust the quota [here](https://console.cloud.google.com/iam-admin/quota))
6. it simulates consumption of 10x the quota 
7. eventually (+10mins) returns `requests got: 1000`, which means it doesn't lose any requests. 
8. before this PR, the same usage would error after 100 requests and then just log the error and continue. you can remove the `rl.Wait()` and `RetryOnResourceExhausted` to see verify

</details>

### Related Issues
- part of https://github.com/elastic/cloudbeat/issues/2054
- closes https://github.com/elastic/cloudbeat/issues/2073

