### PR TITLE
[Create Environment] Add new tag and fix delete env script

### DIFF
--- a/deploy/test-environments/delete_env.sh
+++ b/deploy/test-environments/delete_env.sh
@@ -163,9 +163,14 @@ echo "Failed to delete CloudFormation stacks (${#FAILED_STACKS[@]}):"
 printf "%s\n" "${FAILED_STACKS[@]}"
 
 # Delete GCP deployments
-PROJECT_NAME=$(gcloud config get-value core/project)
-PROJECT_NUMBER=$(gcloud projects list --filter="${PROJECT_NAME}" --format="value(PROJECT_NUMBER)")
-./delete_gcp_env.sh "$PROJECT_NAME" "$PROJECT_NUMBER" "${ALL_GCP_DEPLOYMENTS[@]}"
+# Check if ALL_GCP_DEPLOYMENTS is empty
+if [ ${#ALL_GCP_DEPLOYMENTS[@]} -eq 0 ]; then
+    echo "No GCP deployments to delete."
+else
+    PROJECT_NAME=$(gcloud config get-value core/project)
+    PROJECT_NUMBER=$(gcloud projects list --filter="${PROJECT_NAME}" --format="value(PROJECT_NUMBER)")
+    ./delete_gcp_env.sh "$PROJECT_NAME" "$PROJECT_NUMBER" "${ALL_GCP_DEPLOYMENTS[@]}"
+fi
 
 # Delete Azure groups
 FAILED_AZURE_GROUPS=()

--- a/deploy/test-environments/main.tf
+++ b/deploy/test-environments/main.tf
@@ -4,11 +4,12 @@ provider "aws" {
 
 locals {
   common_tags = {
-    division = "${var.division}"
-    org      = "${var.org}"
-    team     = "${var.team}"
-    project  = "${var.project}"
-    owner    = "${var.owner}"
+    division   = "${var.division}"
+    org        = "${var.org}"
+    team       = "${var.team}"
+    project    = "${var.project}"
+    owner      = "${var.owner}"
+    deployment = "${var.deployment_name}"
   }
   ec_url = "https://cloud.elastic.co"
   ec_headers = {


### PR DESCRIPTION
### Summary of your changes

This PR adds a new tag `deployment` for the create environment Terraform script.
Additionally, it fixes the delete environment script to handle the case where no GCP deployment exists. Instead of failing, the script now provides a message stating that no GCP deployments need to be deleted.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
