### PR TITLE
Label cloud resources

### DIFF
--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -113,8 +113,8 @@ env:
   WORKING_DIR: deploy/test-environments
   INTEGRATIONS_SETUP_DIR: tests/integrations_setup
   AWS_DEFAULT_TAGS: "Key=division,Value=engineering Key=org,Value=security Key=team,Value=cloud-security-posture Key=project,Value=test-environments"
-  GCP_DEFAULT_TAGS: "division=engineering,org=security,team=cloud-security-posture,project=test-environments"
-  AZURE_DEFAULT_TAGS: "division=engineering org=security team=cloud-security-posture project=test-environments ci=integration owner=${{ github.actor }}"
+  GCP_DEFAULT_TAGS: "division=engineering,org=security,team=cloud-security-posture,project=test-environments,owner=${{ github.actor }}"
+  AZURE_DEFAULT_TAGS: "division=engineering org=security team=cloud-security-posture project=test-environments owner=${{ github.actor }}"
   TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
 
 jobs:
@@ -323,10 +323,8 @@ jobs:
       - name: Deploy CSPM GCP agent
         id: cspm-gcp-agent
         working-directory: deploy/deployment-manager
-        env:
-          DEPLOYMENT_LABELS: ${{ env.GCP_DEFAULT_TAGS }}
         run: |
-          . ./set_env.sh && ./deploy.sh
+          . ./set_env.sh && ./deploy.sh && gcloud deployment-manager deployments update "${DEPLOYMENT_NAME}" --update-labels "${GCP_DEFAULT_TAGS}"
 
       - name: Install CSPM Azure integration
         id: cspm-azure-integration

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -114,6 +114,7 @@ env:
   INTEGRATIONS_SETUP_DIR: tests/integrations_setup
   AWS_DEFAULT_TAGS: "Key=division,Value=engineering Key=org,Value=security Key=team,Value=cloud-security-posture Key=project,Value=test-environments"
   GCP_DEFAULT_TAGS: "division=engineering,org=security,team=cloud-security-posture,project=test-environments"
+  AZURE_DEFAULT_TAGS: "division=engineering org=security team=cloud-security-posture project=test-environments ci=integration owner=${{ github.actor }}"
   TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
 
 jobs:
@@ -342,13 +343,9 @@ jobs:
       - name: Deploy CSPM Azure agent
         id: cspm-azure-agent
         working-directory: deploy/azure
-        run: |
-          if [[ "${{ env.STACK_VERSION }}" == *"8.11"* ]]; then
-            az deployment sub create --location EastUS --template-file ARM-for-single-account.json --parameters @arm_parameters.json
-          else
-            az group create --location EastUS --name "${{ env.DEPLOYMENT_NAME }}"
-            az deployment group create --resource-group "${{ env.DEPLOYMENT_NAME }}" --template-file ARM-for-single-account.json --parameters @arm_parameters.json
-          fi
+        env:
+          AZURE_TAGS: ${{ env.AZURE_DEFAULT_TAGS }}
+        run: ./install_agent_az_cli.sh
 
       - name: Install D4C integration
         id: kspm-d4c

--- a/.github/workflows/test-gcp-dm.yml
+++ b/.github/workflows/test-gcp-dm.yml
@@ -22,6 +22,7 @@ env:
   DEPLOYMENT_MANAGER_DIR: deploy/deployment-manager
   TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
   TF_VAR_ess_region: gcp-us-west2 # default region for testing deployments
+  GCP_LABELS: "ci=integration,owner=${{ github.actor }}"
 
 jobs:
   # Test a GCP Deployment Manager deployment using Application Default Credentials
@@ -100,8 +101,9 @@ jobs:
         working-directory: deploy/deployment-manager
         env:
           DEPLOYMENT_LABELS: ${{ env.GCP_DEFAULT_TAGS }}
+          DEPLOYMENT_NAME: ${{env.GCP_DEPLOYMENT_NAME}}
         run: |
-          . ./set_env.sh && ./deploy.sh
+          . ./set_env.sh && ./deploy.sh && gcloud deployment-manager deployments update "${DEPLOYMENT_NAME}" --update-labels "${GCP_LABELS}"
 
       - name: Check for findings
         working-directory: ./tests
@@ -124,8 +126,10 @@ jobs:
       - name: Delete GCP Deployment Manager deployment
         if: always()
         working-directory: ${{ env.TEST_ENVS_DIR }}
+        env:
+          DEPLOYMENT_NAME: ${{env.GCP_DEPLOYMENT_NAME}}
         run: |
-          DEPLOYMENT=${{env.GCP_DEPLOYMENT_NAME}}
+          DEPLOYMENT="${DEPLOYMENT_NAME}"
           PROJECT_NAME=$(gcloud config get-value core/project)
           PROJECT_NUMBER=$(gcloud projects list --filter="${PROJECT_NAME}" --format="value(PROJECT_NUMBER)")
           ./delete_gcp_env.sh $PROJECT_NAME $PROJECT_NUMBER $DEPLOYMENT
@@ -203,22 +207,22 @@ jobs:
           STACK_VERSION: ${{ env.ELK_VERSION }}
         run: |
           # Deploys a GCP Service Account
-          cd ${{ env.DEPLOYMENT_MANAGER_DIR }}
-          export DEPLOYMENT_NAME="${{ env.GCP_SA_DEPLOYMENT_NAME }}"
-          export SERVICE_ACCOUNT_NAME="${{ env.GCP_SA_DEPLOYMENT_NAME }}-sa"
+          cd "${DEPLOYMENT_MANAGER_DIR}"
+          export DEPLOYMENT_NAME="${GCP_SA_DEPLOYMENT_NAME}"
+          export SERVICE_ACCOUNT_NAME="${GCP_SA_DEPLOYMENT_NAME}-sa"
           ./deploy_service_account.sh
-          mv KEY_FILE.json ../../${{ env.INTEGRATIONS_SETUP_DIR }}
+          mv KEY_FILE.json "../../${INTEGRATIONS_SETUP_DIR}"
 
           # Installs CSPM GCP integration
-          cd ../../${{ env.INTEGRATIONS_SETUP_DIR }}
+          cd "../../${INTEGRATIONS_SETUP_DIR}"
           export SERVICE_ACCOUNT_JSON_PATH="KEY_FILE.json"
-          export DEPLOYMENT_NAME="${{ env.GCP_AGENT_DEPLOYMENT_NAME }}"
+          export DEPLOYMENT_NAME="${GCP_AGENT_DEPLOYMENT_NAME}"
           poetry install
           poetry run python ./install_cspm_gcp_integration.py
 
           # Deploys the agent using an existing service account (SERVICE_ACCOUNT_NAME)
-          cd ../../${{ env.DEPLOYMENT_MANAGER_DIR }}
-          . ./set_env.sh && ./deploy.sh
+          cd "../../${DEPLOYMENT_MANAGER_DIR}"
+          . ./set_env.sh && ./deploy.sh && gcloud deployment-manager deployments update "${DEPLOYMENT_NAME}" --update-labels "${GCP_LABELS}"
 
       - name: Check for findings
         working-directory: ./tests
@@ -240,4 +244,4 @@ jobs:
         run: |
           PROJECT_NAME=$(gcloud config get-value core/project)
           PROJECT_NUMBER=$(gcloud projects list --filter="${PROJECT_NAME}" --format="value(PROJECT_NUMBER)")
-          ./delete_gcp_env.sh $PROJECT_NAME $PROJECT_NUMBER ${{env.GCP_SA_DEPLOYMENT_NAME}} ${{env.GCP_AGENT_DEPLOYMENT_NAME}}
+          ./delete_gcp_env.sh $PROJECT_NAME $PROJECT_NUMBER "${GCP_SA_DEPLOYMENT_NAME}" "${GCP_AGENT_DEPLOYMENT_NAME}"

--- a/deploy/azure/install_agent_az_cli.sh
+++ b/deploy/azure/install_agent_az_cli.sh
@@ -52,8 +52,11 @@ group=$(az group show -n "${DEPLOYMENT_NAME}" --query id --output tsv)
 # --tags requires the tags to be passed as separate arguments
 # shellcheck disable=SC2086
 az tag update --resource-id "$group" --operation Merge --tags ${AZURE_TAGS}
-# Get all resources within the resource group and store their IDs in resources
-mapfile -t resources < <(az resource list --resource-group "${DEPLOYMENT_NAME}" --query "[].id" --output tsv)
+# Get all resources within the resource group and store their IDs in an array
+resources=()
+while IFS= read -r resource_id; do
+    resources+=("$resource_id")
+done < <(az resource list --resource-group "${DEPLOYMENT_NAME}" --query "[].id" --output tsv)
 
 # Loop over each resource ID in resources
 for resource in "${resources[@]}"; do

--- a/deploy/azure/install_agent_az_cli.sh
+++ b/deploy/azure/install_agent_az_cli.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# This script is used to deploy Azure resources and apply tags to them using Azure CLI.
+# Requiered environment variables:
+# - AZURE_TAGS: The default tags to apply to the resources. For example, "key1=value1 key2=value2".
+# - DEPLOYMENT_NAME: The name of the deployment.
+# - STACK_VERSION: The version of the stack.
+# Pre-requisites:
+# arm_parameters.json: The parameters file for the ARM template should be present in the same directory as this script.
+# Example:
+# {
+#   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+#   "contentVersion": "1.0.0.0",
+#   "parameters": {
+#     "EnrollmentToken": {
+#       "value": "your-enrollment-token"
+#     },
+#     "FleetUrl": {
+#       "value": "https://your-fleet-url"
+#     },
+#     "ElasticArtifactServer": {
+#       "value": "https://artifacts.elastic.co/downloads/beats/elastic-agent"
+#     },
+#     "ElasticAgentVersion": {
+#       "value": "8.14.1"
+#     }
+#   }
+# }
+# Usage:
+#   cd ./deploy/azure
+#   STACK_VERSION="8.14.1" DEPLOYMENT_NAME="elastic-agent-cspm" AZURE_TAGS="key1=value1 key2=value2" ./install_agent_az_cli.sh
+
+# Exit immediately if a command exits with a non-zero status, print each command before executing it, and fail pipelines if any command fails.
+set -euo pipefail
+
+MINOR_VERSION=$(echo "${STACK_VERSION}" | cut -d'.' -f2)
+# Check if minor version is less than 12, ie. 8.11 and below
+if ((MINOR_VERSION < 12)); then
+    echo "Versions 8.11 and below are not supported. Please use versions 8.12+"
+    exit 0
+fi
+
+# Create a resource group with the name DEPLOYMENT_NAME
+az group create --location EastUS --name "${DEPLOYMENT_NAME}"
+
+# Create a group deployment using the ARM-for-single-account.json
+az deployment group create --resource-group "${DEPLOYMENT_NAME}" --template-file ARM-for-single-account.json --parameters @arm_parameters.json
+
+# Get the resource group ID of the DEPLOYMENT_NAME and store it in group
+group=$(az group show -n "${DEPLOYMENT_NAME}" --query id --output tsv)
+
+# --tags requires the tags to be passed as separate arguments
+# shellcheck disable=SC2086
+az tag update --resource-id "$group" --operation Merge --tags ${AZURE_TAGS}
+# Get all resources within the resource group and store their IDs in resources
+mapfile -t resources < <(az resource list --resource-group "${DEPLOYMENT_NAME}" --query "[].id" --output tsv)
+
+# Loop over each resource ID in resources
+for resource in "${resources[@]}"; do
+    # Merge the deploy_tags with the existing tags of the resource
+    # --tags requires the tags to be passed as separate arguments
+    # shellcheck disable=SC2086
+    az tag update --resource-id "$resource" --operation Merge --tags ${AZURE_TAGS}
+done

--- a/deploy/deployment-manager/deploy.sh
+++ b/deploy/deployment-manager/deploy.sh
@@ -37,7 +37,6 @@ ROLE="roles/resourcemanager.projectIamAdmin"
 
 ELASTIC_ARTIFACT_SERVER=${ELASTIC_ARTIFACT_SERVER%/} # Remove trailing slash if present
 ELASTIC_ARTIFACT_SERVER=${ELASTIC_ARTIFACT_SERVER:-https://artifacts.elastic.co/downloads/beats/elastic-agent}
-DEPLOYMENT_LABELS=${DEPLOYMENT_LABELS:-type=cspm-gcp}
 SERVICE_ACCOUNT_NAME=${SERVICE_ACCOUNT_NAME:-false}
 
 # Set environment variables with the name and number of your project.


### PR DESCRIPTION
### Summary of your changes

This PR introduces tagging for resources deployed in Azure Cloud and GCP. Any resource deployed by the `create environment` workflow will be tagged/labeled with predefined tags. For the GCP DM integration tests workflow, any Elastic Agent deployed will be labeled with `ci:integration` and `owner:${{ github.actor }}` labels.

### Screenshot/Data

**GCP elastic agent deployment**

![GCP dm deployment](https://github.com/elastic/cloudbeat/assets/99176494/5b5e88b6-4ab9-4d4f-bed6-26b72900ef15)

**GCP DM integration tests workflow**

![Screenshot 2024-06-25 at 14 00 26](https://github.com/elastic/cloudbeat/assets/99176494/2aaff830-d823-4e93-b9ca-ad9a9f65cd1f)


**Azure elastic agent VM**

![Azure agent VM](https://github.com/elastic/cloudbeat/assets/99176494/bf2bf240-100c-4e3f-9160-48ffce486f13)



### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
