### PR TITLE
Rename from `related.entities` to `related.entity`

### DIFF
--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -113,7 +113,7 @@ func (a *AssetInventory) publish(assets []AssetEvent) {
 				"network":           e.Network,
 				"iam":               e.IAM,
 				"resource_policies": e.ResourcePolicies,
-				"related.entities":  e.Asset.Id,
+				"related.entity":    e.Asset.Id,
 			},
 		}
 	})

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -85,7 +85,7 @@ func TestAssetInventory_Run(t *testing.T) {
 						Resource:  []string{"s3/bucket"},
 					},
 				},
-				"related.entities": []string{"arn:aws:ec2:us-east::ec2/234567890"},
+				"related.entity": []string{"arn:aws:ec2:us-east::ec2/234567890"},
 			},
 		},
 	}


### PR DESCRIPTION
### Summary of your changes
Based on product decision we are moving away from `related.entities` and towards `related.entity`


### Related Issues
- Related https://github.com/elastic/security-team/issues/10080
- Related https://github.com/elastic/cloudbeat/pull/2379
- Counterpart of https://github.com/elastic/integrations/pull/10719