### PR TITLE
Implement new identifier format for asset inventory

### DIFF
--- a/internal/inventory/asset.go
+++ b/internal/inventory/asset.go
@@ -112,17 +112,11 @@ type AssetClassification struct {
 
 // Entity contains the identifiers of the asset
 type Entity struct {
-	Identifiers EntityIdentifiers `json:"identifiers"`
-	Name        string            `json:"name"`
+	Id   []string `json:"id"`
+	Name string   `json:"name"`
 	AssetClassification
 	Tags map[string]string `json:"tags"`
 	Raw  any               `json:"raw"`
-}
-
-// Specific identifiers of the asset
-type EntityIdentifiers struct {
-	Arns []string `json:"arns,omitempty"`
-	Ids  []string `json:"ids,omitempty"`
 }
 
 // AssetNetwork contains network information
@@ -206,10 +200,10 @@ type AssetResourcePolicy struct {
 // AssetEnricher functional builder function
 type AssetEnricher func(asset *AssetEvent)
 
-func NewAssetEvent(c AssetClassification, identifiers EntityIdentifiers, name string, enrichers ...AssetEnricher) AssetEvent {
+func NewAssetEvent(c AssetClassification, ids []string, name string, enrichers ...AssetEnricher) AssetEvent {
 	a := AssetEvent{
 		Entity: Entity{
-			Identifiers:         identifiers,
+			Id:                  removeEmpty(ids),
 			Name:                name,
 			AssetClassification: c,
 		},

--- a/internal/inventory/awsfetcher/fetcher_ec2_instance.go
+++ b/internal/inventory/awsfetcher/fetcher_ec2_instance.go
@@ -84,10 +84,7 @@ func (e *ec2InstanceFetcher) Fetch(ctx context.Context, assetChannel chan<- inve
 		}
 		assetChannel <- inventory.NewAssetEvent(
 			ec2InstanceClassification,
-			inventory.Identifiers(
-				inventory.Arns(instance.GetResourceArn()),
-				inventory.Ids(pointers.Deref(instance.InstanceId)),
-			),
+			[]string{instance.GetResourceArn(), pointers.Deref(instance.InstanceId)},
 			instance.GetResourceName(),
 
 			inventory.WithRawAsset(instance),

--- a/internal/inventory/awsfetcher/fetcher_ec2_instance.go
+++ b/internal/inventory/awsfetcher/fetcher_ec2_instance.go
@@ -84,7 +84,10 @@ func (e *ec2InstanceFetcher) Fetch(ctx context.Context, assetChannel chan<- inve
 		}
 		assetChannel <- inventory.NewAssetEvent(
 			ec2InstanceClassification,
-			instance.GetResourceArn(),
+			inventory.Identifiers(
+				inventory.Arns(instance.GetResourceArn()),
+				inventory.Ids(pointers.Deref(instance.InstanceId)),
+			),
 			instance.GetResourceName(),
 
 			inventory.WithRawAsset(instance),

--- a/internal/inventory/awsfetcher/fetcher_ec2_instance_test.go
+++ b/internal/inventory/awsfetcher/fetcher_ec2_instance_test.go
@@ -77,7 +77,10 @@ func TestEC2InstanceFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			ec2InstanceClassification,
-			"arn:aws:ec2:us-east::ec2/234567890",
+			inventory.Identifiers(
+				inventory.Arns("arn:aws:ec2:us-east::ec2/234567890"),
+				inventory.Ids("234567890"),
+			),
 			"test-server",
 			inventory.WithRawAsset(instance1),
 			inventory.WithTags(map[string]string{"Name": "test-server", "key": "value"}),
@@ -124,7 +127,7 @@ func TestEC2InstanceFetcher_Fetch(t *testing.T) {
 
 		inventory.NewAssetEvent(
 			ec2InstanceClassification,
-			"",
+			inventory.Identifiers(),
 			"",
 			inventory.WithRawAsset(instance2),
 			inventory.WithTags(map[string]string{}),

--- a/internal/inventory/awsfetcher/fetcher_ec2_instance_test.go
+++ b/internal/inventory/awsfetcher/fetcher_ec2_instance_test.go
@@ -77,10 +77,7 @@ func TestEC2InstanceFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			ec2InstanceClassification,
-			inventory.Identifiers(
-				inventory.Arns("arn:aws:ec2:us-east::ec2/234567890"),
-				inventory.Ids("234567890"),
-			),
+			[]string{"arn:aws:ec2:us-east::ec2/234567890", "234567890"},
 			"test-server",
 			inventory.WithRawAsset(instance1),
 			inventory.WithTags(map[string]string{"Name": "test-server", "key": "value"}),
@@ -127,7 +124,7 @@ func TestEC2InstanceFetcher_Fetch(t *testing.T) {
 
 		inventory.NewAssetEvent(
 			ec2InstanceClassification,
-			inventory.Identifiers(),
+			[]string{},
 			"",
 			inventory.WithRawAsset(instance2),
 			inventory.WithTags(map[string]string{}),

--- a/internal/inventory/awsfetcher/fetcher_elb.go
+++ b/internal/inventory/awsfetcher/fetcher_elb.go
@@ -81,7 +81,7 @@ func (f *elbFetcher) fetch(ctx context.Context, resourceName string, function el
 	for _, item := range awsResources {
 		assetChannel <- inventory.NewAssetEvent(
 			classification,
-			item.GetResourceArn(),
+			inventory.Identifiers(inventory.Arns(item.GetResourceArn())),
 			item.GetResourceName(),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_elb.go
+++ b/internal/inventory/awsfetcher/fetcher_elb.go
@@ -81,7 +81,7 @@ func (f *elbFetcher) fetch(ctx context.Context, resourceName string, function el
 	for _, item := range awsResources {
 		assetChannel <- inventory.NewAssetEvent(
 			classification,
-			inventory.Identifiers(inventory.Arns(item.GetResourceArn())),
+			[]string{item.GetResourceArn()},
 			item.GetResourceName(),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_elb_test.go
+++ b/internal/inventory/awsfetcher/fetcher_elb_test.go
@@ -68,7 +68,7 @@ func TestELBv1Fetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			newElbClassification(inventory.SubTypeELBv1),
-			inventory.Identifiers(inventory.Arns("arn:aws:elasticloadbalancing:::loadbalancer/my-elb-v1")),
+			[]string{"arn:aws:elasticloadbalancing:::loadbalancer/my-elb-v1"},
 			"my-elb-v1",
 			inventory.WithRawAsset(asset),
 			inventory.WithCloud(inventory.AssetCloud{
@@ -118,7 +118,7 @@ func TestELBv2Fetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			newElbClassification(inventory.SubTypeELBv2),
-			inventory.Identifiers(inventory.Arns("arn:aws:elasticloadbalancing:::loadbalancer/my-elb-v2")),
+			[]string{"arn:aws:elasticloadbalancing:::loadbalancer/my-elb-v2"},
 			"my-elb-v2",
 			inventory.WithRawAsset(asset),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_elb_test.go
+++ b/internal/inventory/awsfetcher/fetcher_elb_test.go
@@ -68,7 +68,7 @@ func TestELBv1Fetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			newElbClassification(inventory.SubTypeELBv1),
-			"arn:aws:elasticloadbalancing:::loadbalancer/my-elb-v1",
+			inventory.Identifiers(inventory.Arns("arn:aws:elasticloadbalancing:::loadbalancer/my-elb-v1")),
 			"my-elb-v1",
 			inventory.WithRawAsset(asset),
 			inventory.WithCloud(inventory.AssetCloud{
@@ -118,7 +118,7 @@ func TestELBv2Fetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			newElbClassification(inventory.SubTypeELBv2),
-			"arn:aws:elasticloadbalancing:::loadbalancer/my-elb-v2",
+			inventory.Identifiers(inventory.Arns("arn:aws:elasticloadbalancing:::loadbalancer/my-elb-v2")),
 			"my-elb-v2",
 			inventory.WithRawAsset(asset),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_iam_policy.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_policy.go
@@ -81,10 +81,7 @@ func (i *iamPolicyFetcher) Fetch(ctx context.Context, assetChannel chan<- invent
 
 		assetChannel <- inventory.NewAssetEvent(
 			iamPolicyClassification,
-			inventory.Identifiers(
-				inventory.Arns(policy.GetResourceArn()),
-				inventory.Ids(pointers.Deref(policy.PolicyId)),
-			),
+			[]string{policy.GetResourceArn(), pointers.Deref(policy.PolicyId)},
 			resource.GetResourceName(),
 
 			inventory.WithRawAsset(policy),

--- a/internal/inventory/awsfetcher/fetcher_iam_policy.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_policy.go
@@ -81,7 +81,10 @@ func (i *iamPolicyFetcher) Fetch(ctx context.Context, assetChannel chan<- invent
 
 		assetChannel <- inventory.NewAssetEvent(
 			iamPolicyClassification,
-			policy.GetResourceArn(),
+			inventory.Identifiers(
+				inventory.Arns(policy.GetResourceArn()),
+				inventory.Ids(pointers.Deref(policy.PolicyId)),
+			),
 			resource.GetResourceName(),
 
 			inventory.WithRawAsset(policy),

--- a/internal/inventory/awsfetcher/fetcher_iam_policy_test.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_policy_test.go
@@ -116,7 +116,7 @@ func TestIAMPolicyFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			iamPolicyClassification,
-			"arn:aws:iam::0000:policy/policy-1",
+			inventory.Identifiers(inventory.Arns("arn:aws:iam::0000:policy/policy-1"), inventory.Ids("178263")),
 			"policy-1",
 			inventory.WithRawAsset(policy1),
 			inventory.WithCloud(cloudField),
@@ -139,7 +139,7 @@ func TestIAMPolicyFetcher_Fetch(t *testing.T) {
 
 		inventory.NewAssetEvent(
 			iamPolicyClassification,
-			"arn:aws:iam::0000:policy/policy-2",
+			inventory.Identifiers(inventory.Arns("arn:aws:iam::0000:policy/policy-2")),
 			"policy-2",
 			inventory.WithRawAsset(policy2),
 			inventory.WithCloud(cloudField),
@@ -156,7 +156,7 @@ func TestIAMPolicyFetcher_Fetch(t *testing.T) {
 
 		inventory.NewAssetEvent(
 			iamPolicyClassification,
-			"arn:aws:iam::0000:policy/policy-3",
+			inventory.Identifiers(inventory.Arns("arn:aws:iam::0000:policy/policy-3")),
 			"policy-3",
 			inventory.WithRawAsset(policy3),
 			inventory.WithCloud(cloudField),

--- a/internal/inventory/awsfetcher/fetcher_iam_policy_test.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_policy_test.go
@@ -116,7 +116,7 @@ func TestIAMPolicyFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			iamPolicyClassification,
-			inventory.Identifiers(inventory.Arns("arn:aws:iam::0000:policy/policy-1"), inventory.Ids("178263")),
+			[]string{"arn:aws:iam::0000:policy/policy-1", "178263"},
 			"policy-1",
 			inventory.WithRawAsset(policy1),
 			inventory.WithCloud(cloudField),
@@ -139,7 +139,7 @@ func TestIAMPolicyFetcher_Fetch(t *testing.T) {
 
 		inventory.NewAssetEvent(
 			iamPolicyClassification,
-			inventory.Identifiers(inventory.Arns("arn:aws:iam::0000:policy/policy-2")),
+			[]string{"arn:aws:iam::0000:policy/policy-2"},
 			"policy-2",
 			inventory.WithRawAsset(policy2),
 			inventory.WithCloud(cloudField),
@@ -156,7 +156,7 @@ func TestIAMPolicyFetcher_Fetch(t *testing.T) {
 
 		inventory.NewAssetEvent(
 			iamPolicyClassification,
-			inventory.Identifiers(inventory.Arns("arn:aws:iam::0000:policy/policy-3")),
+			[]string{"arn:aws:iam::0000:policy/policy-3"},
 			"policy-3",
 			inventory.WithRawAsset(policy3),
 			inventory.WithCloud(cloudField),

--- a/internal/inventory/awsfetcher/fetcher_iam_role.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_role.go
@@ -75,7 +75,8 @@ func (i *iamRoleFetcher) Fetch(ctx context.Context, assetChannel chan<- inventor
 
 		assetChannel <- inventory.NewAssetEvent(
 			iamRoleClassification,
-			pointers.Deref(role.Arn),
+			inventory.Identifiers(inventory.Arns(pointers.Deref(role.Arn)),
+				inventory.Ids(pointers.Deref(role.RoleId))),
 			pointers.Deref(role.RoleName),
 
 			inventory.WithRawAsset(*role),

--- a/internal/inventory/awsfetcher/fetcher_iam_role.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_role.go
@@ -75,8 +75,7 @@ func (i *iamRoleFetcher) Fetch(ctx context.Context, assetChannel chan<- inventor
 
 		assetChannel <- inventory.NewAssetEvent(
 			iamRoleClassification,
-			inventory.Identifiers(inventory.Arns(pointers.Deref(role.Arn)),
-				inventory.Ids(pointers.Deref(role.RoleId))),
+			[]string{pointers.Deref(role.Arn), pointers.Deref(role.RoleId)},
 			pointers.Deref(role.RoleName),
 
 			inventory.WithRawAsset(*role),

--- a/internal/inventory/awsfetcher/fetcher_iam_role_test.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_role_test.go
@@ -71,7 +71,7 @@ func TestIAMRoleFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			iamRoleClassification,
-			inventory.Identifiers(inventory.Arns("arn:aws:iam::0000:role/role-name-1"), inventory.Ids("17823618723")),
+			[]string{"arn:aws:iam::0000:role/role-name-1", "17823618723"},
 			"role-name-1",
 			inventory.WithRawAsset(role1),
 			inventory.WithCloud(inventory.AssetCloud{
@@ -89,7 +89,7 @@ func TestIAMRoleFetcher_Fetch(t *testing.T) {
 
 		inventory.NewAssetEvent(
 			iamRoleClassification,
-			inventory.Identifiers(inventory.Arns("arn:aws:iam::0000:role/role-name-2"), inventory.Ids("17823618723")),
+			[]string{"arn:aws:iam::0000:role/role-name-2", "17823618723"},
 			"role-name-2",
 			inventory.WithRawAsset(role2),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_iam_role_test.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_role_test.go
@@ -71,7 +71,7 @@ func TestIAMRoleFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			iamRoleClassification,
-			"arn:aws:iam::0000:role/role-name-1",
+			inventory.Identifiers(inventory.Arns("arn:aws:iam::0000:role/role-name-1"), inventory.Ids("17823618723")),
 			"role-name-1",
 			inventory.WithRawAsset(role1),
 			inventory.WithCloud(inventory.AssetCloud{
@@ -89,7 +89,7 @@ func TestIAMRoleFetcher_Fetch(t *testing.T) {
 
 		inventory.NewAssetEvent(
 			iamRoleClassification,
-			"arn:aws:iam::0000:role/role-name-2",
+			inventory.Identifiers(inventory.Arns("arn:aws:iam::0000:role/role-name-2"), inventory.Ids("17823618723")),
 			"role-name-2",
 			inventory.WithRawAsset(role2),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_iam_user.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_user.go
@@ -80,7 +80,7 @@ func (i *iamUserFetcher) Fetch(ctx context.Context, assetChannel chan<- inventor
 
 		assetChannel <- inventory.NewAssetEvent(
 			iamUserClassification,
-			user.GetResourceArn(),
+			inventory.Identifiers(inventory.Arns(user.GetResourceArn()), inventory.Ids(user.UserId)),
 			user.GetResourceName(),
 
 			inventory.WithRawAsset(user),

--- a/internal/inventory/awsfetcher/fetcher_iam_user.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_user.go
@@ -80,7 +80,7 @@ func (i *iamUserFetcher) Fetch(ctx context.Context, assetChannel chan<- inventor
 
 		assetChannel <- inventory.NewAssetEvent(
 			iamUserClassification,
-			inventory.Identifiers(inventory.Arns(user.GetResourceArn()), inventory.Ids(user.UserId)),
+			[]string{user.GetResourceArn(), user.UserId},
 			user.GetResourceName(),
 
 			inventory.WithRawAsset(user),

--- a/internal/inventory/awsfetcher/fetcher_iam_user_test.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_user_test.go
@@ -38,6 +38,7 @@ func TestIAMUserFetcher_Fetch(t *testing.T) {
 	user1 := iam.User{
 		Name:                "user-1",
 		Arn:                 "arn:aws:iam::000:user/user-1",
+		UserId:              "u-123123",
 		LastAccess:          "2023-03-28T12:27:26+00:00",
 		PasswordEnabled:     true,
 		MfaActive:           true,
@@ -85,7 +86,7 @@ func TestIAMUserFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			iamUserClassification,
-			"arn:aws:iam::000:user/user-1",
+			inventory.Identifiers(inventory.Arns("arn:aws:iam::000:user/user-1"), inventory.Ids("u-123123")),
 			"user-1",
 			inventory.WithRawAsset(user1),
 			inventory.WithCloud(inventory.AssetCloud{
@@ -103,7 +104,7 @@ func TestIAMUserFetcher_Fetch(t *testing.T) {
 
 		inventory.NewAssetEvent(
 			iamUserClassification,
-			"arn:aws:iam::000:user/user-2",
+			inventory.Identifiers(inventory.Arns("arn:aws:iam::000:user/user-2")),
 			"user-2",
 			inventory.WithRawAsset(user2),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_iam_user_test.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_user_test.go
@@ -86,7 +86,7 @@ func TestIAMUserFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			iamUserClassification,
-			inventory.Identifiers(inventory.Arns("arn:aws:iam::000:user/user-1"), inventory.Ids("u-123123")),
+			[]string{"arn:aws:iam::000:user/user-1", "u-123123"},
 			"user-1",
 			inventory.WithRawAsset(user1),
 			inventory.WithCloud(inventory.AssetCloud{
@@ -104,7 +104,7 @@ func TestIAMUserFetcher_Fetch(t *testing.T) {
 
 		inventory.NewAssetEvent(
 			iamUserClassification,
-			inventory.Identifiers(inventory.Arns("arn:aws:iam::000:user/user-2")),
+			[]string{"arn:aws:iam::000:user/user-2"},
 			"user-2",
 			inventory.WithRawAsset(user2),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_lambda.go
+++ b/internal/inventory/awsfetcher/fetcher_lambda.go
@@ -34,13 +34,15 @@ type lambdaFetcher struct {
 	AccountName string
 }
 
-type lambdaDescribeFunc func(context.Context) ([]awslib.AwsResource, error)
-type lambdaProvider interface {
-	ListAliases(context.Context, string, string) ([]awslib.AwsResource, error)
-	ListEventSourceMappings(context.Context) ([]awslib.AwsResource, error)
-	ListFunctions(context.Context) ([]awslib.AwsResource, error)
-	ListLayers(context.Context) ([]awslib.AwsResource, error)
-}
+type (
+	lambdaDescribeFunc func(context.Context) ([]awslib.AwsResource, error)
+	lambdaProvider     interface {
+		ListAliases(context.Context, string, string) ([]awslib.AwsResource, error)
+		ListEventSourceMappings(context.Context) ([]awslib.AwsResource, error)
+		ListFunctions(context.Context) ([]awslib.AwsResource, error)
+		ListLayers(context.Context) ([]awslib.AwsResource, error)
+	}
+)
 
 func newLambdaFetcher(logger *logp.Logger, identity *cloud.Identity, provider lambdaProvider) inventory.AssetFetcher {
 	return &lambdaFetcher{
@@ -84,7 +86,7 @@ func (s *lambdaFetcher) fetch(ctx context.Context, resourceName string, function
 	for _, item := range awsResources {
 		assetChannel <- inventory.NewAssetEvent(
 			classification,
-			item.GetResourceArn(),
+			inventory.Identifiers(inventory.Arns(item.GetResourceArn())),
 			item.GetResourceName(),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_lambda.go
+++ b/internal/inventory/awsfetcher/fetcher_lambda.go
@@ -86,7 +86,7 @@ func (s *lambdaFetcher) fetch(ctx context.Context, resourceName string, function
 	for _, item := range awsResources {
 		assetChannel <- inventory.NewAssetEvent(
 			classification,
-			inventory.Identifiers(inventory.Arns(item.GetResourceArn())),
+			[]string{item.GetResourceArn()},
 			item.GetResourceName(),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_lambda_test.go
+++ b/internal/inventory/awsfetcher/fetcher_lambda_test.go
@@ -60,7 +60,7 @@ func TestLambdaFunction_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			classification,
-			inventory.Identifiers(inventory.Arns("arn:aws:lambda:us-east-1:378890115541:function:kuba-test-func")),
+			[]string{"arn:aws:lambda:us-east-1:378890115541:function:kuba-test-func"},
 			"kuba-test-func",
 			inventory.WithRawAsset(function1),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_lambda_test.go
+++ b/internal/inventory/awsfetcher/fetcher_lambda_test.go
@@ -60,7 +60,7 @@ func TestLambdaFunction_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			classification,
-			"arn:aws:lambda:us-east-1:378890115541:function:kuba-test-func",
+			inventory.Identifiers(inventory.Arns("arn:aws:lambda:us-east-1:378890115541:function:kuba-test-func")),
 			"kuba-test-func",
 			inventory.WithRawAsset(function1),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_networking.go
+++ b/internal/inventory/awsfetcher/fetcher_networking.go
@@ -101,7 +101,7 @@ func (s *networkingFetcher) fetch(ctx context.Context, resourceName string, func
 	for _, item := range awsResources {
 		assetChannel <- inventory.NewAssetEvent(
 			classification,
-			inventory.Identifiers(inventory.Arns(item.GetResourceArn()), inventory.Ids(pointers.Deref(s.retrieveId(item)))),
+			[]string{item.GetResourceArn(), pointers.Deref(s.retrieveId(item))},
 			item.GetResourceName(),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_rds.go
+++ b/internal/inventory/awsfetcher/fetcher_rds.go
@@ -75,7 +75,7 @@ func (s *rdsFetcher) Fetch(ctx context.Context, assetChannel chan<- inventory.As
 	for _, item := range rdsInstances {
 		assetChannel <- inventory.NewAssetEvent(
 			rdsClassification,
-			inventory.Identifiers(inventory.Arns(item.GetResourceArn()), inventory.Ids(item.Identifier)),
+			[]string{item.GetResourceArn(), item.Identifier},
 			item.GetResourceName(),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_rds.go
+++ b/internal/inventory/awsfetcher/fetcher_rds.go
@@ -75,7 +75,7 @@ func (s *rdsFetcher) Fetch(ctx context.Context, assetChannel chan<- inventory.As
 	for _, item := range rdsInstances {
 		assetChannel <- inventory.NewAssetEvent(
 			rdsClassification,
-			item.GetResourceArn(),
+			inventory.Identifiers(inventory.Arns(item.GetResourceArn()), inventory.Ids(item.Identifier)),
 			item.GetResourceName(),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_rds_test.go
+++ b/internal/inventory/awsfetcher/fetcher_rds_test.go
@@ -83,7 +83,7 @@ func TestRDSInstanceFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			rdsClassification,
-			"arn:aws:rds:eu-west-1:123:db:db1",
+			inventory.Identifiers(inventory.Arns("arn:aws:rds:eu-west-1:123:db:db1"), inventory.Ids("db1")),
 			"db1",
 			inventory.WithRawAsset(instance1),
 			inventory.WithCloud(inventory.AssetCloud{
@@ -99,7 +99,7 @@ func TestRDSInstanceFetcher_Fetch(t *testing.T) {
 		),
 		inventory.NewAssetEvent(
 			rdsClassification,
-			"arn:aws:rds:eu-west-1:123:db:db2",
+			inventory.Identifiers(inventory.Arns("arn:aws:rds:eu-west-1:123:db:db2"), inventory.Ids("db2")),
 			"db2",
 			inventory.WithRawAsset(instance2),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_rds_test.go
+++ b/internal/inventory/awsfetcher/fetcher_rds_test.go
@@ -83,7 +83,7 @@ func TestRDSInstanceFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			rdsClassification,
-			inventory.Identifiers(inventory.Arns("arn:aws:rds:eu-west-1:123:db:db1"), inventory.Ids("db1")),
+			[]string{"arn:aws:rds:eu-west-1:123:db:db1", "db1"},
 			"db1",
 			inventory.WithRawAsset(instance1),
 			inventory.WithCloud(inventory.AssetCloud{
@@ -99,7 +99,7 @@ func TestRDSInstanceFetcher_Fetch(t *testing.T) {
 		),
 		inventory.NewAssetEvent(
 			rdsClassification,
-			inventory.Identifiers(inventory.Arns("arn:aws:rds:eu-west-1:123:db:db2"), inventory.Ids("db2")),
+			[]string{"arn:aws:rds:eu-west-1:123:db:db2", "db2"},
 			"db2",
 			inventory.WithRawAsset(instance2),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_s3_bucket.go
+++ b/internal/inventory/awsfetcher/fetcher_s3_bucket.go
@@ -75,7 +75,7 @@ func (s *s3BucketFetcher) Fetch(ctx context.Context, assetChannel chan<- invento
 	for _, bucket := range buckets {
 		assetChannel <- inventory.NewAssetEvent(
 			s3BucketClassification,
-			inventory.Identifiers(inventory.Arns(bucket.GetResourceArn())),
+			[]string{bucket.GetResourceArn()},
 			bucket.GetResourceName(),
 
 			inventory.WithRawAsset(bucket),

--- a/internal/inventory/awsfetcher/fetcher_s3_bucket.go
+++ b/internal/inventory/awsfetcher/fetcher_s3_bucket.go
@@ -75,7 +75,7 @@ func (s *s3BucketFetcher) Fetch(ctx context.Context, assetChannel chan<- invento
 	for _, bucket := range buckets {
 		assetChannel <- inventory.NewAssetEvent(
 			s3BucketClassification,
-			bucket.GetResourceArn(),
+			inventory.Identifiers(inventory.Arns(bucket.GetResourceArn())),
 			bucket.GetResourceName(),
 
 			inventory.WithRawAsset(bucket),

--- a/internal/inventory/awsfetcher/fetcher_s3_bucket_test.go
+++ b/internal/inventory/awsfetcher/fetcher_s3_bucket_test.go
@@ -103,7 +103,7 @@ func TestS3BucketFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			s3BucketClassification,
-			inventory.Identifiers(inventory.Arns("arn:aws:s3:::bucket-1")),
+			[]string{"arn:aws:s3:::bucket-1"},
 			"bucket-1",
 			inventory.WithRawAsset(bucket1),
 			inventory.WithCloud(inventory.AssetCloud{
@@ -138,7 +138,7 @@ func TestS3BucketFetcher_Fetch(t *testing.T) {
 		),
 		inventory.NewAssetEvent(
 			s3BucketClassification,
-			inventory.Identifiers(inventory.Arns("arn:aws:s3:::bucket-2")),
+			[]string{"arn:aws:s3:::bucket-2"},
 			"bucket-2",
 			inventory.WithRawAsset(bucket2),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_s3_bucket_test.go
+++ b/internal/inventory/awsfetcher/fetcher_s3_bucket_test.go
@@ -103,7 +103,7 @@ func TestS3BucketFetcher_Fetch(t *testing.T) {
 	expected := []inventory.AssetEvent{
 		inventory.NewAssetEvent(
 			s3BucketClassification,
-			"arn:aws:s3:::bucket-1",
+			inventory.Identifiers(inventory.Arns("arn:aws:s3:::bucket-1")),
 			"bucket-1",
 			inventory.WithRawAsset(bucket1),
 			inventory.WithCloud(inventory.AssetCloud{
@@ -138,7 +138,7 @@ func TestS3BucketFetcher_Fetch(t *testing.T) {
 		),
 		inventory.NewAssetEvent(
 			s3BucketClassification,
-			"arn:aws:s3:::bucket-2",
+			inventory.Identifiers(inventory.Arns("arn:aws:s3:::bucket-2")),
 			"bucket-2",
 			inventory.WithRawAsset(bucket2),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_sns.go
+++ b/internal/inventory/awsfetcher/fetcher_sns.go
@@ -66,7 +66,7 @@ func (s *snsFetcher) Fetch(ctx context.Context, assetChannel chan<- inventory.As
 	for _, item := range awsResources {
 		assetChannel <- inventory.NewAssetEvent(
 			classification,
-			inventory.Identifiers(inventory.Arns(item.GetResourceArn())),
+			[]string{item.GetResourceArn()},
 			item.GetResourceName(),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_sns.go
+++ b/internal/inventory/awsfetcher/fetcher_sns.go
@@ -66,7 +66,7 @@ func (s *snsFetcher) Fetch(ctx context.Context, assetChannel chan<- inventory.As
 	for _, item := range awsResources {
 		assetChannel <- inventory.NewAssetEvent(
 			classification,
-			item.GetResourceArn(),
+			inventory.Identifiers(inventory.Arns(item.GetResourceArn())),
 			item.GetResourceName(),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_sns_test.go
+++ b/internal/inventory/awsfetcher/fetcher_sns_test.go
@@ -49,7 +49,7 @@ func TestSNSFetcher_Fetch(t *testing.T) {
 				Type:        inventory.TypeNotificationService,
 				SubType:     inventory.SubTypeSNSTopic,
 			},
-			"topic:arn:test-topic",
+			inventory.Identifiers(inventory.Arns("topic:arn:test-topic")),
 			"test-topic",
 			inventory.WithRawAsset(awsResource),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/awsfetcher/fetcher_sns_test.go
+++ b/internal/inventory/awsfetcher/fetcher_sns_test.go
@@ -49,7 +49,7 @@ func TestSNSFetcher_Fetch(t *testing.T) {
 				Type:        inventory.TypeNotificationService,
 				SubType:     inventory.SubTypeSNSTopic,
 			},
-			inventory.Identifiers(inventory.Arns("topic:arn:test-topic")),
+			[]string{"topic:arn:test-topic"},
 			"test-topic",
 			inventory.WithRawAsset(awsResource),
 			inventory.WithCloud(inventory.AssetCloud{

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -124,37 +124,6 @@ func generateIndex(a Entity) string {
 	return fmt.Sprintf(indexTemplate, a.Category, a.SubCategory, a.Type, a.SubType)
 }
 
-type IdentifierEnricher func(EntityIdentifiers) EntityIdentifiers
-
-func Arns(arns ...string) IdentifierEnricher {
-	return func(ei EntityIdentifiers) EntityIdentifiers {
-		arns = removeEmpty(arns)
-		if len(arns) > 0 {
-			ei.Arns = arns
-		}
-		return ei
-	}
-}
-
-func Ids(ids ...string) IdentifierEnricher {
-	return func(ei EntityIdentifiers) EntityIdentifiers {
-		ids = removeEmpty(ids)
-		if len(ids) > 0 {
-			ei.Arns = ids
-		}
-		return ei
-	}
-}
-
-func Identifiers(enrichers ...IdentifierEnricher) EntityIdentifiers {
-	identifiers := EntityIdentifiers{}
-	for _, enrich := range enrichers {
-		identifiers = enrich(identifiers)
-	}
-
-	return identifiers
-}
-
 func (a *AssetInventory) Stop() {
 	close(a.assetCh)
 }

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -40,10 +40,9 @@ func TestAssetInventory_Run(t *testing.T) {
 			Meta:      mapstr.M{libevents.FieldMetaIndex: "logs-cloud_asset_inventory.asset_inventory-infrastructure_compute_virtual-machine_ec2-default"},
 			Timestamp: now(),
 			Fields: mapstr.M{
-				"asset": Asset{
-					UUID: "WH25UKB5ExLpkCAwRJDStPN3U+VGaYg9bF5qKu4L7Ro=",
-					Id:   "arn:aws:ec2:us-east::ec2/234567890",
-					Name: "test-server",
+				"entity": Entity{
+					Identifiers: Identifiers(Arns("arn:aws:ec2:us-east::ec2/234567890")),
+					Name:        "test-server",
 					AssetClassification: AssetClassification{
 						Category:    CategoryInfrastructure,
 						SubCategory: SubCategoryCompute,
@@ -105,7 +104,7 @@ func TestAssetInventory_Run(t *testing.T) {
 				Type:        TypeVirtualMachine,
 				SubType:     SubTypeEC2,
 			},
-			"arn:aws:ec2:us-east::ec2/234567890",
+			Identifiers(Arns("arn:aws:ec2:us-east::ec2/234567890")),
 			"test-server",
 			WithTags(map[string]string{"Name": "test-server", "key": "value"}),
 			WithCloud(AssetCloud{

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -41,8 +41,8 @@ func TestAssetInventory_Run(t *testing.T) {
 			Timestamp: now(),
 			Fields: mapstr.M{
 				"entity": Entity{
-					Identifiers: Identifiers(Arns("arn:aws:ec2:us-east::ec2/234567890")),
-					Name:        "test-server",
+					Id:   []string{"arn:aws:ec2:us-east::ec2/234567890"},
+					Name: "test-server",
 					AssetClassification: AssetClassification{
 						Category:    CategoryInfrastructure,
 						SubCategory: SubCategoryCompute,
@@ -104,7 +104,7 @@ func TestAssetInventory_Run(t *testing.T) {
 				Type:        TypeVirtualMachine,
 				SubType:     SubTypeEC2,
 			},
-			Identifiers(Arns("arn:aws:ec2:us-east::ec2/234567890")),
+			[]string{"arn:aws:ec2:us-east::ec2/234567890"},
 			"test-server",
 			WithTags(map[string]string{"Name": "test-server", "key": "value"}),
 			WithCloud(AssetCloud{

--- a/internal/resources/providers/awslib/iam/iam.go
+++ b/internal/resources/providers/awslib/iam/iam.go
@@ -88,6 +88,7 @@ type User struct {
 	PasswordLastChanged string                 `json:"password_last_changed,omitempty"`
 	MfaActive           bool                   `json:"mfa_active"`
 	PasswordEnabled     bool                   `json:"password_enabled"`
+	UserId              string                 `json:"user_id"`
 }
 
 type AuthDevice struct {

--- a/internal/resources/providers/awslib/iam/user.go
+++ b/internal/resources/providers/awslib/iam/user.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/elastic/cloudbeat/internal/resources/fetching"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
+	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
 )
 
 const (
@@ -110,6 +111,7 @@ func (p Provider) GetUsers(ctx context.Context) ([]awslib.AwsResource, error) {
 			PasswordLastChanged: userAccount.PasswordLastChanged,
 			PasswordEnabled:     pwdEnabled,
 			MfaActive:           userAccount.MfaActive,
+			UserId:              pointers.Deref(apiUser.UserId),
 		})
 	}
 


### PR DESCRIPTION
### Summary of your changes
To comply with https://github.com/elastic/security-team/issues/9798 and be able to correlate multiple datasources, Asset Inventory has changed the `asset` field to `entity` field name, converted `id` to a list and removed the `uuid` earlier introduced


### Related Issues
-  Related https://github.com/elastic/security-team/issues/9798
- Fixes https://github.com/elastic/security-team/issues/9799
- Fixes https://github.com/elastic/security-team/issues/9823


### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)
