### PR TITLE
Re-enable some AWS and EKS sanity checks in integration tests

### DIFF
--- a/tests/integration/tests/test_sanity_checks.py
+++ b/tests/integration/tests/test_sanity_checks.py
@@ -35,6 +35,9 @@ tests_data = {
         "cloud-audit",
         "cloud-database",
         "cloud-config",
+        # DEBUG(kuba): Trying out the disabled tests
+        "cloud-compute",
+        "cloud-storage",
     ],  # Exclude "cloud-compute", "cloud-storage" due to lack of fetcher control and potential delays.
     "cis_gcp": [
         "cloud-compute",
@@ -56,6 +59,7 @@ tests_data = {
     ],  # Exclude "cloud-compute", Azure environment is not static, so we can't guarantee findings of all types.
     "cis_k8s": ["file", "process", "k8s_object"],
     "cis_eks": [
+        "file",
         "process",
         "k8s_object",
     ],  # Optimize search findings by excluding 'file'.

--- a/tests/integration/tests/test_sanity_checks.py
+++ b/tests/integration/tests/test_sanity_checks.py
@@ -19,7 +19,7 @@ GCP_CONFIG_TIMEOUT = 600
 CNVM_CONFIG_TIMEOUT = 3600
 
 # The timeout and backoff for waiting all agents are running the specified component.
-COMPONENTS_TIMEOUT = 180
+COMPONENTS_TIMEOUT = 300
 COMPONENTS_BACKOFF = 10
 
 AGENT_VERSION = elasticsearch.agent_version

--- a/tests/integration/tests/test_sanity_checks.py
+++ b/tests/integration/tests/test_sanity_checks.py
@@ -35,10 +35,9 @@ tests_data = {
         "cloud-audit",
         "cloud-database",
         "cloud-config",
-        # DEBUG(kuba): Trying out the disabled tests
         "cloud-compute",
         "cloud-storage",
-    ],  # Exclude "cloud-compute", "cloud-storage" due to lack of fetcher control and potential delays.
+    ],
     "cis_gcp": [
         "cloud-compute",
         "cloud-database",
@@ -62,7 +61,7 @@ tests_data = {
         "file",
         "process",
         "k8s_object",
-    ],  # Optimize search findings by excluding 'file'.
+    ],
     "cnvm": ["vulnerability"],
 }
 


### PR DESCRIPTION
### Summary of your changes

Re-enable some AWS (`cloud-compute`, `cloud-storage`) and EKS (`file`) sanity checks. Increased initial timeout.

### Screenshot/Data

<details><summary>Successful run of the Tests workflow</summary>
<img width="1398" alt="Screenshot 2024-04-03 at 12 50 06" src="https://github.com/elastic/cloudbeat/assets/4587658/6964ab36-8d58-4252-b643-60b241b7757a">
</details>

<details><summary>New AWS sanity checks passed</summary>
<img width="807" alt="Screenshot 2024-04-03 at 12 39 19" src="https://github.com/elastic/cloudbeat/assets/4587658/f349dab6-ac35-4323-a54f-6da8e6fcaf35">
</details>

<details><summary>Successful run of the EKS-CI workflow</summary>
<img width="2538" alt="Screenshot 2024-04-03 at 12 37 10" src="https://github.com/elastic/cloudbeat/assets/4587658/c7b86be8-039c-4b6a-ae1c-b11fae71b04a">
</details>

<details><summary>New EKS sanity checks passed - config 1</summary>
<img width="1156" alt="Screenshot 2024-04-03 at 12 36 53" src="https://github.com/elastic/cloudbeat/assets/4587658/26ad7c08-84da-46f7-a4d3-ff81bc528a1b">
</details>

<details><summary>New EKS sanity checks passed - config 2</summary>
<img width="1156" alt="Screenshot 2024-04-03 at 12 36 28" src="https://github.com/elastic/cloudbeat/assets/4587658/f144eb72-e261-4d24-8845-b41fcb4f304a">
</details>

<details><summary>Successful sanity tests in Create Environment workflow</summary>
URL: <a href="https://github.com/elastic/cloudbeat/actions/runs/8538309690/job/23390701836">https://github.com/elastic/cloudbeat/actions/runs/8538309690/job/23390701836</a>

![image](https://github.com/elastic/cloudbeat/assets/4587658/4c654337-e89c-412f-874c-c9b141948321)
</details>

### Related Issues
Fixes https://github.com/elastic/security-team/issues/6909

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- ~~I have added the necessary README/documentation (if appropriate)~~

#### Introducing a new rule?

No