### PR TITLE
Add correct user info for select IAM resources

### DIFF
--- a/internal/resources/fetching/fetchers/aws/iam_fetcher.go
+++ b/internal/resources/fetching/fetchers/aws/iam_fetcher.go
@@ -131,7 +131,22 @@ func (r IAMResource) GetMetadata() (fetching.ResourceMetadata, error) {
 }
 
 func (r IAMResource) GetElasticCommonData() (map[string]any, error) {
-	return map[string]any{
+	m := map[string]any{
 		"cloud.service.name": "IAM",
-	}, nil
+	}
+
+	switch r.AwsResource.GetResourceType() {
+	case fetching.IAMUserType:
+		{
+			m["user.id"] = r.GetResourceArn()
+			m["user.name"] = r.GetResourceName()
+		}
+	case fetching.PolicyType:
+		{
+			m["user.effective.id"] = r.GetResourceArn()
+			m["user.effective.name"] = r.GetResourceName()
+		}
+	}
+
+	return m, nil
 }

--- a/internal/resources/fetching/fetchers/aws/iam_fetcher_test.go
+++ b/internal/resources/fetching/fetchers/aws/iam_fetcher_test.go
@@ -367,7 +367,12 @@ func (s *IamFetcherTestSuite) TestIamResource_GetMetadata() {
 
 			m, err := iamResource.GetElasticCommonData()
 			s.Require().NoError(err)
-			s.Len(m, 1)
+			switch iamResource.GetResourceType() {
+			case fetching.IAMUserType, fetching.PolicyType:
+				s.Len(m, 3)
+			default:
+				s.Len(m, 1)
+			}
 			s.Contains(m, "cloud.service.name")
 		})
 	}

--- a/internal/resources/fetching/fetchers/azure/assets_fetcher.go
+++ b/internal/resources/fetching/fetchers/azure/assets_fetcher.go
@@ -201,7 +201,7 @@ func (r *AzureResource) GetElasticCommonData() (map[string]any, error) {
 			}
 			m["host.hostname"] = computerName
 		}
-	case fetching.AzureRoleDefinitionType:
+	case inventory.RoleDefinitionsType:
 		{
 			m["user.effective.id"] = r.Asset.Id
 			m["user.effective.name"] = r.Asset.Name

--- a/internal/resources/fetching/fetchers/azure/assets_fetcher.go
+++ b/internal/resources/fetching/fetchers/azure/assets_fetcher.go
@@ -175,30 +175,38 @@ func (r *AzureResource) GetMetadata() (fetching.ResourceMetadata, error) {
 }
 
 func (r *AzureResource) GetElasticCommonData() (map[string]any, error) {
-	if r.Asset.Type == inventory.VirtualMachineAssetType {
-		m := map[string]any{
-			"host.name": r.Asset.Name,
-		}
+	m := map[string]any{}
 
-		// "host.hostname" = "properties.osProfile.computerName" if it exists
-		osProfileRaw, ok := r.Asset.Properties["osProfile"]
-		if !ok {
-			return m, nil
+	switch r.Asset.Type {
+	case inventory.VirtualMachineAssetType:
+		{
+			m["host.name"] = r.Asset.Name
+
+			// "host.hostname" = "properties.osProfile.computerName" if it exists
+			osProfileRaw, ok := r.Asset.Properties["osProfile"]
+			if !ok {
+				break
+			}
+			osProfile, ok := osProfileRaw.(map[string]any)
+			if !ok {
+				break
+			}
+			computerNameRaw, ok := osProfile["computerName"]
+			if !ok {
+				break
+			}
+			computerName, ok := computerNameRaw.(string)
+			if !ok {
+				break
+			}
+			m["host.hostname"] = computerName
 		}
-		osProfile, ok := osProfileRaw.(map[string]any)
-		if !ok {
-			return m, nil
+	case fetching.AzureRoleDefinitionType:
+		{
+			m["user.effective.id"] = r.Asset.Id
+			m["user.effective.name"] = r.Asset.Name
 		}
-		computerNameRaw, ok := osProfile["computerName"]
-		if !ok {
-			return m, nil
-		}
-		computerName, ok := computerNameRaw.(string)
-		if !ok {
-			return m, nil
-		}
-		m["host.hostname"] = computerName
-		return m, nil
 	}
-	return nil, nil
+
+	return m, nil
 }

--- a/internal/resources/fetching/fetchers/azure/assets_fetcher_test.go
+++ b/internal/resources/fetching/fetchers/azure/assets_fetcher_test.go
@@ -220,9 +220,19 @@ func (s *AzureAssetsFetcherTestSuite) TestFetcher_Fetch() {
 
 			ecs, err := result.GetElasticCommonData()
 			s.Require().NoError(err)
-			if expected.Type == inventory.VirtualMachineAssetType {
-				s.Contains(ecs, "host.name")
-			} else {
+			switch expected.Type {
+			case inventory.VirtualMachineAssetType:
+				{
+					s.GreaterOrEqual(len(ecs), 1)
+					s.Contains(ecs, "host.name")
+				}
+			case inventory.RoleDefinitionsType:
+				{
+					s.Len(ecs, 2)
+					s.Contains(ecs, "user.effective.id")
+					s.Contains(ecs, "user.effective.name")
+				}
+			default:
 				s.Empty(ecs)
 			}
 		})

--- a/internal/resources/fetching/fetchers/gcp/assets_fetcher.go
+++ b/internal/resources/fetching/fetchers/gcp/assets_fetcher.go
@@ -157,17 +157,17 @@ func (r *GcpAsset) GetElasticCommonData() (map[string]any, error) {
 	}
 
 	if r.Type == fetching.CloudCompute && r.SubType == inventory.ComputeInstanceAssetType {
-		data := r.ExtendedAsset.Resource.Data
-		if data == nil {
+		fields := getAssetDataFields(r.ExtendedAsset)
+		if fields == nil {
 			return m, nil
 		}
-		nameField, ok := data.Fields["name"]
+		nameField, ok := fields["name"]
 		if ok {
 			if name := nameField.GetStringValue(); name != "" {
 				m["host.name"] = name
 			}
 		}
-		hostnameField, ok := data.Fields["hostname"]
+		hostnameField, ok := fields["hostname"]
 		if ok {
 			if hostname := hostnameField.GetStringValue(); hostname != "" {
 				m["host.hostname"] = hostname

--- a/internal/resources/fetching/fetchers/gcp/assets_fetcher.go
+++ b/internal/resources/fetching/fetchers/gcp/assets_fetcher.go
@@ -156,7 +156,7 @@ func (r *GcpAsset) GetElasticCommonData() (map[string]any, error) {
 		m["user.effective.name"] = getAssetResourceName(r.ExtendedAsset)
 	}
 
-	if r.Type == fetching.CloudCompute && r.SubType == inventory.ComputeInstanceAssetType {
+	if r.Type == fetching.CloudCompute && r.ExtendedAsset.AssetType == inventory.ComputeInstanceAssetType {
 		fields := getAssetDataFields(r.ExtendedAsset)
 		if fields == nil {
 			return m, nil

--- a/internal/resources/fetching/fetchers/gcp/assets_fetcher.go
+++ b/internal/resources/fetching/fetchers/gcp/assets_fetcher.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/huandu/xstrings"
-	structpb "google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/elastic/cloudbeat/internal/resources/fetching"
 	"github.com/elastic/cloudbeat/internal/resources/fetching/cycle"

--- a/internal/resources/fetching/fetchers/gcp/assets_fetcher.go
+++ b/internal/resources/fetching/fetchers/gcp/assets_fetcher.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/huandu/xstrings"
+	structpb "google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/elastic/cloudbeat/internal/resources/fetching"
 	"github.com/elastic/cloudbeat/internal/resources/fetching/cycle"
@@ -148,11 +149,17 @@ func (r *GcpAsset) GetMetadata() (fetching.ResourceMetadata, error) {
 }
 
 func (r *GcpAsset) GetElasticCommonData() (map[string]any, error) {
-	if r.Type == fetching.CloudCompute && r.ExtendedAsset.AssetType == inventory.ComputeInstanceAssetType {
-		m := map[string]any{}
+	m := map[string]any{}
+
+	if r.Type == fetching.CloudIdentity {
+		m["user.effective.id"] = r.ExtendedAsset.Name
+		m["user.effective.name"] = getAssetResourceName(r.ExtendedAsset)
+	}
+
+	if r.Type == fetching.CloudCompute && r.SubType == inventory.ComputeInstanceAssetType {
 		data := r.ExtendedAsset.Resource.Data
 		if data == nil {
-			return nil, nil
+			return m, nil
 		}
 		nameField, ok := data.Fields["name"]
 		if ok {
@@ -166,22 +173,24 @@ func (r *GcpAsset) GetElasticCommonData() (map[string]any, error) {
 				m["host.hostname"] = hostname
 			}
 		}
-		return m, nil
 	}
-	return nil, nil
+
+	return m, nil
 }
 
 // try to retrieve the resource name from the asset data fields (name or displayName), in case it is not set
 // get the last part of the asset name (https://cloud.google.com/apis/design/resource_names#resource_id)
 func getAssetResourceName(asset *inventory.ExtendedGcpAsset) string {
-	if name, exist := asset.GetResource().GetData().GetFields()["displayName"]; exist && name.GetStringValue() != "" {
-		return name.GetStringValue()
-	}
+	fields := getAssetDataFields(asset)
+	if fields != nil {
+		if name, exist := fields["displayName"]; exist && name.GetStringValue() != "" {
+			return name.GetStringValue()
+		}
 
-	if name, exist := asset.GetResource().GetData().GetFields()["name"]; exist && name.GetStringValue() != "" {
-		return name.GetStringValue()
+		if name, exist := fields["name"]; exist && name.GetStringValue() != "" {
+			return name.GetStringValue()
+		}
 	}
-
 	parts := strings.Split(asset.Name, "/")
 	return parts[len(parts)-1]
 }
@@ -194,4 +203,18 @@ func getGcpSubType(assetType string) string {
 	suffix := assetType[slashIndex+1:]
 
 	return strings.ToLower(fmt.Sprintf("gcp-%s-%s", prefix, xstrings.ToKebabCase(suffix)))
+}
+
+// getAssetDataFields tries to retrieve asset.resource.data fields if possible.
+// Returns nil otherwise.
+func getAssetDataFields(asset *inventory.ExtendedGcpAsset) map[string]*structpb.Value {
+	resource := asset.GetResource()
+	if resource == nil {
+		return nil
+	}
+	data := resource.GetData()
+	if data == nil {
+		return nil
+	}
+	return data.GetFields()
 }

--- a/internal/resources/fetching/fetchers/gcp/assets_fetcher_test.go
+++ b/internal/resources/fetching/fetchers/gcp/assets_fetcher_test.go
@@ -95,6 +95,11 @@ func (s *GcpAssetsFetcherTestSuite) TestFetcher_Fetch() {
 		s.Equal("prjId", cloudAccountMetadata.AccountId)
 		s.Equal("orgId", cloudAccountMetadata.OrganisationId)
 		s.Equal("orgName", cloudAccountMetadata.OrganizationName)
+		if metadata.Type == fetching.CloudIdentity {
+			m, err := r.GetElasticCommonData()
+			s.Require().NoError(err, "error getting Elastic Common Data")
+			s.Len(m, 2)
+		}
 	})
 }
 


### PR DESCRIPTION
`user.*` section of our findings and their ECS has been empty so far. This PR adds user details where applicable.

### Summary of your changes

##### AWS
- 1.4 - 1.7 -  enriched; root account
- 1.8, 1.9 - no change; Password Policy not tied to a single user
- 1.10 - 1.15 - enriched; regular users
- 1.16, 1.17 - Policies; enriched; making an assumption based on the [spreadhsheet](https://docs.google.com/spreadsheets/d/1p7m6c-sPn_Orgfc-jwJod9wupvF-2Qp7SDrDLle15_8/edit#gid=124010285), changing `user.effective.*`
- 1.19 - no change; AWS IAM server certificate rule
- 1.20 - no change; AWS Access Analyzer

#### Azure
- 1.23 - enriched

### GCP IAM - add user data
- 1.4, 1.7 - enriched; `idendity-management`
- 1.5, 1.6, 1.8, 1.11 - no change; one finding has a full report on all users and roles (type: `project-management`)
- 1.9, 1.10, 1.12, 1.14, 1.15 - no change; `key-management`
- 1.17 - no change; `data-processing`

### Related Issues
Related to https://github.com/elastic/cloudbeat/issues/2081

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

No
