### PR TITLE
[Asset Inventory] Update index to match Index Template

### DIFF
--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -29,6 +29,8 @@ import (
 	"github.com/samber/lo"
 )
 
+const indexTemplate = "logs-cloud_asset_inventory.asset_inventory-%s_%s_%s_%s-default"
+
 type AssetInventory struct {
 	fetchers            []AssetFetcher
 	publisher           AssetPublisher
@@ -119,7 +121,7 @@ func (a *AssetInventory) publish(assets []AssetEvent) {
 }
 
 func generateIndex(a Asset) string {
-	return fmt.Sprintf("asset_inventory_%s_%s_%s_%s", a.Category, a.SubCategory, a.Type, a.SubType)
+	return fmt.Sprintf(indexTemplate, a.Category, a.SubCategory, a.Type, a.SubType)
 }
 
 func (a *AssetInventory) Stop() {

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -37,7 +37,7 @@ func TestAssetInventory_Run(t *testing.T) {
 	now := func() time.Time { return time.Date(2024, 1, 1, 1, 1, 1, 0, time.Local) }
 	expected := []beat.Event{
 		{
-			Meta:      mapstr.M{libevents.FieldMetaIndex: "asset_inventory_infrastructure_compute_virtual-machine_ec2"},
+			Meta:      mapstr.M{libevents.FieldMetaIndex: "logs-cloud_asset_inventory.asset_inventory-infrastructure_compute_virtual-machine_ec2-default"},
 			Timestamp: now(),
 			Fields: mapstr.M{
 				"asset": Asset{


### PR DESCRIPTION
### Summary of your changes

Asset inventory needs to comply with the datastream index template created by the integration and write permissions granted (it needs to end with `-default`).

![image](https://github.com/elastic/cloudbeat/assets/5350001/ac6d3704-8583-4acf-89ef-c31a9db07e26)


### Related Issues
- Related https://github.com/elastic/security-team/issues/9066

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works