### PR TITLE
Add `related.entities` to asset inventory

### DIFF
--- a/internal/inventory/asset.go
+++ b/internal/inventory/asset.go
@@ -133,7 +133,7 @@ var (
 
 // AssetEvent holds the whole asset
 type AssetEvent struct {
-	Entity           Entity
+	Asset            Asset
 	Network          *AssetNetwork
 	Cloud            *AssetCloud
 	Host             *AssetHost
@@ -141,8 +141,8 @@ type AssetEvent struct {
 	ResourcePolicies []AssetResourcePolicy
 }
 
-// Entity contains the identifiers of the asset
-type Entity struct {
+// Asset contains the identifiers of the asset
+type Asset struct {
 	Id   []string `json:"id"`
 	Name string   `json:"name"`
 	AssetClassification
@@ -233,7 +233,7 @@ type AssetEnricher func(asset *AssetEvent)
 
 func NewAssetEvent(c AssetClassification, ids []string, name string, enrichers ...AssetEnricher) AssetEvent {
 	a := AssetEvent{
-		Entity: Entity{
+		Asset: Asset{
 			Id:                  removeEmpty(ids),
 			Name:                name,
 			AssetClassification: c,
@@ -249,7 +249,7 @@ func NewAssetEvent(c AssetClassification, ids []string, name string, enrichers .
 
 func WithRawAsset(raw any) AssetEnricher {
 	return func(a *AssetEvent) {
-		a.Entity.Raw = &raw
+		a.Asset.Raw = &raw
 	}
 }
 
@@ -259,7 +259,7 @@ func WithTags(tags map[string]string) AssetEnricher {
 			return
 		}
 
-		a.Entity.Tags = tags
+		a.Asset.Tags = tags
 	}
 }
 

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -104,15 +104,16 @@ func (a *AssetInventory) Run(ctx context.Context) {
 func (a *AssetInventory) publish(assets []AssetEvent) {
 	events := lo.Map(assets, func(e AssetEvent, _ int) beat.Event {
 		return beat.Event{
-			Meta:      mapstr.M{libevents.FieldMetaIndex: generateIndex(e.Entity)},
+			Meta:      mapstr.M{libevents.FieldMetaIndex: generateIndex(e.Asset)},
 			Timestamp: a.now(),
 			Fields: mapstr.M{
-				"entity":            e.Entity,
+				"asset":             e.Asset,
 				"cloud":             e.Cloud,
 				"host":              e.Host,
 				"network":           e.Network,
 				"iam":               e.IAM,
 				"resource_policies": e.ResourcePolicies,
+				"related.entities":  e.Asset.Id,
 			},
 		}
 	})
@@ -120,7 +121,7 @@ func (a *AssetInventory) publish(assets []AssetEvent) {
 	a.publisher.PublishAll(events)
 }
 
-func generateIndex(a Entity) string {
+func generateIndex(a Asset) string {
 	return fmt.Sprintf(indexTemplate, a.Category, a.SubCategory, a.Type, a.SubType)
 }
 

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -40,7 +40,7 @@ func TestAssetInventory_Run(t *testing.T) {
 			Meta:      mapstr.M{libevents.FieldMetaIndex: "logs-cloud_asset_inventory.asset_inventory-infrastructure_compute_virtual-machine_ec2-instance-default"},
 			Timestamp: now(),
 			Fields: mapstr.M{
-				"entity": Entity{
+				"asset": Asset{
 					Id:   []string{"arn:aws:ec2:us-east::ec2/234567890"},
 					Name: "test-server",
 					AssetClassification: AssetClassification{
@@ -85,6 +85,7 @@ func TestAssetInventory_Run(t *testing.T) {
 						Resource:  []string{"s3/bucket"},
 					},
 				},
+				"related.entities": []string{"arn:aws:ec2:us-east::ec2/234567890"},
 			},
 		},
 	}


### PR DESCRIPTION
### Summary of your changes

- Rollback the previous changes of having asset renamed to entity, because there is no final decision of how should the field be named.
- Add `related.entities` field directly on `inventory.go`. I considered having another structure called `Related` that would the field `entities`. I didn't do it because I don't believe we should duplicate this data, `Asset.Id` is the source of truth, having a duplicated slice could lead to inconsistency, and even if we have a reference, seems like overcomplicating. I considered this `related.entities` as an ECS related concern. The `asset.go` map the domain used inside cloudbeat, and `inventory.go` is dealing with elasticsearch integration, ecs concern and so on. Of course we map the Asset to match ECS, we shouldn't have data translation layers here. But on this subject I decided to implement on inventory. I'm open to hear different opinions.

#### Screenshots
<img width="2558" alt="image" src="https://github.com/user-attachments/assets/79b2b78c-cbc6-4b91-92ad-466d5c5538c0">


### Related Issues
- Closes https://github.com/elastic/security-team/issues/10080