### PR TITLE
Update slack channel name

### DIFF
--- a/.github/actions/slack-notification/README.md
+++ b/.github/actions/slack-notification/README.md
@@ -82,13 +82,13 @@ jobs:
 
 Following inputs can be used as `step.with` keys:
 
-| Name             | Type     | Required | Description                                                 |
-|------------------|----------|----------|-------------------------------------------------------------|
-| `vault-role-id`  | String   | yes      | The Vault role id.                                          |
-| `vault-secret-id`| String   | yes      | The Vault secret id.                                        |
-| `vault-url`      | String   | yes      | The Vault URL to connect to.                                |
-| `slack-channel`  | String   | no       | Slack channel id or channel name. Default: #csp-qa-alerts   |
-| `slack-message`  | String   | no       | Posting a simple plain text message.                        |
-| `slack-payload`  | String   | no       | Posting a rich message using Block Kit.                     |
-| `mask-secrets`   | String   | no       | Masking secrets in the logs. Default: 'true'                |
-| `url-encoded`    | String   | no       | URL-encoded message. Default: 'true'                        |
+| Name             | Type     | Required | Description                                                       |
+|------------------|----------|----------|-------------------------------------------------------------------|
+| `vault-role-id`  | String   | yes      | The Vault role id.                                                |
+| `vault-secret-id`| String   | yes      | The Vault secret id.                                              |
+| `vault-url`      | String   | yes      | The Vault URL to connect to.                                      |
+| `slack-channel`  | String   | no       | Slack channel id or channel name. Default: #cloud-sec-qa-alerts   |
+| `slack-message`  | String   | no       | Posting a simple plain text message.                              |
+| `slack-payload`  | String   | no       | Posting a rich message using Block Kit.                           |
+| `mask-secrets`   | String   | no       | Masking secrets in the logs. Default: 'true'                      |
+| `url-encoded`    | String   | no       | URL-encoded message. Default: 'true'                              |

--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -13,7 +13,7 @@ inputs:
   slack-channel:
     description: 'Slack channel'
     required: false
-    default: '#csp-qa-alerts'
+    default: '#cloud-sec-qa-alerts'
   slack-message:
     description: 'Slack message: For multiple lines, provide a URL-encoded message and set url-encoded to true'
     required: false


### PR DESCRIPTION
### Summary of your changes

This PR updates the Slack channel name from `csp-qa-alerts` to `cloud-sec-qa-alerts`

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
