### PR TITLE
[Release] Update version to 8.13.2

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -18,7 +18,7 @@
 package version
 
 // name matches github.com/elastic/beats/v7/dev-tools/mage/settings.go parseBeatVersion
-const defaultBeatVersion = "8.13.1"
+const defaultBeatVersion = "8.13.2"
 
 // Version represents version information for a package
 type Version struct {


### PR DESCRIPTION
Updates references to the new release 8.13.2.

Merge after the release 8.13.1.