### PR TITLE
update CNVM timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
     needs: [ init-hermit ]
     name: CNVM CI
     runs-on: ubuntu-22.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
bump timeout so we can maybe see logs in failed runs 

cc @oren-zohar going to need a force merge here as CNVM-CI is going to fail