### PR TITLE
Revert "Bump andrcuns/allure-publish-action from 2.6.0 to 2.7.0 in /.github/workflows"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
 
       - name: Publish allure report
         if: ${{ always() }}
-        uses: andrcuns/allure-publish-action@v2.7.0
+        uses: andrcuns/allure-publish-action@v2.6.0
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}

--- a/.github/workflows/eks-ci.yml
+++ b/.github/workflows/eks-ci.yml
@@ -243,7 +243,7 @@ jobs:
 
       - name: Publish allure report
         if: always()
-        uses: andrcuns/allure-publish-action@v2.7.0
+        uses: andrcuns/allure-publish-action@v2.6.0
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_REGION: eu-west-1


### PR DESCRIPTION
Reverts elastic/cloudbeat#2285 because of broken parallel support (https://github.com/andrcuns/allure-publish-action/issues/40)