### PR TITLE
fix terraform output values

### DIFF
--- a/deploy/test-environments/output.tf
+++ b/deploy/test-environments/output.tf
@@ -38,17 +38,17 @@ output "ec2_cspm_key" {
 }
 
 output "ec2_cloudtrail_ssh_cmd" {
-  value     = module.aws_ec2_for_cloudtrail.cloudbeat_ssh_cmd
+  value     = var.cdr_infra ? module.aws_ec2_for_cloudtrail.cloudbeat_ssh_cmd : null
   sensitive = true
 }
 
 output "ec2_cloudtrail_public_ip" {
-  value     = module.aws_ec2_for_cloudtrail.aws_instance_cloudbeat_public_ip
+  value     = var.cdr_infra ? module.aws_ec2_for_cloudtrail.aws_instance_cloudbeat_public_ip : null
   sensitive = true
 }
 
 output "ec2_cloudtrail_key" {
-  value     = module.aws_ec2_for_cloudtrail.ec2_ssh_key
+  value     = var.cdr_infra ? module.aws_ec2_for_cloudtrail.ec2_ssh_key : null
   sensitive = true
 }
 # =============================================================


### PR DESCRIPTION
### Summary of your changes

This PR fixes the output values. Since the CloudTrail EC2 machine is optional, the output parameters should not be displayed if it is not deployed.


### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
