### PR TITLE
add GCP credentials deployment 

### DIFF
--- a/.github/workflows/test-gcp-dm.yml
+++ b/.github/workflows/test-gcp-dm.yml
@@ -12,6 +12,9 @@ on:
       - "deploy/deployment-manager/compute_engine.py.schema"
       - "deploy/deployment-manager/deploy.sh"
       - "deploy/deployment-manager/set_env.sh"
+      - "deploy/deployment-manager/deploy_service_account.sh"
+      - "deploy/deployment-manager/service_account.py"
+      - "deploy/deployment-manager/service_account.py.schema"
 
 env:
   TEST_ENVS_DIR: deploy/test-environments

--- a/.github/workflows/test-gcp-dm.yml
+++ b/.github/workflows/test-gcp-dm.yml
@@ -226,14 +226,12 @@ jobs:
           poetry run pytest -k "cspm_gcp" --alluredir=./allure/results/ --clean-alluredir --maxfail=4
 
       - name: Destory EC deployment
-        # if: steps.deploy_ec.outcome == 'success'
         if: always()
         working-directory: ${{ env.TEST_ENVS_DIR }}
         run: |
           terraform destroy --auto-approve -target="module.ec_deployment" -target="module.ec_project"
 
       - name: Delete GCP Deployments
-        # if: steps.gcp_deploy.outcome == 'success'
         if: always()
         working-directory: ${{ env.TEST_ENVS_DIR }}
         run: |

--- a/.github/workflows/test-gcp-dm.yml
+++ b/.github/workflows/test-gcp-dm.yml
@@ -14,14 +14,16 @@ on:
       - "deploy/deployment-manager/set_env.sh"
 
 env:
-  WORKING_DIR: deploy/test-environments
+  TEST_ENVS_DIR: deploy/test-environments
   INTEGRATIONS_SETUP_DIR: tests/integrations_setup
+  DEPLOYMENT_MANAGER_DIR: deploy/deployment-manager
   TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
   TF_VAR_ess_region: gcp-us-west2 # default region for testing deployments
 
 jobs:
-  Test-GCP-DM:
-    name: GCP Deployment Manager Test
+  # Test a GCP Deployment Manager deployment using Application Default Credentials
+  gcp_dm_adc:
+    name: CSPM GCP with ADC
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     permissions:
@@ -65,7 +67,7 @@ jobs:
       - name: Provision Test Environment (EC)
         id: apply
         if: success()
-        working-directory: ${{ env.WORKING_DIR }}
+        working-directory: ${{ env.TEST_ENVS_DIR }}
         run: |
           terraform -v
           terraform init
@@ -108,7 +110,7 @@ jobs:
 
       - name: Destory EC deployment
         if: always()
-        working-directory: ${{ env.WORKING_DIR }}
+        working-directory: ${{ env.TEST_ENVS_DIR }}
         run: |
           terraform destroy --auto-approve -target="module.ec_deployment" -target="module.ec_project"
 
@@ -118,9 +120,123 @@ jobs:
 
       - name: Delete GCP Deployment Manager deployment
         if: always()
-        working-directory: ${{ env.WORKING_DIR }}
+        working-directory: ${{ env.TEST_ENVS_DIR }}
         run: |
           DEPLOYMENT=${{env.GCP_DEPLOYMENT_NAME}}
           PROJECT_NAME=$(gcloud config get-value core/project)
           PROJECT_NUMBER=$(gcloud projects list --filter="${PROJECT_NAME}" --format="value(PROJECT_NUMBER)")
           ./delete_gcp_env.sh $PROJECT_NAME $PROJECT_NUMBER $DEPLOYMENT
+
+  # Test a GCP Deployment Manager deployment using a Service Account
+  gcp_dm_sa:
+    needs: gcp_dm_adc
+    name: CSPM GCP with SA
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - name: Set up unique deployment names
+        run: |
+          suffix="$(date +%s | tail -c 3)"
+          echo "TF_VAR_deployment_name=gcp-dm-ci-sa-test-$suffix" >> $GITHUB_ENV
+          echo "GCP_AGENT_DEPLOYMENT_NAME=ea-cspm-gcp-ci-test-$suffix" >> $GITHUB_ENV
+          echo "GCP_SA_DEPLOYMENT_NAME=sa-cspm-gcp-ci-test-$suffix" >> $GITHUB_ENV
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Init Hermit
+        run: ./bin/hermit env -r >> $GITHUB_ENV
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          poetry --version
+
+      - id: google-auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }} # this also sets the project name
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: set TF_VAR_stack_version
+        run: |
+          version=$(grep defaultBeatVersion version/version.go | cut -f2 -d "\"")
+          echo "TF_VAR_stack_version=$version" >> $GITHUB_ENV
+
+      - name: Provision Test Environment (EC)
+        id: deploy_ec
+        if: success()
+        working-directory: ${{ env.TEST_ENVS_DIR }}
+        run: |
+          terraform -v
+          terraform init
+          terraform validate
+          terraform apply --auto-approve -target="module.ec_deployment" -target="module.ec_project"
+          terraform output
+          echo "KIBANA_URL=$(terraform output -raw kibana_url)" >> $GITHUB_ENV
+          echo "ES_URL=$(terraform output -raw elasticsearch_url)" >> $GITHUB_ENV
+          echo "ES_USER=$(terraform output -raw elasticsearch_username)" >> $GITHUB_ENV
+
+          export ES_PASSWORD=$(terraform output -raw elasticsearch_password)
+          echo "::add-mask::$ES_PASSWORD"
+          echo "ES_PASSWORD=$ES_PASSWORD" >> $GITHUB_ENV
+
+      - name: Set up GCP Cloud SDK
+        if: always()
+        uses: "google-github-actions/setup-gcloud@v2"
+
+      - name: Deploy GCP Service Account and Agent
+        id: gcp_deploy
+        env:
+          STACK_VERSION: ${{ env.ELK_VERSION }}
+        run: |
+          # Deploys a GCP Service Account
+          cd ${{ env.DEPLOYMENT_MANAGER_DIR }}
+          export DEPLOYMENT_NAME="${{ env.GCP_SA_DEPLOYMENT_NAME }}"
+          export SERVICE_ACCOUNT_NAME="${{ env.GCP_SA_DEPLOYMENT_NAME }}-sa"
+          ./deploy_service_account.sh
+          mv KEY_FILE.json ../../${{ env.INTEGRATIONS_SETUP_DIR }}
+
+          # Installs CSPM GCP integration
+          cd ../../${{ env.INTEGRATIONS_SETUP_DIR }}
+          export SERVICE_ACCOUNT_JSON_PATH="KEY_FILE.json"
+          export DEPLOYMENT_NAME="${{ env.GCP_AGENT_DEPLOYMENT_NAME }}"
+          poetry install
+          poetry run python ./install_cspm_gcp_integration.py
+
+          # Deploys the agent using an existing service account (SERVICE_ACCOUNT_NAME)
+          cd ../../${{ env.DEPLOYMENT_MANAGER_DIR }}
+          . ./set_env.sh && ./deploy.sh
+
+      - name: Check for findings
+        working-directory: ./tests
+        env:
+          USE_K8S: false
+        run: |
+          poetry install
+          poetry run pytest -k "cspm_gcp" --alluredir=./allure/results/ --clean-alluredir --maxfail=4
+
+      - name: Destory EC deployment
+        # if: steps.deploy_ec.outcome == 'success'
+        if: always()
+        working-directory: ${{ env.TEST_ENVS_DIR }}
+        run: |
+          terraform destroy --auto-approve -target="module.ec_deployment" -target="module.ec_project"
+
+      - name: Delete GCP Deployments
+        # if: steps.gcp_deploy.outcome == 'success'
+        if: always()
+        working-directory: ${{ env.TEST_ENVS_DIR }}
+        run: |
+          PROJECT_NAME=$(gcloud config get-value core/project)
+          PROJECT_NUMBER=$(gcloud projects list --filter="${PROJECT_NAME}" --format="value(PROJECT_NUMBER)")
+          ./delete_gcp_env.sh $PROJECT_NAME $PROJECT_NUMBER ${{env.GCP_SA_DEPLOYMENT_NAME}} ${{env.GCP_AGENT_DEPLOYMENT_NAME}}

--- a/deploy/deployment-manager/common.sh
+++ b/deploy/deployment-manager/common.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+configure_scope() {
+    if [ -n "$ORG_ID" ]; then
+        SCOPE="organizations"
+        PARENT_ID="$ORG_ID"
+        ROLE="roles/resourcemanager.organizationAdmin"
+    fi
+
+    # If ORG_ID is not set, SCOPE defaults to "projects" and PARENT_ID defaults to PROJECT_NAME
+    SCOPE=${SCOPE:-"projects"}
+    PARENT_ID=${PARENT_ID:-"$PROJECT_NAME"}
+}
+
+# Function to check if a role is assigned to the service account
+is_role_not_assigned() {
+    local role_assigned
+    role_assigned=$(gcloud ${SCOPE} get-iam-policy "${PARENT_ID}" \
+        --flatten="bindings[].members" --format="value(bindings.members)" \
+        --filter="bindings.role=${ROLE}" \
+        --format="table[no-heading](bindings.members)" |
+        grep "${PROJECT_NUMBER}@cloudservices.gserviceaccount.com")
+
+    if [ -n "${role_assigned}" ]; then
+        return 1 # Role is assigned
+    else
+        return 0 # Role is not assigned
+    fi
+}

--- a/deploy/deployment-manager/common.sh
+++ b/deploy/deployment-manager/common.sh
@@ -16,7 +16,7 @@ configure_scope() {
 # Function to check if a role is assigned to the service account
 is_role_not_assigned() {
     local role_assigned
-    role_assigned=$(gcloud ${SCOPE} get-iam-policy "${PARENT_ID}" \
+    role_assigned=$(gcloud "${SCOPE}" get-iam-policy "${PARENT_ID}" \
         --flatten="bindings[].members" --format="value(bindings.members)" \
         --filter="bindings.role=${ROLE}" \
         --format="table[no-heading](bindings.members)" |

--- a/deploy/deployment-manager/compute_engine.py
+++ b/deploy/deployment-manager/compute_engine.py
@@ -51,7 +51,6 @@ def generate_config(context):
             ),
             "serviceAccounts": [
                 {
-                    # "email": f"$(ref.{sa_name}.email)",
                     "email": get_service_account_email(sa_name, project),
                     "scopes": [
                         "https://www.googleapis.com/auth/cloud-platform",
@@ -79,7 +78,6 @@ def generate_config(context):
                 },
             ],
             "metadata": {
-                # "dependsOn": [sa_name],
                 "items": [
                     {
                         "key": "startup-script",
@@ -175,7 +173,6 @@ def get_service_account(sa_name, deployment_name, roles, scope, parent_id, proje
                 "properties": {
                     "resource": get_resource_name(scope, parent_id),
                     "role": role,
-                    # "member": f"serviceAccount:$(ref.{sa_name}.email)",
                     "member": f"serviceAccount:{get_service_account_email(sa_name, project_id)}",
                 },
                 "metadata": {

--- a/deploy/deployment-manager/compute_engine.py
+++ b/deploy/deployment-manager/compute_engine.py
@@ -14,10 +14,9 @@ def generate_config(context):
     artifact_server = context.properties["elasticArtifactServer"]
     scope = context.properties["scope"]
     parent_id = context.properties["parentId"]
-
     roles = ["roles/cloudasset.viewer", "roles/browser"]
     network_name = f"{deployment_name}-network"
-    sa_name = f"{deployment_name}-sa"
+    sa_name = context.properties["serviceAccountName"] or f"{deployment_name}-sa"
 
     ssh_fw_rule = {
         "name": "elastic-agent-firewall-rule",
@@ -52,7 +51,8 @@ def generate_config(context):
             ),
             "serviceAccounts": [
                 {
-                    "email": f"$(ref.{sa_name}.email)",
+                    # "email": f"$(ref.{sa_name}.email)",
+                    "email": get_service_account_email(sa_name, project),
                     "scopes": [
                         "https://www.googleapis.com/auth/cloud-platform",
                         "https://www.googleapis.com/auth/cloudplatformorganizations",
@@ -79,7 +79,7 @@ def generate_config(context):
                 },
             ],
             "metadata": {
-                "dependsOn": [sa_name],
+                # "dependsOn": [sa_name],
                 "items": [
                     {
                         "key": "startup-script",
@@ -115,16 +115,6 @@ def generate_config(context):
         },
     }
 
-    service_account = {
-        "name": sa_name,
-        "type": "iam.v1.serviceAccount",
-        "properties": {
-            "accountId": sa_name,
-            "displayName": "Elastic agent service account for CSPM",
-            "projectId": context.env["project"],
-        },
-    }
-
     network = {
         "name": network_name,
         "type": "compute.v1.network",
@@ -136,25 +126,20 @@ def generate_config(context):
         },
     }
 
-    bindings = []
-    for role in roles:
-        bindings.append(
-            {
-                "name": f"{deployment_name}-iam-binding-{role}",
-                "type": f"gcp-types/cloudresourcemanager-v1:virtual.{scope}.iamMemberBinding",
-                "properties": {
-                    "resource": get_resource_name(scope, parent_id),
-                    "role": role,
-                    "member": f"serviceAccount:$(ref.{sa_name}.email)",
-                },
-                "metadata": {
-                    "dependsOn": [sa_name],
-                },
-            },
+    resources = [instance, network]
+    # Create service account if not provided
+    if not context.properties["serviceAccountName"]:
+        instance["properties"]["metadata"]["dependsOn"] = [sa_name]
+        service_account, bindings = get_service_account(
+            sa_name,
+            deployment_name,
+            roles,
+            scope,
+            parent_id,
+            project,
         )
-
-    resources = [instance, service_account, network]
-    resources.extend(bindings)
+        resources.append(service_account)
+        resources.extend(bindings)
 
     if context.properties["allowSSH"]:
         resources.append(ssh_fw_rule)
@@ -167,3 +152,40 @@ def get_resource_name(scope, parent_id):
     if scope == "organizations":
         return f"{scope}/{parent_id}"
     return parent_id
+
+
+def get_service_account(sa_name, deployment_name, roles, scope, parent_id, project_id):
+    """return the service account and its bindings."""
+    service_account = {
+        "name": sa_name,
+        "type": "iam.v1.serviceAccount",
+        "properties": {
+            "accountId": sa_name,
+            "displayName": "Elastic agent service account for CSPM",
+            "projectId": project_id,
+        },
+    }
+
+    bindings = []
+    for role in roles:
+        bindings.append(
+            {
+                "name": f"{deployment_name}-iam-binding-{role}",
+                "type": f"gcp-types/cloudresourcemanager-v1:virtual.{scope}.iamMemberBinding",
+                "properties": {
+                    "resource": get_resource_name(scope, parent_id),
+                    "role": role,
+                    # "member": f"serviceAccount:$(ref.{sa_name}.email)",
+                    "member": f"serviceAccount:{get_service_account_email(sa_name, project_id)}",
+                },
+                "metadata": {
+                    "dependsOn": [sa_name],
+                },
+            },
+        )
+    return (service_account, bindings)
+
+
+def get_service_account_email(sa_name, project_id):
+    """return the service account email."""
+    return f"{sa_name}@{project_id}.iam.gserviceaccount.com"

--- a/deploy/deployment-manager/compute_engine.py.schema
+++ b/deploy/deployment-manager/compute_engine.py.schema
@@ -35,3 +35,9 @@ properties:
     type: boolean
     description: Allow SSH access to the instance
     metadata: allow-ssh
+
+  serviceAccountName:
+    oneOf:
+      - type: string
+      - type: boolean
+    description: Use an existing service account for the agent

--- a/deploy/deployment-manager/deploy.sh
+++ b/deploy/deployment-manager/deploy.sh
@@ -38,6 +38,7 @@ ROLE="roles/resourcemanager.projectIamAdmin"
 ELASTIC_ARTIFACT_SERVER=${ELASTIC_ARTIFACT_SERVER%/} # Remove trailing slash if present
 ELASTIC_ARTIFACT_SERVER=${ELASTIC_ARTIFACT_SERVER:-https://artifacts.elastic.co/downloads/beats/elastic-agent}
 DEPLOYMENT_LABELS=${DEPLOYMENT_LABELS:-type=cspm-gcp}
+SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-false}
 
 # Set environment variables with the name and number of your project.
 export PROJECT_NAME=$(gcloud config get-value core/project)
@@ -115,7 +116,7 @@ fi
 # Apply the deployment manager templates
 run_command "gcloud deployment-manager deployments create --automatic-rollback-on-error ${DEPLOYMENT_NAME} --project ${PROJECT_NAME} \
     --template compute_engine.py \
-    --properties elasticAgentVersion:${STACK_VERSION},fleetUrl:${FLEET_URL},enrollmentToken:${ENROLLMENT_TOKEN},allowSSH:${ALLOW_SSH},zone:${ZONE},elasticArtifactServer:${ELASTIC_ARTIFACT_SERVER},scope:${SCOPE},parentId:${PARENT_ID}"
+    --properties elasticAgentVersion:${STACK_VERSION},fleetUrl:${FLEET_URL},enrollmentToken:${ENROLLMENT_TOKEN},allowSSH:${ALLOW_SSH},zone:${ZONE},elasticArtifactServer:${ELASTIC_ARTIFACT_SERVER},scope:${SCOPE},parentId:${PARENT_ID},serviceAccountName:${SERVICE_ACCOUNT_NAME}"
 
 ## Remove the role required to deploy the DM templates
 if [ "$ADD_ROLE" = "true" ]; then

--- a/deploy/deployment-manager/deploy.sh
+++ b/deploy/deployment-manager/deploy.sh
@@ -44,6 +44,8 @@ SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-false}
 export PROJECT_NAME=$(gcloud config get-value core/project)
 export PROJECT_NUMBER=$(gcloud projects list --filter=${PROJECT_NAME} --format="value(PROJECT_NUMBER)")
 
+source ./common.sh
+
 # Function to check if an environment variable is not provided
 check_env_not_provided() {
     local var_name="$1"
@@ -61,34 +63,6 @@ run_command() {
     if [ $status -ne 0 ]; then
         echo "Error: Command \"$1\" failed with exit code $status. Exiting..."
         exit $status
-    fi
-}
-
-configure_scope() {
-    if [ -n "$ORG_ID" ]; then
-        SCOPE="organizations"
-        PARENT_ID="$ORG_ID"
-        ROLE="roles/resourcemanager.organizationAdmin"
-    fi
-
-    # If ORG_ID is not set, SCOPE defaults to "projects" and PARENT_ID defaults to PROJECT_NAME
-    SCOPE=${SCOPE:-"projects"}
-    PARENT_ID=${PARENT_ID:-"$PROJECT_NAME"}
-}
-
-# Function to check if a role is assigned to the service account
-is_role_not_assigned() {
-    local role_assigned
-    role_assigned=$(gcloud ${SCOPE} get-iam-policy "${PARENT_ID}" \
-        --flatten="bindings[].members" --format="value(bindings.members)" \
-        --filter="bindings.role=${ROLE}" \
-        --format="table[no-heading](bindings.members)" |
-        grep "${PROJECT_NUMBER}@cloudservices.gserviceaccount.com")
-
-    if [ -n "${role_assigned}" ]; then
-        return 1 # Role is assigned
-    else
-        return 0 # Role is not assigned
     fi
 }
 

--- a/deploy/deployment-manager/deploy_service_account.sh
+++ b/deploy/deployment-manager/deploy_service_account.sh
@@ -13,40 +13,12 @@ PROJECT_NAME="$(gcloud config get-value core/project)"
 PROJECT_NUMBER="$(gcloud projects list --filter="${PROJECT_NAME}" --format="value(PROJECT_NUMBER)")"
 ROLE="roles/resourcemanager.projectIamAdmin"
 
-echo "DEPLOYMENT_NAME - $DEPLOYMENT_NAME"
-echo "SERVICE_ACCOUNT_NAME - $SERVICE_ACCOUNT_NAME"
-
 export PROJECT_NAME
 export PROJECT_NUMBER
 
-configure_scope() {
-    if [ -n "$ORG_ID" ]; then
-        SCOPE="organizations"
-        PARENT_ID="$ORG_ID"
-        ROLE="roles/resourcemanager.organizationAdmin"
-    fi
-
-    # If ORG_ID is not set, SCOPE defaults to "projects" and PARENT_ID defaults to PROJECT_NAME
-    SCOPE=${SCOPE:-"projects"}
-    PARENT_ID=${PARENT_ID:-"$PROJECT_NAME"}
-}
+source ./common.sh
 
 configure_scope
-
-is_role_not_assigned() {
-    local role_assigned
-    role_assigned=$(gcloud "${SCOPE}" get-iam-policy "${PARENT_ID}" \
-        --flatten="bindings[].members" --format="value(bindings.members)" \
-        --filter="bindings.role=${ROLE}" \
-        --format="table[no-heading](bindings.members)" |
-        grep "${PROJECT_NUMBER}@cloudservices.gserviceaccount.com")
-
-    if [ -n "${role_assigned}" ]; then
-        return 1 # Role is assigned
-    else
-        return 0 # Role is not assigned
-    fi
-}
 
 # Enable the Google Cloud APIs needed for misconfiguration scanning
 gcloud services enable \

--- a/deploy/deployment-manager/deploy_service_account.sh
+++ b/deploy/deployment-manager/deploy_service_account.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# set -oe pipefail
 set -e
 
 # this script:

--- a/deploy/deployment-manager/deploy_service_account.sh
+++ b/deploy/deployment-manager/deploy_service_account.sh
@@ -58,5 +58,5 @@ gcloud deployment-manager deployments describe "${DEPLOYMENT_NAME}" --format='ta
 
 echo "$key" | base64 -d >KEY_FILE.json
 
-echo -e "\n${GREEN}Run 'cat KEY_FILE.json' to view the service account key. Copy and paste it in the CIS GCP integration."
+echo -e "\n${GREEN}Run 'cat KEY_FILE.json' to view the service account key. Copy and paste it in the CSPM GCP integration."
 echo -e "\nYou should also save the key in a secure location for future use.${RESET}"

--- a/deploy/deployment-manager/deploy_service_account.sh
+++ b/deploy/deployment-manager/deploy_service_account.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# set -oe pipefail
+set -e
+
+# this script:
+# 1. enables necessary APIs for CSPM GCP integration
+# 2. applies a Deployment Manager template to create a service account with role and a key
+# 3. saves generated key to a file (KEY_FILE.json) and prompts the user to copy-paste it to the GCP integration
+# 4. handles deployment failure cleanup
+
+DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-elastic-agent-cspm-user}
+SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-elastic-agent-cspm-user-sa}
+PROJECT_NAME="$(gcloud config get-value core/project)"
+PROJECT_NUMBER="$(gcloud projects list --filter="${PROJECT_NAME}" --format="value(PROJECT_NUMBER)")"
+ROLE="roles/resourcemanager.projectIamAdmin"
+
+echo "DEPLOYMENT_NAME - $DEPLOYMENT_NAME"
+echo "SERVICE_ACCOUNT_NAME - $SERVICE_ACCOUNT_NAME"
+
+export PROJECT_NAME
+export PROJECT_NUMBER
+
+configure_scope() {
+    if [ -n "$ORG_ID" ]; then
+        SCOPE="organizations"
+        PARENT_ID="$ORG_ID"
+        ROLE="roles/resourcemanager.organizationAdmin"
+    fi
+
+    # If ORG_ID is not set, SCOPE defaults to "projects" and PARENT_ID defaults to PROJECT_NAME
+    SCOPE=${SCOPE:-"projects"}
+    PARENT_ID=${PARENT_ID:-"$PROJECT_NAME"}
+}
+
+configure_scope
+
+is_role_not_assigned() {
+    local role_assigned
+    role_assigned=$(gcloud "${SCOPE}" get-iam-policy "${PARENT_ID}" \
+        --flatten="bindings[].members" --format="value(bindings.members)" \
+        --filter="bindings.role=${ROLE}" \
+        --format="table[no-heading](bindings.members)" |
+        grep "${PROJECT_NUMBER}@cloudservices.gserviceaccount.com")
+
+    if [ -n "${role_assigned}" ]; then
+        return 1 # Role is assigned
+    else
+        return 0 # Role is not assigned
+    fi
+}
+
+# Enable the Google Cloud APIs needed for misconfiguration scanning
+gcloud services enable \
+    iam.googleapis.com \
+    deploymentmanager.googleapis.com \
+    cloudresourcemanager.googleapis.com \
+    cloudasset.googleapis.com
+
+ADD_ROLE=false
+if is_role_not_assigned; then
+    gcloud "${SCOPE}" add-iam-policy-binding "${PARENT_ID}" --member="serviceAccount:${PROJECT_NUMBER}@cloudservices.gserviceaccount.com" --role="${ROLE}"
+    ADD_ROLE=true
+fi
+
+result="$(gcloud deployment-manager deployments create --automatic-rollback-on-error "${DEPLOYMENT_NAME}" --project "${PROJECT_NAME}" \
+    --template service_account.py \
+    --properties scope:"${SCOPE}",parentId:"${PARENT_ID}",serviceAccountName:"${SERVICE_ACCOUNT_NAME}")"
+
+key="$(echo "$result" | grep -o 'serviceAccountKey .*' | awk '{print $2}')"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+if [ -z "$key" ]; then
+    echo "${RED}Error: Failed to deploy a service account. Exiting...${RESET}"
+    exit 1
+fi
+
+if [ "$ADD_ROLE" = "true" ]; then
+    gcloud "${SCOPE}" remove-iam-policy-binding "${PARENT_ID}" --member=serviceAccount:"${PROJECT_NUMBER}"@cloudservices.gserviceaccount.com --role="${ROLE}"
+fi
+
+echo -e "\n${GREEN}Deployment complete.${RESET}\n"
+
+gcloud deployment-manager deployments describe "${DEPLOYMENT_NAME}" --format='table(resources)'
+
+echo "$key" | base64 -d >KEY_FILE.json
+
+echo -e "\n${GREEN}Run 'cat KEY_FILE.json' to view the service account key. Copy and paste it in the CIS GCP integration."
+echo -e "\nYou should also save the key in a secure location for future use.${RESET}"

--- a/deploy/deployment-manager/service_account.py
+++ b/deploy/deployment-manager/service_account.py
@@ -1,0 +1,65 @@
+"""A template file for deploying a service account"""
+
+
+def generate_config(context):
+    """Generates service account user"""
+    deployment_name = context.env["deployment"]
+    scope = context.properties["scope"]
+    parent_id = context.properties["parentId"]
+    sa_name = context.properties["serviceAccountName"]
+    roles = ["roles/cloudasset.viewer", "roles/browser"]
+
+    # pylint: disable=duplicate-code
+    service_account = {
+        "name": sa_name,
+        "type": "iam.v1.serviceAccount",
+        "properties": {
+            "accountId": sa_name,
+            "displayName": "Elastic agent service account for CSPM",
+            "projectId": context.env["project"],
+        },
+    }
+
+    service_account_key = {
+        "name": f"{deployment_name}-sa-key",
+        "type": "iam.v1.serviceAccounts.key",
+        "metadata": {
+            "dependsOn": [sa_name],
+        },
+        "properties": {
+            "parent": f"$(ref.{sa_name}.name)",
+        },
+    }
+
+    # pylint: disable=duplicate-code
+    bindings = []
+    for role in roles:
+        bindings.append(
+            {
+                "name": f"{deployment_name}-iam-binding-{role}",
+                "type": f"gcp-types/cloudresourcemanager-v1:virtual.{scope}.iamMemberBinding",
+                "properties": {
+                    "resource": get_resource_name(scope, parent_id),
+                    "role": role,
+                    "member": f"serviceAccount:$(ref.{sa_name}.email)",
+                },
+                "metadata": {
+                    "dependsOn": [sa_name],
+                },
+            },
+        )
+
+    resources = [service_account, service_account_key]
+    resources.extend(bindings)
+
+    return {
+        "outputs": [{"name": "serviceAccountKey", "value": f"$(ref.{deployment_name}-sa-key.privateKeyData)"}],
+        "resources": resources,
+    }
+
+
+def get_resource_name(scope, parent_id):
+    """return the resource name based on the scope."""
+    if scope == "organizations":
+        return f"{scope}/{parent_id}"
+    return parent_id

--- a/deploy/deployment-manager/service_account.py.schema
+++ b/deploy/deployment-manager/service_account.py.schema
@@ -1,0 +1,20 @@
+info:
+  title: service account user json credentials
+  description: service account user json credentials
+  version: 1.0.0
+
+properties:
+  scope:
+    type: string
+    description: organizations or projects scope
+
+  parentId:
+    type: string
+    description: organization id or project id
+
+  serviceAccountName:
+    type: string
+    description: Name of service account to deploy
+
+outputs:
+  serviceAccountKey:

--- a/deploy/test-environments/delete_gcp_env.sh
+++ b/deploy/test-environments/delete_gcp_env.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [ "$#" -lt 3 ]; then
-    echo "Missing params. Usage: $0 PROJECT_NAME PROJECT_NUMBER DEPLOYMENT1,DEPLOYMENT2,..."
+    echo "Missing params. Usage: $0 PROJECT_NAME PROJECT_NUMBER DEPLOYMENT1 DEPLOYMENT2,..."
     exit 1
 fi
 

--- a/tests/fleet_api/utils.py
+++ b/tests/fleet_api/utils.py
@@ -21,20 +21,18 @@ from pathlib import Path
 import ruamel.yaml
 from jinja2 import Template
 from loguru import logger
+import sys
 
 
 def read_json(json_path: Path) -> dict:
     """
-    Read JSON data from a file.
+    Read JSON data from a file. Exits if the file is not found or an error occurs while reading the file.
 
     Args:
         json_path (Path): Path to the JSON file.
 
     Returns:
         dict: Dictionary containing the JSON data.
-
-    Raises:
-        FileNotFoundError: If the specified JSON file does not exist.
     """
 
     try:
@@ -42,7 +40,10 @@ def read_json(json_path: Path) -> dict:
             return json.load(json_file)
     except FileNotFoundError:
         logger.error(f"{json_path.name} file not found.")
-        return {}
+        sys.exit(1)
+    except json.JSONDecodeError as ex:
+        logger.error(f"Error reading file {json_path}: {ex}")
+        sys.exit(1)
 
 
 def delete_file(file_path: Path):

--- a/tests/fleet_api/utils.py
+++ b/tests/fleet_api/utils.py
@@ -16,12 +16,13 @@ Import this module to utilize the provided functions for JSON file operations an
 """
 
 import json
-from typing import Union
+import sys
 from pathlib import Path
+from typing import Union
+
 import ruamel.yaml
 from jinja2 import Template
 from loguru import logger
-import sys
 
 
 def read_json(json_path: Path) -> dict:

--- a/tests/integrations_setup/configuration_fleet.py
+++ b/tests/integrations_setup/configuration_fleet.py
@@ -50,6 +50,7 @@ gcp_dm_config.deployment_name = os.getenv("DEPLOYMENT_NAME", "")
 gcp_dm_config.zone = os.getenv("ZONE", "us-central1-a")
 gcp_dm_config.allow_ssh = os.getenv("ALLOW_SSH", "false") == "true"
 gcp_dm_config.credentials_file = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+gcp_dm_config.service_account_json_path = os.getenv("SERVICE_ACCOUNT_JSON_PATH", "")
 
 # Used for Azure deployment on stack 8.11.* (1.6.* package version)
 azure_arm_parameters = Munch()

--- a/tests/integrations_setup/install_cspm_gcp_integration.py
+++ b/tests/integrations_setup/install_cspm_gcp_integration.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from munch import Munch
 from packaging import version
 import configuration_fleet as cnfg
+from fleet_api.utils import read_json
 from fleet_api.agent_policy_api import create_agent_policy
 from fleet_api.package_policy_api import create_cspm_integration
 from fleet_api.common_api import (
@@ -30,7 +31,6 @@ from package_policy import (
     generate_random_name,
     VERSION_MAP,
 )
-from tests.fleet_api.utils import read_json
 
 CSPM_GCP_EXPECTED_AGENTS = 1
 DEPLOYMENT_MANAGER_CONFIG = "../../deploy/deployment-manager/config.json"

--- a/tests/integrations_setup/install_cspm_gcp_integration.py
+++ b/tests/integrations_setup/install_cspm_gcp_integration.py
@@ -52,11 +52,11 @@ def read_json_file(file_path):
     """Reads a json file and returns its content"""
     try:
         with open(file_path, "r") as json_file:
-            return json_file.read()
+            return json.load(json_file)
     except FileNotFoundError:
         logger.error(f"Error: File '{file_path}' not found.")
         sys.exit(1)
-    except IOError as e:
+    except json.JSONDecodeError as e:
         logger.error(f"Error reading file '{file_path}': {e}")
         sys.exit(1)
 

--- a/tests/integrations_setup/install_cspm_gcp_integration.py
+++ b/tests/integrations_setup/install_cspm_gcp_integration.py
@@ -48,7 +48,6 @@ AGENT_INPUT = {
     "name": generate_random_name("cspm-gcp"),
 }
 
-
 if __name__ == "__main__":
     # pylint: disable=duplicate-code
     package_version = get_package_version(cfg=cnfg.elk_config)
@@ -73,7 +72,7 @@ if __name__ == "__main__":
             logger.info("Using service account credentials json")
             json_path = Path(__file__).parent / cnfg.gcp_dm_config.service_account_json_path
             service_account_json = read_json(json_path)
-            INTEGRATION_INPUT["vars"]["gcp.credentials.json"] = service_account_json
+            INTEGRATION_INPUT["vars"]["gcp.credentials.json"] = json.dumps(service_account_json)
 
     logger.info(f"Starting installation of {INTEGRATION_NAME} integration.")
     agent_data, package_data = load_data(

--- a/tests/integrations_setup/install_cspm_gcp_integration.py
+++ b/tests/integrations_setup/install_cspm_gcp_integration.py
@@ -48,7 +48,7 @@ AGENT_INPUT = {
 }
 
 
-def read_json_file(file_path):
+def read_json_file(file_path: Path):
     """Reads a json file and returns its content"""
     try:
         with open(file_path, "r") as json_file:
@@ -83,7 +83,7 @@ if __name__ == "__main__":
         }
         if cnfg.gcp_dm_config.service_account_json_path:
             logger.info("Using service account credentials json")
-            service_account_json = read_json_file(cnfg.gcp_dm_config.service_account_json_path)
+            service_account_json = read_json_file(Path(cnfg.gcp_dm_config.service_account_json_path))
             INTEGRATION_INPUT["vars"]["gcp.credentials.json"] = service_account_json
 
     logger.info(f"Starting installation of {INTEGRATION_NAME} integration.")

--- a/tests/integrations_setup/install_cspm_gcp_integration.py
+++ b/tests/integrations_setup/install_cspm_gcp_integration.py
@@ -48,6 +48,19 @@ AGENT_INPUT = {
 }
 
 
+def read_json_file(file_path):
+    """Reads a json file and returns its content"""
+    try:
+        with open(file_path, "r") as json_file:
+            return json_file.read()
+    except FileNotFoundError:
+        logger.error(f"Error: File '{file_path}' not found.")
+        sys.exit(1)
+    except IOError as e:
+        logger.error(f"Error reading file '{file_path}': {e}")
+        sys.exit(1)
+
+
 if __name__ == "__main__":
     # pylint: disable=duplicate-code
     package_version = get_package_version(cfg=cnfg.elk_config)
@@ -68,6 +81,11 @@ if __name__ == "__main__":
         INTEGRATION_INPUT["vars"] = {
             "gcp.account_type": "single-account",
         }
+        if cnfg.gcp_dm_config.service_account_json_path:
+            logger.info("Using service account credentials json")
+            service_account_json = read_json_file(cnfg.gcp_dm_config.service_account_json_path)
+            INTEGRATION_INPUT["vars"]["gcp.credentials.json"] = service_account_json
+
     logger.info(f"Starting installation of {INTEGRATION_NAME} integration.")
     agent_data, package_data = load_data(
         cfg=cnfg.elk_config,

--- a/tests/integrations_setup/install_cspm_gcp_integration.py
+++ b/tests/integrations_setup/install_cspm_gcp_integration.py
@@ -30,6 +30,7 @@ from package_policy import (
     generate_random_name,
     VERSION_MAP,
 )
+from tests.fleet_api.utils import read_json
 
 CSPM_GCP_EXPECTED_AGENTS = 1
 DEPLOYMENT_MANAGER_CONFIG = "../../deploy/deployment-manager/config.json"
@@ -46,19 +47,6 @@ INTEGRATION_INPUT = {
 AGENT_INPUT = {
     "name": generate_random_name("cspm-gcp"),
 }
-
-
-def read_json_file(file_path):
-    """Reads a json file and returns its content"""
-    try:
-        with open(file_path, "r") as json_file:
-            return json_file.read()
-    except FileNotFoundError:
-        logger.error(f"Error: File '{file_path}' not found.")
-        sys.exit(1)
-    except IOError as e:
-        logger.error(f"Error reading file '{file_path}': {e}")
-        sys.exit(1)
 
 
 if __name__ == "__main__":
@@ -83,7 +71,8 @@ if __name__ == "__main__":
         }
         if cnfg.gcp_dm_config.service_account_json_path:
             logger.info("Using service account credentials json")
-            service_account_json = read_json_file(cnfg.gcp_dm_config.service_account_json_path)
+            json_path = Path(__file__).parent / cnfg.gcp_dm_config.service_account_json_path
+            service_account_json = read_json(json_path)
             INTEGRATION_INPUT["vars"]["gcp.credentials.json"] = service_account_json
 
     logger.info(f"Starting installation of {INTEGRATION_NAME} integration.")

--- a/tests/integrations_setup/install_cspm_gcp_integration.py
+++ b/tests/integrations_setup/install_cspm_gcp_integration.py
@@ -48,15 +48,15 @@ AGENT_INPUT = {
 }
 
 
-def read_json_file(file_path: Path):
+def read_json_file(file_path):
     """Reads a json file and returns its content"""
     try:
         with open(file_path, "r") as json_file:
-            return json.load(json_file)
+            return json_file.read()
     except FileNotFoundError:
         logger.error(f"Error: File '{file_path}' not found.")
         sys.exit(1)
-    except json.JSONDecodeError as e:
+    except IOError as e:
         logger.error(f"Error reading file '{file_path}': {e}")
         sys.exit(1)
 
@@ -83,7 +83,7 @@ if __name__ == "__main__":
         }
         if cnfg.gcp_dm_config.service_account_json_path:
             logger.info("Using service account credentials json")
-            service_account_json = read_json_file(Path(cnfg.gcp_dm_config.service_account_json_path))
+            service_account_json = read_json_file(cnfg.gcp_dm_config.service_account_json_path)
             INTEGRATION_INPUT["vars"]["gcp.credentials.json"] = service_account_json
 
     logger.info(f"Starting installation of {INTEGRATION_NAME} integration.")


### PR DESCRIPTION
- [x] adds a Deployment Manager template to deploy a new service account and key
- [x] adds a CI test to verify deployment of service account is useable

- this is how a successful deployment looks from a user POV after they ran the service account deployment script in a GCP shell:
![Screenshot 2024-04-15 at 18 25 05](https://github.com/elastic/cloudbeat/assets/20814186/d1920407-f99e-4b1e-a4da-19076dcea42b)


- tested we get findings using the generated key by providing it as a JSON blob credentials option on the manual deployment option:
![Screenshot 2024-05-08 at 15 09 18](https://github.com/elastic/cloudbeat/assets/20814186/e7914188-6e39-4ef8-ba5d-4d6a20f8017a)


- closes https://github.com/elastic/cloudbeat/issues/2005