### PR TITLE
Disable integration tests for Azure 4.4.1

### DIFF
--- a/security-policies/RULES.md
+++ b/security-policies/RULES.md
@@ -404,7 +404,7 @@
 
 #### Manual rules: 0/74 (0%)
 
-#### Integration Tests Coverage: 102/302 (34%)
+#### Integration Tests Coverage: 100/302 (33%)
 
 <details><summary><h3>Full Table 📋</h3></summary>
 
@@ -501,7 +501,7 @@
 |  [4.3.6](bundle/compliance/cis_azure/rules/cis_4_3_6)  | PostgreSQL Database Server              | Ensure Server Parameter 'log_retention_days' is greater than 3 days for PostgreSQL Database Server                                                     | :white_check_mark: | Passed :white_check_mark: / Failed :white_check_mark: | Automated |
 |  [4.3.7](bundle/compliance/cis_azure/rules/cis_4_3_7)  | PostgreSQL Database Server              | Ensure 'Allow access to Azure services' for PostgreSQL Database Server is disabled                                                                     | :white_check_mark: | Passed :white_check_mark: / Failed :white_check_mark: | Automated |
 |  [4.3.8](bundle/compliance/cis_azure/rules/cis_4_3_8)  | PostgreSQL Database Server              | Ensure 'Infrastructure double encryption' for PostgreSQL Database Server is 'Enabled'                                                                  | :white_check_mark: |        Passed :x: / Failed :white_check_mark:         | Automated |
-|  [4.4.1](bundle/compliance/cis_azure/rules/cis_4_4_1)  | MySQL Database                          | Ensure 'Enforce SSL connection' is set to 'Enabled' for Standard MySQL Database Server                                                                 | :white_check_mark: | Passed :white_check_mark: / Failed :white_check_mark: | Automated |
+|  [4.4.1](bundle/compliance/cis_azure/rules/cis_4_4_1)  | MySQL Database                          | Ensure 'Enforce SSL connection' is set to 'Enabled' for Standard MySQL Database Server                                                                 | :white_check_mark: |                Passed :x: / Failed :x:                | Automated |
 |  [4.4.2](bundle/compliance/cis_azure/rules/cis_4_4_2)  | MySQL Database                          | Ensure 'TLS Version' is set to 'TLSV1.2' for MySQL flexible Database Server                                                                            | :white_check_mark: |        Passed :white_check_mark: / Failed :x:         | Automated |
 |                         4.4.3                          | MySQL Database                          | Ensure server parameter 'audit_log_enabled' is set to 'ON' for MySQL Database Server                                                                   |        :x:         |                Passed :x: / Failed :x:                | Manual    |
 |                         4.4.4                          | MySQL Database                          | Ensure server parameter 'audit_log_events' has 'CONNECTION' set for MySQL Database Server                                                              |        :x:         |                Passed :x: / Failed :x:                | Manual    |

--- a/tests/product/tests/data/azure/azure_database_service_test_cases.py
+++ b/tests/product/tests/data/azure/azure_database_service_test_cases.py
@@ -23,7 +23,9 @@ CIS_4_3_5 = "CIS 4.3.5"
 CIS_4_3_6 = "CIS 4.3.6"
 CIS_4_3_7 = "CIS 4.3.7"
 CIS_4_3_8 = "CIS 4.3.8"
-CIS_4_4_1 = "CIS 4.4.1"
+# Disable 4.4.1 - Azure Database for MySQL - Single Server is being retired
+# See: https://learn.microsoft.com/en-us/azure/mysql/single-server/whats-happening-to-mysql-single-server
+# CIS_4_4_1 = "CIS 4.4.1"
 CIS_4_4_2 = "CIS 4.4.2"
 CIS_4_5_1 = "CIS 4.5.1"
 
@@ -327,24 +329,24 @@ cis_azure_4_3_8 = {
 
 # 4.4.* Rules ====================================
 
-cis_azure_4_4_1_pass = AzureServiceCase(
-    rule_tag=CIS_4_4_1,
-    case_identifier="rule-441",
-    expected=RULE_PASS_STATUS,
-)
-
-cis_azure_4_4_1_fail = AzureServiceCase(
-    rule_tag=CIS_4_4_1,
-    case_identifier="rule-441-fail",
-    expected=RULE_FAIL_STATUS,
-)
-
-cis_azure_4_4_1 = {
-    """4.4.1 Ensure 'Enforce SSL connection' is set to 'Enabled'
-      for Standard MySQL Database Server expect: passed""": cis_azure_4_4_1_pass,
-    """4.4.1 Ensure 'Enforce SSL connection' is set to 'Enabled'
-      for Standard MySQL Database Server expect: failed""": cis_azure_4_4_1_fail,
-}
+# cis_azure_4_4_1_pass = AzureServiceCase(
+#     rule_tag=CIS_4_4_1,
+#     case_identifier="rule-441",
+#     expected=RULE_PASS_STATUS,
+# )
+#
+# cis_azure_4_4_1_fail = AzureServiceCase(
+#     rule_tag=CIS_4_4_1,
+#     case_identifier="rule-441-fail",
+#     expected=RULE_FAIL_STATUS,
+# )
+#
+# cis_azure_4_4_1 = {
+#     """4.4.1 Ensure 'Enforce SSL connection' is set to 'Enabled'
+#       for Standard MySQL Database Server expect: passed""": cis_azure_4_4_1_pass,
+#     """4.4.1 Ensure 'Enforce SSL connection' is set to 'Enabled'
+#       for Standard MySQL Database Server expect: failed""": cis_azure_4_4_1_fail,
+# }
 
 cis_azure_4_4_2_pass = AzureServiceCase(
     rule_tag=CIS_4_4_2,
@@ -395,7 +397,7 @@ test_cases = {
     **cis_azure_4_3_6,
     **cis_azure_4_3_7,
     **cis_azure_4_3_8,
-    **cis_azure_4_4_1,
+    # **cis_azure_4_4_1,
     **cis_azure_4_4_2,
     **cis_azure_4_5_1,
 }


### PR DESCRIPTION
### Summary of your changes

`Azure Database for MySQL - Single Server` is being retired by Azure portal. It is no longer possible to create them via UI or via CLI. Existing resources need migration to `Flexible Server` type. Our test resources have already been migrated.

```
~ az mysql server list --resource-group AzureCloudbeatCITests
[]

~ az mysql flexible-server list --resource-group AzureCloudbeatCITests | jq '.[] | .name'
"rule-441"
"rule-441-fail"
"test-mysql-db-fail"
"test-mysql-db-pass"
```

See https://learn.microsoft.com/en-us/azure/mysql/single-server/whats-happening-to-mysql-single-server

### Related Issues
Slack thread by @moukoublen: https://elastic.slack.com/archives/C056S4ZJW3W/p1712239647533959

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

No
