### PR TITLE
Temporarily disable long running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 name: Tests
 
 on:
-  pull_request_target:
-    branches:
-      - main
-      - "[0-9]+.[0-9]+"
-    types: [opened, synchronize, reopened]
+  # Temporary disabled, will be solved by https://github.com/elastic/security-team/issues/9129
+  # pull_request_target:
+  #   branches:
+  #     - main
+  #     - "[0-9]+.[0-9]+"
+  #   types: [opened, synchronize, reopened]
   push:
     branches:
       - main


### PR DESCRIPTION
### Summary of your changes

Before this change all the PRs were executing these long running jobs, on avg ~15min each run. But the branch with the changes was not the one being tested, rather just main, therefore wasting time and resource. With the ticket https://github.com/elastic/security-team/issues/9129 we will solve this issue. But in the meanwhile, we are disabling these jobs.
