### PR TITLE
Update rerun workflow to send Slack notification if event name is not a pull request.

### DIFF
--- a/.github/workflows/rerun-flaky-workflows.yml
+++ b/.github/workflows/rerun-flaky-workflows.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Slack Notification
         uses: ./.github/actions/slack-notification
-        if: ${{ !cancelled() && failure() }} # Run only if the previous step failed
+        if: ${{ !cancelled() && failure() && github.event_name != 'pull_request' }} # Run only if the previous step failed
         continue-on-error: true
         env:
           BREAKING_COMMIT: "${{ github.event.workflow_run.head_sha }}"


### PR DESCRIPTION
### Summary of your changes

This PR enhances the rerun workflow to send a Slack notification when the event differs from a pull request

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
