### PR TITLE
[CIS GCP] Add owner label to a deployment manager deployments

### DIFF
--- a/deploy/deployment-manager/deploy.sh
+++ b/deploy/deployment-manager/deploy.sh
@@ -34,6 +34,7 @@ DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-elastic-agent-cspm}
 ALLOW_SSH=${ALLOW_SSH:-false}
 ZONE=${ZONE:-us-central1-a}
 ROLE="roles/resourcemanager.projectIamAdmin"
+OWNER=$(whoami)
 
 ELASTIC_ARTIFACT_SERVER=${ELASTIC_ARTIFACT_SERVER%/} # Remove trailing slash if present
 ELASTIC_ARTIFACT_SERVER=${ELASTIC_ARTIFACT_SERVER:-https://artifacts.elastic.co/downloads/beats/elastic-agent}
@@ -115,7 +116,8 @@ fi
 # Apply the deployment manager templates
 run_command "gcloud deployment-manager deployments create --automatic-rollback-on-error ${DEPLOYMENT_NAME} --project ${PROJECT_NAME} \
     --template compute_engine.py \
-    --properties elasticAgentVersion:${STACK_VERSION},fleetUrl:${FLEET_URL},enrollmentToken:${ENROLLMENT_TOKEN},allowSSH:${ALLOW_SSH},zone:${ZONE},elasticArtifactServer:${ELASTIC_ARTIFACT_SERVER},scope:${SCOPE},parentId:${PARENT_ID}"
+    --properties elasticAgentVersion:${STACK_VERSION},fleetUrl:${FLEET_URL},enrollmentToken:${ENROLLMENT_TOKEN},allowSSH:${ALLOW_SSH},zone:${ZONE},elasticArtifactServer:${ELASTIC_ARTIFACT_SERVER},scope:${SCOPE},parentId:${PARENT_ID} \
+    --labels owner=${OWNER}"
 
 ## Remove the role required to deploy the DM templates
 if [ "$ADD_ROLE" = "true" ]; then


### PR DESCRIPTION
### Summary of your changes
Currently, the deployment created using IAC lacks any label making it hard to identify the owner.
This PR adds an owner label according to the user who is logged in to Cloud Shell.


<img width="1215" alt="Screenshot 2024-04-03 at 12 57 11" src="https://github.com/elastic/cloudbeat/assets/68195305/bef68a07-926b-40a1-a307-0589af8da4ff">

