### PR TITLE
use CloudAccountMetadata in GCP

### DIFF
--- a/internal/flavors/benchmark/gcp.go
+++ b/internal/flavors/benchmark/gcp.go
@@ -74,7 +74,9 @@ func (g *GCP) initialize(ctx context.Context, log *logp.Logger, cfg *config.Conf
 	}
 
 	return registry.NewRegistry(log, registry.WithFetchersMap(fetchers)),
-		cloud.NewDataProvider(),
+		cloud.NewDataProvider(cloud.WithAccount(cloud.Identity{
+			Provider: "gcp",
+		})),
 		nil,
 		nil
 }

--- a/internal/resources/fetching/fetcher.go
+++ b/internal/resources/fetching/fetcher.go
@@ -121,14 +121,6 @@ type ResourceInfo struct {
 	CycleMetadata cycle.Metadata
 }
 
-type EcsGcp struct {
-	Provider         string
-	ProjectId        string
-	ProjectName      string
-	OrganizationId   string
-	OrganizationName string
-}
-
 type Resource interface {
 	GetMetadata() (ResourceMetadata, error)
 	GetData() any

--- a/internal/resources/fetching/fetchers/gcp/assets_fetcher.go
+++ b/internal/resources/fetching/fetchers/gcp/assets_fetcher.go
@@ -138,28 +138,17 @@ func (r *GcpAsset) GetMetadata() (fetching.ResourceMetadata, error) {
 	}
 
 	return fetching.ResourceMetadata{
-		ID:      r.ExtendedAsset.Name,
-		Type:    r.Type,
-		SubType: r.SubType,
-		Name:    getAssetResourceName(r.ExtendedAsset),
-		Region:  region,
+		ID:                   r.ExtendedAsset.Name,
+		Type:                 r.Type,
+		SubType:              r.SubType,
+		Name:                 getAssetResourceName(r.ExtendedAsset),
+		Region:               region,
+		CloudAccountMetadata: *r.ExtendedAsset.CloudAccount,
 	}, nil
 }
 
 func (r *GcpAsset) GetElasticCommonData() (map[string]any, error) {
-	return map[string]any{
-		"cloud": map[string]any{
-			"provider": "gcp",
-			"account": map[string]any{
-				"id":   r.ExtendedAsset.Ecs.ProjectId,
-				"name": r.ExtendedAsset.Ecs.ProjectName,
-			},
-			"Organization": map[string]any{
-				"id":   r.ExtendedAsset.Ecs.OrganizationId,
-				"name": r.ExtendedAsset.Ecs.OrganizationName,
-			},
-		},
-	}, nil
+	return nil, nil
 }
 
 // try to retrieve the resource name from the asset data fields (name or displayName), in case it is not set

--- a/internal/resources/fetching/fetchers/gcp/log_sink_fetcher.go
+++ b/internal/resources/fetching/fetchers/gcp/log_sink_fetcher.go
@@ -82,13 +82,14 @@ func (f *GcpLogSinkFetcher) Stop() {
 }
 
 func (g *GcpLoggingAsset) GetMetadata() (fetching.ResourceMetadata, error) {
-	id := fmt.Sprintf("%s-%s", g.subType, g.Asset.Ecs.ProjectId)
+	id := fmt.Sprintf("%s-%s", g.subType, g.Asset.CloudAccount.AccountId)
 	return fetching.ResourceMetadata{
-		ID:      id,
-		Type:    g.Type,
-		SubType: g.subType,
-		Name:    id,
-		Region:  gcplib.GlobalRegion,
+		ID:                   id,
+		Type:                 g.Type,
+		SubType:              g.subType,
+		Name:                 id,
+		Region:               gcplib.GlobalRegion,
+		CloudAccountMetadata: *g.Asset.CloudAccount,
 	}, nil
 }
 
@@ -97,17 +98,5 @@ func (g *GcpLoggingAsset) GetData() any {
 }
 
 func (g *GcpLoggingAsset) GetElasticCommonData() (map[string]any, error) {
-	return map[string]any{
-		"cloud": map[string]any{
-			"provider": "gcp",
-			"account": map[string]any{
-				"id":   g.Asset.Ecs.ProjectId,
-				"name": g.Asset.Ecs.ProjectName,
-			},
-			"Organization": map[string]any{
-				"id":   g.Asset.Ecs.OrganizationId,
-				"name": g.Asset.Ecs.OrganizationName,
-			},
-		},
-	}, nil
+	return nil, nil
 }

--- a/internal/resources/fetching/fetchers/gcp/monitoring_fetcher.go
+++ b/internal/resources/fetching/fetchers/gcp/monitoring_fetcher.go
@@ -87,13 +87,14 @@ func (f *GcpMonitoringFetcher) Stop() {
 }
 
 func (g *GcpMonitoringAsset) GetMetadata() (fetching.ResourceMetadata, error) {
-	id := fmt.Sprintf("%s-%s", g.subType, g.Asset.Ecs.ProjectId)
+	id := fmt.Sprintf("%s-%s", g.subType, g.Asset.CloudAccount.AccountId)
 	return fetching.ResourceMetadata{
-		ID:      id,
-		Type:    g.Type,
-		SubType: g.subType,
-		Name:    id,
-		Region:  gcplib.GlobalRegion,
+		ID:                   id,
+		Type:                 g.Type,
+		SubType:              g.subType,
+		Name:                 id,
+		Region:               gcplib.GlobalRegion,
+		CloudAccountMetadata: *g.Asset.CloudAccount,
 	}, nil
 }
 
@@ -102,17 +103,5 @@ func (g *GcpMonitoringAsset) GetData() any {
 }
 
 func (g *GcpMonitoringAsset) GetElasticCommonData() (map[string]any, error) {
-	return map[string]any{
-		"cloud": map[string]any{
-			"provider": "gcp",
-			"account": map[string]any{
-				"id":   g.Asset.Ecs.ProjectId,
-				"name": g.Asset.Ecs.ProjectName,
-			},
-			"Organization": map[string]any{
-				"id":   g.Asset.Ecs.OrganizationId,
-				"name": g.Asset.Ecs.OrganizationName,
-			},
-		},
-	}, nil
+	return nil, nil
 }

--- a/internal/resources/fetching/fetchers/gcp/policies_fetcher.go
+++ b/internal/resources/fetching/fetchers/gcp/policies_fetcher.go
@@ -81,13 +81,14 @@ func (f *GcpPoliciesFetcher) Stop() {
 }
 
 func (g *GcpPoliciesAsset) GetMetadata() (fetching.ResourceMetadata, error) {
-	id := fmt.Sprintf("%s-%s", g.subType, g.Asset.Ecs.ProjectId)
+	id := fmt.Sprintf("%s-%s", g.subType, g.Asset.CloudAccount.AccountId)
 	return fetching.ResourceMetadata{
-		ID:      id,
-		Type:    g.Type,
-		SubType: g.subType,
-		Name:    id,
-		Region:  gcplib.GlobalRegion,
+		ID:                   id,
+		Type:                 g.Type,
+		SubType:              g.subType,
+		Name:                 id,
+		Region:               gcplib.GlobalRegion,
+		CloudAccountMetadata: *g.Asset.CloudAccount,
 	}, nil
 }
 
@@ -96,17 +97,5 @@ func (g *GcpPoliciesAsset) GetData() any {
 }
 
 func (g *GcpPoliciesAsset) GetElasticCommonData() (map[string]any, error) {
-	return map[string]any{
-		"cloud": map[string]any{
-			"provider": "gcp",
-			"account": map[string]any{
-				"id":   g.Asset.Ecs.ProjectId,
-				"name": g.Asset.Ecs.ProjectName,
-			},
-			"Organization": map[string]any{
-				"id":   g.Asset.Ecs.OrganizationId,
-				"name": g.Asset.Ecs.OrganizationName,
-			},
-		},
-	}, nil
+	return nil, nil
 }

--- a/internal/resources/fetching/fetchers/gcp/service_usage_fetcher.go
+++ b/internal/resources/fetching/fetchers/gcp/service_usage_fetcher.go
@@ -82,13 +82,14 @@ func (f *GcpServiceUsageFetcher) Stop() {
 }
 
 func (g *GcpServiceUsageAsset) GetMetadata() (fetching.ResourceMetadata, error) {
-	id := fmt.Sprintf("%s-%s", g.subType, g.Asset.Ecs.ProjectId)
+	id := fmt.Sprintf("%s-%s", g.subType, g.Asset.CloudAccount.AccountId)
 	return fetching.ResourceMetadata{
-		ID:      id,
-		Type:    g.Type,
-		SubType: g.subType,
-		Name:    id,
-		Region:  gcplib.GlobalRegion,
+		ID:                   id,
+		Type:                 g.Type,
+		SubType:              g.subType,
+		Name:                 id,
+		Region:               gcplib.GlobalRegion,
+		CloudAccountMetadata: *g.Asset.CloudAccount,
 	}, nil
 }
 
@@ -97,17 +98,5 @@ func (g *GcpServiceUsageAsset) GetData() any {
 }
 
 func (g *GcpServiceUsageAsset) GetElasticCommonData() (map[string]any, error) {
-	return map[string]any{
-		"cloud": map[string]any{
-			"provider": "gcp",
-			"account": map[string]any{
-				"id":   g.Asset.Ecs.ProjectId,
-				"name": g.Asset.Ecs.ProjectName,
-			},
-			"Organization": map[string]any{
-				"id":   g.Asset.Ecs.OrganizationId,
-				"name": g.Asset.Ecs.OrganizationName,
-			},
-		},
-	}, nil
+	return nil, nil
 }

--- a/internal/resources/providers/gcplib/inventory/provider.go
+++ b/internal/resources/providers/gcplib/inventory/provider.go
@@ -42,7 +42,7 @@ type Provider struct {
 	config    auth.GcpFactoryConfig
 	inventory *AssetsInventoryWrapper
 	crm       *ResourceManagerWrapper
-	crmCache  map[string]*fetching.EcsGcp
+	crmCache  map[string]*fetching.CloudAccountMetadata
 }
 
 type AssetsInventoryWrapper struct {
@@ -59,29 +59,29 @@ type ResourceManagerWrapper struct {
 }
 
 type MonitoringAsset struct {
-	Ecs        *fetching.EcsGcp
-	LogMetrics []*ExtendedGcpAsset `json:"log_metrics,omitempty"`
-	Alerts     []*ExtendedGcpAsset `json:"alerts,omitempty"`
+	CloudAccount *fetching.CloudAccountMetadata
+	LogMetrics   []*ExtendedGcpAsset `json:"log_metrics,omitempty"`
+	Alerts       []*ExtendedGcpAsset `json:"alerts,omitempty"`
 }
 
 type LoggingAsset struct {
-	Ecs      *fetching.EcsGcp
-	LogSinks []*ExtendedGcpAsset `json:"log_sinks,omitempty"`
+	CloudAccount *fetching.CloudAccountMetadata
+	LogSinks     []*ExtendedGcpAsset `json:"log_sinks,omitempty"`
 }
 
 type ProjectPoliciesAsset struct {
-	Ecs      *fetching.EcsGcp
-	Policies []*ExtendedGcpAsset `json:"policies,omitempty"`
+	CloudAccount *fetching.CloudAccountMetadata
+	Policies     []*ExtendedGcpAsset `json:"policies,omitempty"`
 }
 
 type ServiceUsageAsset struct {
-	Ecs      *fetching.EcsGcp
-	Services []*ExtendedGcpAsset `json:"services,omitempty"`
+	CloudAccount *fetching.CloudAccountMetadata
+	Services     []*ExtendedGcpAsset `json:"services,omitempty"`
 }
 
 type ExtendedGcpAsset struct {
 	*assetpb.Asset
-	Ecs *fetching.EcsGcp
+	CloudAccount *fetching.CloudAccountMetadata
 }
 
 type ProviderInitializer struct{}
@@ -175,7 +175,7 @@ func (p *ProviderInitializer) Init(ctx context.Context, log *logp.Logger, gcpCon
 		log:       log,
 		inventory: assetsInventoryWrapper,
 		crm:       crmServiceWrapper,
-		crmCache:  make(map[string]*fetching.EcsGcp),
+		crmCache:  make(map[string]*fetching.CloudAccountMetadata),
 	}, nil
 }
 
@@ -235,11 +235,10 @@ func (p *Provider) ListMonitoringAssets(ctx context.Context, monitoringAssetType
 		return &MonitoringAsset{
 			LogMetrics: getAssetsByType(assets, MonitoringLogMetricAssetType),
 			Alerts:     getAssetsByType(assets, MonitoringAlertPolicyAssetType),
-			Ecs: &fetching.EcsGcp{
-				Provider:         "gcp",
-				ProjectId:        projectId,
-				ProjectName:      projectName,
-				OrganizationId:   orgId,
+			CloudAccount: &fetching.CloudAccountMetadata{
+				AccountId:        projectId,
+				AccountName:      projectName,
+				OrganisationId:   orgId,
 				OrganizationName: orgName,
 			},
 		}
@@ -262,11 +261,10 @@ func (p *Provider) ListLoggingAssets(ctx context.Context) ([]*LoggingAsset, erro
 	typeGenerator := func(assets []*ExtendedGcpAsset, projectId, projectName, orgId, orgName string) *LoggingAsset {
 		return &LoggingAsset{
 			LogSinks: assets,
-			Ecs: &fetching.EcsGcp{
-				Provider:         "gcp",
-				ProjectId:        projectId,
-				ProjectName:      projectName,
-				OrganizationId:   orgId,
+			CloudAccount: &fetching.CloudAccountMetadata{
+				AccountId:        projectId,
+				AccountName:      projectName,
+				OrganisationId:   orgId,
 				OrganizationName: orgName,
 			},
 		}
@@ -286,11 +284,10 @@ func (p *Provider) ListServiceUsageAssets(ctx context.Context) ([]*ServiceUsageA
 	typeGenerator := func(assets []*ExtendedGcpAsset, projectId, projectName, orgId, orgName string) *ServiceUsageAsset {
 		return &ServiceUsageAsset{
 			Services: assets,
-			Ecs: &fetching.EcsGcp{
-				Provider:         "gcp",
-				ProjectId:        projectId,
-				ProjectName:      projectName,
-				OrganizationId:   orgId,
+			CloudAccount: &fetching.CloudAccountMetadata{
+				AccountId:        projectId,
+				AccountName:      projectName,
+				OrganisationId:   orgId,
 				OrganizationName: orgName,
 			},
 		}
@@ -378,7 +375,7 @@ func decodeDnsPolicies(dnsPolicyAssets []*assetpb.Asset) []*dnsPolicyFields {
 
 // getAssetsByProject groups assets by project, extracts metadata for each project, and adds folder and organization-level resources for each group.
 func getAssetsByProject[T any](assets []*ExtendedGcpAsset, log *logp.Logger, f TypeGenerator[T]) []*T {
-	assetsByProject := lo.GroupBy(assets, func(asset *ExtendedGcpAsset) string { return asset.Ecs.ProjectId })
+	assetsByProject := lo.GroupBy(assets, func(asset *ExtendedGcpAsset) string { return asset.CloudAccount.AccountId })
 	enrichedAssets := make([]*T, 0, len(assetsByProject))
 	for projectId, projectAssets := range assetsByProject {
 		if projectId == "" {
@@ -390,16 +387,16 @@ func getAssetsByProject[T any](assets []*ExtendedGcpAsset, log *logp.Logger, f T
 			continue
 		}
 
-		ecs := projectAssets[0].Ecs
+		c := projectAssets[0].CloudAccount
 
 		// add folder and org level log sinks for each project
 		projectAssets = append(projectAssets, assetsByProject[""]...)
 		enrichedAssets = append(enrichedAssets, f(
 			projectAssets,
 			projectId,
-			ecs.ProjectName,
-			ecs.OrganizationId,
-			ecs.OrganizationName,
+			c.AccountName,
+			c.OrganisationId,
+			c.OrganizationName,
 		))
 	}
 	return enrichedAssets
@@ -447,22 +444,22 @@ func mergeAssetContentType(assets []*assetpb.Asset) []*assetpb.Asset {
 }
 
 // extends the assets with the project and organization display name
-func extendWithECS(ctx context.Context, crm *ResourceManagerWrapper, cache map[string]*fetching.EcsGcp, assets []*assetpb.Asset) []*ExtendedGcpAsset {
+func extendWithECS(ctx context.Context, crm *ResourceManagerWrapper, cache map[string]*fetching.CloudAccountMetadata, assets []*assetpb.Asset) []*ExtendedGcpAsset {
 	extendedAssets := make([]*ExtendedGcpAsset, 0, len(assets))
 	for _, asset := range assets {
 		keys := getAssetIds(asset)
 		cacheKey := fmt.Sprintf("%s/%s", keys.parentProject, keys.parentOrg)
-		if ecsGcpCloudCached, ok := cache[cacheKey]; ok {
+		if cloudAccount, ok := cache[cacheKey]; ok {
 			extendedAssets = append(extendedAssets, &ExtendedGcpAsset{
-				Asset: asset,
-				Ecs:   ecsGcpCloudCached,
+				Asset:        asset,
+				CloudAccount: cloudAccount,
 			})
 			continue
 		}
-		cache[cacheKey] = getEcsGcpCloudData(ctx, crm, keys)
+		cache[cacheKey] = getCloudAccountMetadata(ctx, crm, keys)
 		extendedAssets = append(extendedAssets, &ExtendedGcpAsset{
-			Asset: asset,
-			Ecs:   cache[cacheKey],
+			Asset:        asset,
+			CloudAccount: cache[cacheKey],
 		})
 	}
 	return extendedAssets
@@ -479,7 +476,7 @@ func (p *Provider) ListProjectsAncestorsPolicies(ctx context.Context) ([]*Projec
 		projectAsset := extendWithECS(ctx, p.crm, p.crmCache, []*assetpb.Asset{project})[0]
 		// Skip first ancestor it as we already got it
 		policiesAssets := append([]*ExtendedGcpAsset{projectAsset}, getAncestorsAssets(ctx, p, project.Ancestors[1:])...)
-		return &ProjectPoliciesAsset{Ecs: projectAsset.Ecs, Policies: policiesAssets}
+		return &ProjectPoliciesAsset{CloudAccount: projectAsset.CloudAccount, Policies: policiesAssets}
 	}), nil
 }
 
@@ -514,7 +511,7 @@ func getAssetIds(asset *assetpb.Asset) GcpAssetIDs {
 	}
 }
 
-func getEcsGcpCloudData(ctx context.Context, crm *ResourceManagerWrapper, keys GcpAssetIDs) *fetching.EcsGcp {
+func getCloudAccountMetadata(ctx context.Context, crm *ResourceManagerWrapper, keys GcpAssetIDs) *fetching.CloudAccountMetadata {
 	var orgName string
 	var projectName string
 	wg := sync.WaitGroup{}
@@ -529,10 +526,10 @@ func getEcsGcpCloudData(ctx context.Context, crm *ResourceManagerWrapper, keys G
 		wg.Done()
 	}()
 	wg.Wait()
-	return &fetching.EcsGcp{
-		ProjectId:        keys.projectId,
-		ProjectName:      projectName,
-		OrganizationId:   keys.orgId,
+	return &fetching.CloudAccountMetadata{
+		AccountId:        keys.projectId,
+		AccountName:      projectName,
+		OrganisationId:   keys.orgId,
 		OrganizationName: orgName,
 	}
 }

--- a/internal/resources/providers/gcplib/inventory/provider.go
+++ b/internal/resources/providers/gcplib/inventory/provider.go
@@ -387,16 +387,16 @@ func getAssetsByProject[T any](assets []*ExtendedGcpAsset, log *logp.Logger, f T
 			continue
 		}
 
-		c := projectAssets[0].CloudAccount
+		cloudAccount := projectAssets[0].CloudAccount
 
 		// add folder and org level log sinks for each project
 		projectAssets = append(projectAssets, assetsByProject[""]...)
 		enrichedAssets = append(enrichedAssets, f(
 			projectAssets,
 			projectId,
-			c.AccountName,
-			c.OrganisationId,
-			c.OrganizationName,
+			cloudAccount.AccountName,
+			cloudAccount.OrganisationId,
+			cloudAccount.OrganizationName,
 		))
 	}
 	return enrichedAssets

--- a/internal/resources/providers/gcplib/inventory/provider_test.go
+++ b/internal/resources/providers/gcplib/inventory/provider_test.go
@@ -89,7 +89,7 @@ func (s *ProviderTestSuite) TestListAllAssetTypesByName() {
 				return "OrganizationName"
 			},
 		},
-		crmCache: make(map[string]*fetching.EcsGcp),
+		crmCache: make(map[string]*fetching.CloudAccountMetadata),
 	}
 
 	s.mockedIterator.On("Next").Return(&assetpb.Asset{Name: "AssetName1", Resource: &assetpb.Resource{}, Ancestors: []string{"projects/1", "organizations/1"}}, nil).Once()
@@ -111,12 +111,12 @@ func (s *ProviderTestSuite) TestListAllAssetTypesByName() {
 	s.Len(value, 2)          // 2 assets in total 		(assetName1 merged resource/policy, assetName2)
 
 	// tests extending assets with display names for org/prj:
-	projectNames := lo.UniqBy(value, func(asset *ExtendedGcpAsset) string { return asset.Ecs.ProjectName })
-	orgNames := lo.UniqBy(value, func(asset *ExtendedGcpAsset) string { return asset.Ecs.OrganizationName })
+	projectNames := lo.UniqBy(value, func(asset *ExtendedGcpAsset) string { return asset.CloudAccount.AccountName })
+	orgNames := lo.UniqBy(value, func(asset *ExtendedGcpAsset) string { return asset.CloudAccount.OrganizationName })
 	s.Len(projectNames, 1)
-	s.Equal("ProjectName", projectNames[0].Ecs.ProjectName)
+	s.Equal("ProjectName", projectNames[0].CloudAccount.AccountName)
 	s.Len(orgNames, 1)
-	s.Equal("OrganizationName", orgNames[0].Ecs.OrganizationName)
+	s.Equal("OrganizationName", orgNames[0].CloudAccount.OrganizationName)
 }
 
 func (s *ProviderTestSuite) TestListMonitoringAssets() {
@@ -138,42 +138,40 @@ func (s *ProviderTestSuite) TestListMonitoringAssets() {
 				return "OrganizationName1"
 			},
 		},
-		crmCache: make(map[string]*fetching.EcsGcp),
+		crmCache: make(map[string]*fetching.CloudAccountMetadata),
 	}
 
 	expected := []*MonitoringAsset{
 		{
 			LogMetrics: []*ExtendedGcpAsset{
 				{
-					Asset: &assetpb.Asset{Name: "LogMetric1", Resource: &assetpb.Resource{}, Ancestors: []string{"projects/1", "organizations/1"}, AssetType: MonitoringLogMetricAssetType},
-					Ecs:   &fetching.EcsGcp{ProjectId: "1", ProjectName: "ProjectName1", OrganizationId: "1", OrganizationName: "OrganizationName1"},
+					Asset:        &assetpb.Asset{Name: "LogMetric1", Resource: &assetpb.Resource{}, Ancestors: []string{"projects/1", "organizations/1"}, AssetType: MonitoringLogMetricAssetType},
+					CloudAccount: &fetching.CloudAccountMetadata{AccountId: "1", AccountName: "ProjectName1", OrganisationId: "1", OrganizationName: "OrganizationName1"},
 				},
 			},
-			Ecs: &fetching.EcsGcp{
-				Provider:         "gcp",
-				ProjectId:        "1",
-				ProjectName:      "ProjectName1",
-				OrganizationId:   "1",
+			CloudAccount: &fetching.CloudAccountMetadata{
+				AccountId:        "1",
+				AccountName:      "ProjectName1",
+				OrganisationId:   "1",
 				OrganizationName: "OrganizationName1",
 			},
 			Alerts: make([]*ExtendedGcpAsset, 0, 1),
 		},
 		{
 			LogMetrics: make([]*ExtendedGcpAsset, 0, 1),
-			Ecs: &fetching.EcsGcp{
-				Provider:         "gcp",
-				ProjectId:        "2",
-				ProjectName:      "ProjectName2",
-				OrganizationId:   "1",
+			CloudAccount: &fetching.CloudAccountMetadata{
+				AccountId:        "2",
+				AccountName:      "ProjectName2",
+				OrganisationId:   "1",
 				OrganizationName: "OrganizationName1",
 			},
 			Alerts: []*ExtendedGcpAsset{
 				{
 					Asset: &assetpb.Asset{Name: "AlertPolicy1", Resource: nil, IamPolicy: &iampb.Policy{}, Ancestors: []string{"projects/2", "organizations/1"}, AssetType: MonitoringAlertPolicyAssetType},
-					Ecs: &fetching.EcsGcp{
-						ProjectId:        "2",
-						ProjectName:      "ProjectName2",
-						OrganizationId:   "1",
+					CloudAccount: &fetching.CloudAccountMetadata{
+						AccountId:        "2",
+						AccountName:      "ProjectName2",
+						OrganisationId:   "1",
 						OrganizationName: "OrganizationName1",
 					},
 				},
@@ -220,7 +218,7 @@ func (s *ProviderTestSuite) TestEnrichNetworkAssets() {
 				return "OrganizationName"
 			},
 		},
-		crmCache: make(map[string]*fetching.EcsGcp),
+		crmCache: make(map[string]*fetching.CloudAccountMetadata),
 	}
 
 	assets := []*ExtendedGcpAsset{
@@ -286,29 +284,27 @@ func (s *ProviderTestSuite) TestEnrichNetworkAssets() {
 func (s *ProviderTestSuite) TestListServiceUsageAssets() {
 	expected := []*ServiceUsageAsset{
 		{
-			Ecs: &fetching.EcsGcp{
-				Provider:         "gcp",
-				ProjectId:        "1",
-				ProjectName:      "ProjectName1",
-				OrganizationId:   "1",
+			CloudAccount: &fetching.CloudAccountMetadata{
+				AccountId:        "1",
+				AccountName:      "ProjectName1",
+				OrganisationId:   "1",
 				OrganizationName: "OrganizationName1",
 			},
 			Services: []*ExtendedGcpAsset{{
-				Asset: &assetpb.Asset{Name: "ServiceUsage1", Resource: &assetpb.Resource{}, IamPolicy: nil, Ancestors: []string{"projects/1", "organizations/1"}, AssetType: "serviceusage.googleapis.com/Service"},
-				Ecs:   &fetching.EcsGcp{ProjectId: "1", ProjectName: "ProjectName1", OrganizationId: "1", OrganizationName: "OrganizationName1"},
+				Asset:        &assetpb.Asset{Name: "ServiceUsage1", Resource: &assetpb.Resource{}, IamPolicy: nil, Ancestors: []string{"projects/1", "organizations/1"}, AssetType: "serviceusage.googleapis.com/Service"},
+				CloudAccount: &fetching.CloudAccountMetadata{AccountId: "1", AccountName: "ProjectName1", OrganisationId: "1", OrganizationName: "OrganizationName1"},
 			}},
 		},
 		{
-			Ecs: &fetching.EcsGcp{
-				Provider:         "gcp",
-				ProjectId:        "2",
-				ProjectName:      "ProjectName2",
-				OrganizationId:   "1",
+			CloudAccount: &fetching.CloudAccountMetadata{
+				AccountId:        "2",
+				AccountName:      "ProjectName2",
+				OrganisationId:   "1",
 				OrganizationName: "OrganizationName1",
 			},
 			Services: []*ExtendedGcpAsset{{
-				Asset: &assetpb.Asset{Name: "ServiceUsage2", Resource: nil, IamPolicy: &iampb.Policy{}, Ancestors: []string{"projects/2", "organizations/1"}, AssetType: "serviceusage.googleapis.com/Service"},
-				Ecs:   &fetching.EcsGcp{ProjectId: "2", ProjectName: "ProjectName2", OrganizationId: "1", OrganizationName: "OrganizationName1"},
+				Asset:        &assetpb.Asset{Name: "ServiceUsage2", Resource: nil, IamPolicy: &iampb.Policy{}, Ancestors: []string{"projects/2", "organizations/1"}, AssetType: "serviceusage.googleapis.com/Service"},
+				CloudAccount: &fetching.CloudAccountMetadata{AccountId: "2", AccountName: "ProjectName2", OrganisationId: "1", OrganizationName: "OrganizationName1"},
 			}},
 		},
 	}
@@ -336,7 +332,7 @@ func (s *ProviderTestSuite) TestListServiceUsageAssets() {
 				return "OrganizationName1"
 			},
 		},
-		crmCache: make(map[string]*fetching.EcsGcp),
+		crmCache: make(map[string]*fetching.CloudAccountMetadata),
 	}
 
 	// asset's resource
@@ -360,40 +356,38 @@ func (s *ProviderTestSuite) TestListServiceUsageAssets() {
 func (s *ProviderTestSuite) TestListLoggingAssets() {
 	expected := []*LoggingAsset{
 		{
-			Ecs: &fetching.EcsGcp{
-				Provider:         "gcp",
-				ProjectId:        "1",
-				ProjectName:      "ProjectName1",
-				OrganizationId:   "1",
+			CloudAccount: &fetching.CloudAccountMetadata{
+				AccountId:        "1",
+				AccountName:      "ProjectName1",
+				OrganisationId:   "1",
 				OrganizationName: "OrganizationName1",
 			},
 			LogSinks: []*ExtendedGcpAsset{
 				{
-					Asset: &assetpb.Asset{Name: "LogSink1", Resource: &assetpb.Resource{}, IamPolicy: nil, Ancestors: []string{"projects/1", "organizations/1"}, AssetType: "logging.googleapis.com/LogSink"},
-					Ecs:   &fetching.EcsGcp{ProjectId: "1", ProjectName: "ProjectName1", OrganizationId: "1", OrganizationName: "OrganizationName1"},
+					Asset:        &assetpb.Asset{Name: "LogSink1", Resource: &assetpb.Resource{}, IamPolicy: nil, Ancestors: []string{"projects/1", "organizations/1"}, AssetType: "logging.googleapis.com/LogSink"},
+					CloudAccount: &fetching.CloudAccountMetadata{AccountId: "1", AccountName: "ProjectName1", OrganisationId: "1", OrganizationName: "OrganizationName1"},
 				},
 				{
-					Asset: &assetpb.Asset{Name: "LogSink3", Resource: nil, IamPolicy: nil, Ancestors: []string{"organizations/1"}, AssetType: "logging.googleapis.com/LogSink"},
-					Ecs:   &fetching.EcsGcp{ProjectId: "", ProjectName: "", OrganizationId: "1", OrganizationName: "OrganizationName1"},
+					Asset:        &assetpb.Asset{Name: "LogSink3", Resource: nil, IamPolicy: nil, Ancestors: []string{"organizations/1"}, AssetType: "logging.googleapis.com/LogSink"},
+					CloudAccount: &fetching.CloudAccountMetadata{AccountId: "", AccountName: "", OrganisationId: "1", OrganizationName: "OrganizationName1"},
 				},
 			},
 		},
 		{
-			Ecs: &fetching.EcsGcp{
-				Provider:         "gcp",
-				ProjectId:        "2",
-				ProjectName:      "ProjectName2",
-				OrganizationId:   "1",
+			CloudAccount: &fetching.CloudAccountMetadata{
+				AccountId:        "2",
+				AccountName:      "ProjectName2",
+				OrganisationId:   "1",
 				OrganizationName: "OrganizationName1",
 			},
 			LogSinks: []*ExtendedGcpAsset{
 				{
-					Asset: &assetpb.Asset{Name: "LogSink2", Resource: nil, IamPolicy: &iampb.Policy{}, Ancestors: []string{"projects/2", "organizations/1"}, AssetType: "logging.googleapis.com/LogSink"},
-					Ecs:   &fetching.EcsGcp{ProjectId: "2", ProjectName: "ProjectName2", OrganizationId: "1", OrganizationName: "OrganizationName1"},
+					Asset:        &assetpb.Asset{Name: "LogSink2", Resource: nil, IamPolicy: &iampb.Policy{}, Ancestors: []string{"projects/2", "organizations/1"}, AssetType: "logging.googleapis.com/LogSink"},
+					CloudAccount: &fetching.CloudAccountMetadata{AccountId: "2", AccountName: "ProjectName2", OrganisationId: "1", OrganizationName: "OrganizationName1"},
 				},
 				{
-					Asset: &assetpb.Asset{Name: "LogSink3", Resource: nil, IamPolicy: nil, Ancestors: []string{"organizations/1"}, AssetType: "logging.googleapis.com/LogSink"},
-					Ecs:   &fetching.EcsGcp{ProjectId: "", ProjectName: "", OrganizationId: "1", OrganizationName: "OrganizationName1"},
+					Asset:        &assetpb.Asset{Name: "LogSink3", Resource: nil, IamPolicy: nil, Ancestors: []string{"organizations/1"}, AssetType: "logging.googleapis.com/LogSink"},
+					CloudAccount: &fetching.CloudAccountMetadata{AccountId: "", AccountName: "", OrganisationId: "1", OrganizationName: "OrganizationName1"},
 				},
 			},
 		},
@@ -427,7 +421,7 @@ func (s *ProviderTestSuite) TestListLoggingAssets() {
 				return "OrganizationName1"
 			},
 		},
-		crmCache: make(map[string]*fetching.EcsGcp),
+		crmCache: make(map[string]*fetching.CloudAccountMetadata),
 	}
 
 	// asset's resource
@@ -466,7 +460,7 @@ func (s *ProviderTestSuite) TestListProjectsAncestorsPolicies() {
 				return "OrganizationName"
 			},
 		},
-		crmCache: make(map[string]*fetching.EcsGcp),
+		crmCache: make(map[string]*fetching.CloudAccountMetadata),
 	}
 
 	s.mockedIterator.On("Next").Return(&assetpb.Asset{Name: "AssetName1", IamPolicy: &iampb.Policy{}, Ancestors: []string{"projects/1", "organizations/1"}}, nil).Once()
@@ -479,8 +473,8 @@ func (s *ProviderTestSuite) TestListProjectsAncestorsPolicies() {
 
 	s.Len(value, 1)             // single project
 	s.Len(value[0].Policies, 2) // multiple policies - project + org
-	s.Equal("ProjectName", value[0].Ecs.ProjectName)
-	s.Equal("OrganizationName", value[0].Ecs.OrganizationName)
+	s.Equal("ProjectName", value[0].CloudAccount.AccountName)
+	s.Equal("OrganizationName", value[0].CloudAccount.OrganizationName)
 	s.Equal("AssetName1", value[0].Policies[0].Name)
 	s.Equal("AssetName2", value[0].Policies[1].Name)
 }


### PR DESCRIPTION
### Summary of your changes

AWS and Azure both use `fetching.CloudAccountMetadata` to describe cloud metadata and `resource.GetMetadata` to populate it (via `EnrichEvent` of cloud data provider). 

GCP uses `EcsGcp` to describe the same cloud metadata and uses `resource.GetElasticCommonData` to populate it. 

this PR makes it so that GCP describes and populates cloud data the same way AWS and Azure do it. 

### Screenshot/Data

![Screenshot 2024-04-03 at 6 55 38](https://github.com/elastic/cloudbeat/assets/20814186/5ed000b3-180c-4183-b492-3a87bc335c1e)




### Related Issues
- closes https://github.com/elastic/cloudbeat/issues/2079

