### PR TITLE
fix panic due to missing logger of aws IdentityProvider

### DIFF
--- a/internal/flavors/asset_inventory.go
+++ b/internal/flavors/asset_inventory.go
@@ -86,7 +86,7 @@ func initAwsFetchers(ctx context.Context, cfg *config.Config, logger *logp.Logge
 		return nil, err
 	}
 
-	idProvider := awslib.IdentityProvider{}
+	idProvider := awslib.IdentityProvider{Logger: logger}
 	awsIdentity, err := idProvider.GetIdentity(ctx, awsConfig)
 	if err != nil {
 		return nil, err

--- a/internal/flavors/benchmark/strategy.go
+++ b/internal/flavors/benchmark/strategy.go
@@ -39,24 +39,24 @@ type Strategy interface {
 	checkDependencies() error
 }
 
-func GetStrategy(cfg *config.Config) (Strategy, error) {
+func GetStrategy(cfg *config.Config, log *logp.Logger) (Strategy, error) {
 	switch cfg.Benchmark {
 	case config.CIS_AWS:
 		if cfg.CloudConfig.Aws.AccountType == config.OrganizationAccount {
 			return &AWSOrg{
 				IAMProvider:      &iam.Provider{},
-				IdentityProvider: awslib.IdentityProvider{},
+				IdentityProvider: awslib.IdentityProvider{Logger: log},
 				AccountProvider:  awslib.AccountProvider{},
 			}, nil
 		}
 
 		return &AWS{
-			IdentityProvider: awslib.IdentityProvider{},
+			IdentityProvider: awslib.IdentityProvider{Logger: log},
 		}, nil
 	case config.CIS_EKS:
 		return &EKS{
 			AWSCfgProvider:         awslib.ConfigProvider{MetadataProvider: awslib.Ec2MetadataProvider{}},
-			AWSIdentityProvider:    awslib.IdentityProvider{},
+			AWSIdentityProvider:    awslib.IdentityProvider{Logger: log},
 			AWSMetadataProvider:    awslib.Ec2MetadataProvider{},
 			EKSClusterNameProvider: awslib.EKSClusterNameProvider{},
 			ClientProvider:         k8s.ClientGetter{},
@@ -75,7 +75,8 @@ func GetStrategy(cfg *config.Config) (Strategy, error) {
 	case config.CIS_AZURE:
 		return &Azure{
 			cfgProvider:         &azure_auth.ConfigProvider{AuthProvider: &azure_auth.AzureAuthProvider{}},
-			providerInitializer: &azurelib.ProviderInitializer{}}, nil
+			providerInitializer: &azurelib.ProviderInitializer{},
+		}, nil
 	}
 	return nil, fmt.Errorf("unknown benchmark: '%s'", cfg.Benchmark)
 }

--- a/internal/flavors/benchmark/strategy_test.go
+++ b/internal/flavors/benchmark/strategy_test.go
@@ -93,7 +93,7 @@ func TestGetStrategy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%T", tt.wantType), func(t *testing.T) {
-			got, err := GetStrategy(&tt.cfg)
+			got, err := GetStrategy(&tt.cfg, testhelper.NewLogger(t))
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/internal/flavors/posture.go
+++ b/internal/flavors/posture.go
@@ -51,7 +51,7 @@ func newPostureFromCfg(b *beat.Beat, cfg *config.Config) (*posture, error) {
 	log.Info("Config initiated with cycle period of ", cfg.Period)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	strategy, err := benchmark.GetStrategy(cfg)
+	strategy, err := benchmark.GetStrategy(cfg, log)
 	if err != nil {
 		cancel()
 		return nil, err


### PR DESCRIPTION
### Summary of your changes
<!--
Please provide a detailed description of the changes introduced by this Pull Request.
Provide a description of the main changes, as well as any additional information the code reviewer should be aware of before beginning the review process.
-->
Initialize logger in all `awslib.IdentityProvider` usages to avoid panic when trying to log error.


### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
Fixes: https://github.com/elastic/cloudbeat/issues/2096

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
