### PR TITLE
Clean trivy cache before each cycle

### DIFF
--- a/internal/vulnerability/runner.go
+++ b/internal/vulnerability/runner.go
@@ -34,7 +34,13 @@ type VulnerabilityRunner struct {
 }
 
 func NewVulnerabilityRunner(log *logp.Logger) (VulnerabilityRunner, error) {
+	ctx := context.Background() // TODO: carry
 	log.Debug("NewVulnerabilityRunner: New")
+
+	if err := clearTrivyCache(ctx, log); err != nil {
+		log.Warnf("error during runner cache clearing %s", err.Error())
+	}
+
 	opts := flag.Options{
 		GlobalOptions: flag.GlobalOptions{
 			// TODO: Make configurable
@@ -56,7 +62,7 @@ func NewVulnerabilityRunner(log *logp.Logger) (VulnerabilityRunner, error) {
 		},
 	}
 
-	runner, err := artifact.NewRunner(context.Background(), opts)
+	runner, err := artifact.NewRunner(ctx, opts)
 	if err != nil {
 		log.Error("NewVulnerabilityRunner: NewRunner error: ", err)
 		return VulnerabilityRunner{}, err
@@ -72,7 +78,8 @@ func (f VulnerabilityRunner) GetRunner() artifact.Runner {
 	return f.runner
 }
 
-func (f VulnerabilityRunner) ClearCache(ctx context.Context) error {
+func clearTrivyCache(ctx context.Context, log *logp.Logger) error {
+	log.Info("Starting VulnerabilityRunner.ClearCache")
 	options := []flag.Options{
 		{CacheOptions: flag.CacheOptions{ClearCache: true}},
 		{DBOptions: flag.DBOptions{Reset: true}},
@@ -93,6 +100,8 @@ func (f VulnerabilityRunner) ClearCache(ctx context.Context) error {
 		// it should never go here (NewRunner should always return artifact.SkipScan), but just in case it goes, lets close the runner.
 		errs = append(errs, r.Close(ctx))
 	}
+
+	log.Infof("Ending VulnerabilityRunner.ClearCache %d", len(errs))
 
 	return errors.Join(errs...)
 }

--- a/internal/vulnerability/runner.go
+++ b/internal/vulnerability/runner.go
@@ -83,7 +83,6 @@ func clearTrivyCache(ctx context.Context, log *logp.Logger) error {
 	options := []flag.Options{
 		{CacheOptions: flag.CacheOptions{ClearCache: true}},
 		{DBOptions: flag.DBOptions{Reset: true}},
-		// {MisconfOptions: flag.MisconfOptions{ResetPolicyBundle: true}},
 	}
 
 	errs := make([]error, 0, len(options))

--- a/internal/vulnerability/runner.go
+++ b/internal/vulnerability/runner.go
@@ -19,6 +19,7 @@ package vulnerability
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/aquasecurity/trivy/pkg/commands/artifact"
@@ -69,4 +70,29 @@ func NewVulnerabilityRunner(log *logp.Logger) (VulnerabilityRunner, error) {
 
 func (f VulnerabilityRunner) GetRunner() artifact.Runner {
 	return f.runner
+}
+
+func (f VulnerabilityRunner) ClearCache(ctx context.Context) error {
+	options := []flag.Options{
+		{CacheOptions: flag.CacheOptions{ClearCache: true}},
+		{DBOptions: flag.DBOptions{Reset: true}},
+		{MisconfOptions: flag.MisconfOptions{ResetPolicyBundle: true}},
+	}
+
+	errs := make([]error, 0, len(options))
+
+	for _, opts := range options {
+		r, err := artifact.NewRunner(ctx, opts)
+		if err != nil {
+			if !errors.Is(err, artifact.SkipScan) {
+				errs = append(errs, err)
+			}
+			continue
+		}
+
+		// it should never go here (NewRunner should always return artifact.SkipScan), but just in case it goes, lets close the runner.
+		errs = append(errs, r.Close(ctx))
+	}
+
+	return errors.Join(errs...)
 }

--- a/internal/vulnerability/runner.go
+++ b/internal/vulnerability/runner.go
@@ -38,7 +38,7 @@ func NewVulnerabilityRunner(log *logp.Logger) (VulnerabilityRunner, error) {
 	log.Debug("NewVulnerabilityRunner: New")
 
 	if err := clearTrivyCache(ctx, log); err != nil {
-		log.Warnf("error during runner cache clearing %s", err.Error())
+		log.Errorf("error during runner cache clearing %s", err.Error())
 	}
 
 	opts := flag.Options{
@@ -80,27 +80,26 @@ func (f VulnerabilityRunner) GetRunner() artifact.Runner {
 
 func clearTrivyCache(ctx context.Context, log *logp.Logger) error {
 	log.Info("Starting VulnerabilityRunner.ClearCache")
-	options := []flag.Options{
-		{CacheOptions: flag.CacheOptions{ClearCache: true}},
-		{DBOptions: flag.DBOptions{Reset: true}},
-	}
+	defer log.Info("Ending VulnerabilityRunner.ClearCache")
 
-	errs := make([]error, 0, len(options))
+	// These are the three available cli settings for clean/reset translated to flag.Options object.
+	// 	{CacheOptions: flag.CacheOptions{ClearCache: true}},
+	// 	{DBOptions: flag.DBOptions{Reset: true}},
+	// 	{MisconfOptions: flag.MisconfOptions{ResetPolicyBundle: true}},
+	// In our case we will use only the ClearCache option.
 
-	for _, opts := range options {
-		r, err := artifact.NewRunner(ctx, opts)
-		if err != nil {
-			if !errors.Is(err, artifact.SkipScan) {
-				errs = append(errs, err)
-			}
-		}
-
-		// it should never go here (NewRunner should always return artifact.SkipScan and nil runner), but just in case it goes, lets close the runner.
-		if r != nil {
-			errs = append(errs, r.Close(ctx))
+	errs := make([]error, 0, 2)
+	r, err := artifact.NewRunner(ctx, flag.Options{CacheOptions: flag.CacheOptions{ClearCache: true}})
+	if err != nil {
+		if !errors.Is(err, artifact.SkipScan) {
+			errs = append(errs, err)
 		}
 	}
-	log.Infof("Ending VulnerabilityRunner.ClearCache %d", len(errs))
+
+	// it should never go here (NewRunner should always return artifact.SkipScan and nil runner), but just in case it goes, lets close the runner.
+	if r != nil {
+		errs = append(errs, r.Close(ctx))
+	}
 
 	return errors.Join(errs...)
 }

--- a/internal/vulnerability/runner.go
+++ b/internal/vulnerability/runner.go
@@ -83,7 +83,7 @@ func clearTrivyCache(ctx context.Context, log *logp.Logger) error {
 	options := []flag.Options{
 		{CacheOptions: flag.CacheOptions{ClearCache: true}},
 		{DBOptions: flag.DBOptions{Reset: true}},
-		{MisconfOptions: flag.MisconfOptions{ResetPolicyBundle: true}},
+		// {MisconfOptions: flag.MisconfOptions{ResetPolicyBundle: true}},
 	}
 
 	errs := make([]error, 0, len(options))
@@ -94,13 +94,13 @@ func clearTrivyCache(ctx context.Context, log *logp.Logger) error {
 			if !errors.Is(err, artifact.SkipScan) {
 				errs = append(errs, err)
 			}
-			continue
 		}
 
-		// it should never go here (NewRunner should always return artifact.SkipScan), but just in case it goes, lets close the runner.
-		errs = append(errs, r.Close(ctx))
+		// it should never go here (NewRunner should always return artifact.SkipScan and nil runner), but just in case it goes, lets close the runner.
+		if r != nil {
+			errs = append(errs, r.Close(ctx))
+		}
 	}
-
 	log.Infof("Ending VulnerabilityRunner.ClearCache %d", len(errs))
 
 	return errors.Join(errs...)

--- a/internal/vulnerability/runner.go
+++ b/internal/vulnerability/runner.go
@@ -34,7 +34,7 @@ type VulnerabilityRunner struct {
 }
 
 func NewVulnerabilityRunner(log *logp.Logger) (VulnerabilityRunner, error) {
-	ctx := context.Background() // TODO: carry
+	ctx := context.Background()
 	log.Debug("NewVulnerabilityRunner: New")
 
 	if err := clearTrivyCache(ctx, log); err != nil {

--- a/internal/vulnerability/worker.go
+++ b/internal/vulnerability/worker.go
@@ -96,7 +96,18 @@ func NewVulnerabilityWorker(log *logp.Logger, c *config.Config, bdp dataprovider
 
 func (f *VulnerabilityWorker) Run(ctx context.Context) {
 	f.log.Info("Starting VulnerabilityWorker.work")
-	defer f.runner.GetRunner().Close(ctx)
+	defer func() {
+		err := f.runner.ClearCache(ctx)
+		if err != nil {
+			f.log.Warnf("error during runner cache clearing %s", err.Error())
+		}
+	}()
+	defer func() {
+		err := f.runner.GetRunner().Close(ctx)
+		if err != nil {
+			f.log.Warnf("error during runner closing %s", err.Error())
+		}
+	}()
 
 	select {
 	case <-ctx.Done():

--- a/internal/vulnerability/worker.go
+++ b/internal/vulnerability/worker.go
@@ -97,14 +97,7 @@ func NewVulnerabilityWorker(log *logp.Logger, c *config.Config, bdp dataprovider
 func (f *VulnerabilityWorker) Run(ctx context.Context) {
 	f.log.Info("Starting VulnerabilityWorker.work")
 	defer func() {
-		err := f.runner.ClearCache(ctx)
-		if err != nil {
-			f.log.Warnf("error during runner cache clearing %s", err.Error())
-		}
-	}()
-	defer func() {
-		err := f.runner.GetRunner().Close(ctx)
-		if err != nil {
+		if err := f.runner.GetRunner().Close(ctx); err != nil {
 			f.log.Warnf("error during runner closing %s", err.Error())
 		}
 	}()


### PR DESCRIPTION
### Summary of your changes
**Clean trivy cache after each cycle** 


Trivy [artifact.NewRunner](https://github.com/aquasecurity/trivy/blob/main/pkg/commands/artifact/run.go#L116) calls [initCache](https://github.com/aquasecurity/trivy/blob/main/pkg/commands/artifact/run.go#L341). 

Depending on the provided configuration, the latter (initCache) could either return a runner or the error `SkipScan` (and nil runner).

In case one of the below flags is `true`, the `artifact.NewRunner` will perform the relevant clean/reset operation and return `SkipScan`. 

  * `CacheOptions.ClearCache`
  * `DBOptions.Reset`
  * `MisconfOptions.ResetPolicyBundle`

This means that:
  1. The clean/reset operations are embedded inside `initCache`, called inside `artifact.NewRunner`. We cannot execute them standalonely. 
  2. When at least one on those flags are true, the clean/reset operation takes place and returns `SkipScan` and `nil` runner, which means we cannot set the flags and get a valid runner with a single call (that's why I created a separate function `ClearCache` in my code changes). 
  3. `initCache` could perform only one of each clean/reset operation and then return `SkipScan`, which means we cannot perform a single `artifact.NewRunner` call and init all of those flags to true and expect all those clear/reset operations to run. We need to do one at a time (that's why I created the loop inside `ClearCache` in my code changes).
 
Also Note: `initCache` with reset/clean flags could run only when no other bbolt client "holds" open the db. So it must be run before we create the `artifact.NewRunner`.


### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->
With this PR the below happens at the beginning of the cycle:


<img width="1247" alt="Screenshot 2024-05-17 at 4 42 01 PM" src="https://github.com/elastic/cloudbeat/assets/1380039/4a9c2c9c-0167-47a5-86ec-99d60670a51a">

### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
Fixes: https://github.com/elastic/cloudbeat/issues/2142

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
