### PR TITLE
Rollback to a previous beats version to verify when the problem started

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/cloudbeat
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/asset v1.18.1
@@ -47,7 +47,7 @@ require (
 	github.com/aws/smithy-go v1.20.2
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/djherbis/times v1.6.0
-	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20240506063642-ff424ea42bbd
+	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20240413024007-ca4adcecac03
 	github.com/elastic/e2e-testing v1.99.2-0.20231005090720-556e60d449dc
 	github.com/elastic/elastic-agent-autodiscover v0.6.14
 	github.com/elastic/elastic-agent-client/v7 v7.8.1

--- a/go.sum
+++ b/go.sum
@@ -1132,8 +1132,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 h1:YEetp8
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/elastic/beats/v7 v7.0.0-alpha2.0.20240506063642-ff424ea42bbd h1:XWHCSGDITaBd9DqMEGw8/6YIqeNRoIE3uYM+YZtfC2o=
-github.com/elastic/beats/v7 v7.0.0-alpha2.0.20240506063642-ff424ea42bbd/go.mod h1:SIktMzFsYob4fSPmKI8m1Yo8+DnjsKk8NW2+ti9T3i4=
+github.com/elastic/beats/v7 v7.0.0-alpha2.0.20240413024007-ca4adcecac03 h1:qaf0zAAUM1Y7NPqi/QdvyuRTCoj+DUzRA2+iNxaEE+s=
+github.com/elastic/beats/v7 v7.0.0-alpha2.0.20240413024007-ca4adcecac03/go.mod h1:kdguBWXulzsJpqFYPAyH9DxfuOMkhlqLCzxCJzkbWXo=
 github.com/elastic/e2e-testing v1.99.2-0.20231005090720-556e60d449dc h1:3hGO3+tipLIULlrabnXpXpOV5qSDbN/EJo9Xsj3hqyo=
 github.com/elastic/e2e-testing v1.99.2-0.20231005090720-556e60d449dc/go.mod h1:8q2d8dmwavJXISowwaoreHFBnbR/uK4qanfRGhC/W9A=
 github.com/elastic/elastic-agent-autodiscover v0.6.14 h1:0zJYNyv9GKTOiNqCHqEVboP+WioV73ia17Et+UlFbz8=


### PR DESCRIPTION
### Summary of your changes

Debugging the issues with buildkite build.

The issue has started with this commit https://github.com/elastic/cloudbeat/commit/27baac2d89cc5b7adc4402e8819d9f7ab2401645

Which introduced the beats version of commit https://github.com/elastic/beats/commit/81f63103678f (2024-04-26)

There was multiple added commits in this updated because the previous version we were using was https://github.com/elastic/beats/commit/f871b5c5f76b (2024-03-29)

Therefore I'm trying to narrow down when the issue started, after what commit - so we can better provide information to the beats team.

The chosen commit is this one, https://github.com/elastic/beats/commit/ca4adcecac031b8c7ba83a16d1803140b018f3a1 introduced on 2024-04-13, roughly mid of the road between 2024-04-26 and 2024-03-29.

Unfortunately I have to merge this to properly test. More PR's will follow up with further tests and a complete rollback to the latest version we are at right now.
