### PR TITLE
eks ci - enable config 1

### DIFF
--- a/.github/workflows/eks-ci.yml
+++ b/.github/workflows/eks-ci.yml
@@ -24,7 +24,7 @@ env:
   AWS_REGION: eu-west-2
   REPORTS_DIR: tests/allure/results/
   KUBE_NAMESPACE: kube-system
-  CI_ELASTIC_AGENT_DOCKER_TAG: "8.14.0-SNAPSHOT"
+  CI_ELASTIC_AGENT_DOCKER_TAG: "8.16.0-SNAPSHOT"
   CI_ELASTIC_AGENT_DOCKER_IMAGE: "391946104644.dkr.ecr.eu-west-2.amazonaws.com/elastic-agent"
 
 # run only a single job at a time
@@ -160,11 +160,11 @@ jobs:
       matrix:
         include:
           # GitHub issue: https://github.com/elastic/cloudbeat/issues/2190
-          # - test-target: eks
-          #   range: ""
-          #   values_file: tests/test_environments/values/ci-eks-config-1.yml
-          #   k8s_context: "test-eks-config-1"
-          #   label: "EKS functional tests: config 1"
+          - test-target: eks
+            range: ""
+            values_file: tests/test_environments/values/ci-eks-config-1.yml
+            k8s_context: "test-eks-config-1"
+            label: "EKS functional tests: config 1"
           - test-target: eks
             range: ""
             values_file: tests/test_environments/values/ci-eks-config-2.yml
@@ -193,7 +193,7 @@ jobs:
         id: deploy_helm
         if: success()
         env:
-          ELK_VERSION: 8.13.0-SNAPSHOT
+          ELK_VERSION: 8.16.0-SNAPSHOT
         run: |
           just deploy-tests-helm ${{ matrix.test-target }} ${{ matrix.values_file }} ${{ matrix.range }}
 

--- a/.github/workflows/eks-ci.yml
+++ b/.github/workflows/eks-ci.yml
@@ -24,7 +24,7 @@ env:
   AWS_REGION: eu-west-2
   REPORTS_DIR: tests/allure/results/
   KUBE_NAMESPACE: kube-system
-  CI_ELASTIC_AGENT_DOCKER_TAG: "8.16.0-SNAPSHOT"
+  CI_ELASTIC_AGENT_DOCKER_TAG: "8.14.0-SNAPSHOT"
   CI_ELASTIC_AGENT_DOCKER_IMAGE: "391946104644.dkr.ecr.eu-west-2.amazonaws.com/elastic-agent"
 
 # run only a single job at a time
@@ -159,7 +159,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # GitHub issue: https://github.com/elastic/cloudbeat/issues/2190
           - test-target: eks
             range: ""
             values_file: tests/test_environments/values/ci-eks-config-1.yml
@@ -192,8 +191,6 @@ jobs:
       - name: Deploy tests Helm chart
         id: deploy_helm
         if: success()
-        env:
-          ELK_VERSION: 8.16.0-SNAPSHOT
         run: |
           just deploy-tests-helm ${{ matrix.test-target }} ${{ matrix.values_file }} ${{ matrix.range }}
 

--- a/tests/test_environments/aws/eks_config/test-eks-config-1-node-2-10-kubelet-args.conf
+++ b/tests/test_environments/aws/eks_config/test-eks-config-1-node-2-10-kubelet-args.conf
@@ -1,2 +1,2 @@
 [Service]
-Environment='KUBELET_ARGS=--node-ip=192.168.93.227 --pod-infra-container-image=602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/pause:3.5 --v=2 --cloud-provider=aws --make-iptables-util-chains=false --event-qps=5 --hostname-override'
+Environment='KUBELET_ARGS=--node-ip=192.168.89.114 --pod-infra-container-image=602401143452.dkr.ecr.eu-west-2.amazonaws.com/eks/pause:3.5 --v=2 --cloud-provider=aws --make-iptables-util-chains=false --event-qps=5 --hostname-override'

--- a/tests/test_environments/k8s-cloudbeat-tests/values.yaml
+++ b/tests/test_environments/k8s-cloudbeat-tests/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   name: cloudbeat-test
   repository: cloudbeat-test
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
   ecr: 391946104644.dkr.ecr.eu-west-2.amazonaws.com
@@ -19,7 +19,7 @@ testData:
   clusterConfig: test-eks-config-1
   eksNodes:
     EKS_CONFIG_1_NODE_1: "ip-192-168-29-162.eu-west-2.compute.internal"
-    EKS_CONFIG_1_NODE_2: "ip-192-168-93-227.eu-west-2.compute.internal"
+    EKS_CONFIG_1_NODE_2: "ip-192-168-89-114.eu-west-2.compute.internal"
     EKS_CONFIG_2_NODE_1: "ip-192-168-33-106.eu-west-2.compute.internal"
     EKS_CONFIG_2_NODE_2: "ip-192-168-6-157.eu-west-2.compute.internal"
 
@@ -125,6 +125,9 @@ elasticsearch:
 
   protocol: http
 
+  nodeSelector:
+    "elasticsearch-node": "true"
+
   xpackSecurity:
     enabled: false
 
@@ -170,6 +173,59 @@ elasticsearch:
   labels:
     catf: related
 
+  lifecycle:
+    postStart:
+      exec:
+        command:
+          - bash
+          - -c
+          - |
+            #!/bin/bash
+            ES_URL=http://localhost:9200
+            while [[ "$(curl -s -o /dev/null -w '%{http_code}\n' $ES_URL)" != "200" ]]; do sleep 1; done
+            curl -s -XPUT "$ES_URL/_index_template/common_template" -H 'Content-Type: application/json' -d '{
+              "index_patterns": ["logs-cloud_security_posture.findings*"],
+              "priority": 500,
+              "template": {
+                "mappings": {
+                  "dynamic": false,
+                  "properties": {
+                    "resource": {
+                      "dynamic": false,
+                      "properties": {
+                        "type": { "type": "keyword" }
+                      }
+                    },
+                    "result": {
+                      "dynamic": false,
+                      "properties": {
+                        "evaluation": { "type": "keyword" }
+                      }
+                    },
+                    "rule": {
+                      "dynamic": false,
+                      "properties": {
+                        "benchmark": {
+                          "dynamic": false,
+                          "properties": {
+                            "id": { "type": "keyword" }
+                          }
+                        },
+                        "tags": { "type": "keyword" }
+                      }
+                    },
+                    "agent": {
+                      "dynamic": false,
+                      "properties": {
+                        "id": { "type": "keyword" },
+                        "version": { "type": "keyword" }
+                      }
+                    },
+                    "@timestamp": { "type": "date" }
+                  }
+                }
+              }
+            }'
 
 kibana:
   imageTag: "8.5.0-SNAPSHOT"


### PR DESCRIPTION
### Summary of your changes

After investigating, it was found that the EKS node had been restarted and reverted to its default configuration. After updating the node configuration with custom kubelet settings, the problem was resolved. This PR enables the execution of tests on the EKS config 1 cluster and updates the configuration files used for the EKS cluster.

### Screenshot/Data

[Successful Run](https://github.com/elastic/cloudbeat/actions/runs/10198769627)
