### PR TITLE
add cloudsecmachine email for CI

### DIFF
--- a/.ci/updatecli/updatecli.d/update-beats.yml
+++ b/.ci/updatecli/updatecli.d/update-beats.yml
@@ -12,6 +12,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
       branch: '{{ requiredEnv "GIT_BRANCH" }}'
+      email: 'cloudsecmachine@elastic.co'
 
 actions:
   default:

--- a/.ci/updatecli/updatecli.d/update-golang.yml
+++ b/.ci/updatecli/updatecli.d/update-golang.yml
@@ -12,6 +12,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
       branch: '{{ requiredEnv "GIT_BRANCH" }}'
+      email: 'cloudsecmachine@elastic.co'
 
 actions:
   cloudbeat:

--- a/.ci/updatecli/updatecli.d/update-hermit.yml
+++ b/.ci/updatecli/updatecli.d/update-hermit.yml
@@ -12,6 +12,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
       branch: '{{ requiredEnv "GIT_BRANCH" }}'
+      email: 'cloudsecmachine@elastic.co'
 
 actions:
   default:

--- a/.ci/updatecli/updatecli.d/update-mods.yml
+++ b/.ci/updatecli/updatecli.d/update-mods.yml
@@ -12,6 +12,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
       branch: '{{ requiredEnv "GIT_BRANCH" }}'
+      email: 'cloudsecmachine@elastic.co'
 
 actions:
   default:


### PR DESCRIPTION
in https://github.com/elastic/cloudbeat/pull/2224 we've changed to use `cloudsecmachine` token for `update-cli` PRs

seems like although we use its token, the email is not configured and thus [fails](https://github.com/elastic/cloudbeat/pull/2247#issuecomment-2144436482) CLA check 

[commit with no CLA issue](https://github.com/elastic/cloudbeat/commit/ac62cad88db661fd24b6db6d42cb5e165ece1954.patch) 

[commit with CLA issue](https://github.com/elastic/cloudbeat/commit/8c39f78c82735ed0c0b1c057d68341902b67555b.patch)

note the email is set on the first one (`cloudsecmachine@users.noreply.github.com`) but not on the second one (`<>`)

i've changed the email used to be `cloudsecmachine@elastic.co`, should work the same, if not we'll use the other one ^

