### PR TITLE
GA: disable cache restore

### DIFF
--- a/.github/actions/hermit/action.yml
+++ b/.github/actions/hermit/action.yml
@@ -8,6 +8,18 @@ inputs:
 runs:
   using: composite
   steps:
+    - id: free-disk
+      name: Free Disk Space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: true
+
     - id: hermit-hash
       shell: bash
       run: |
@@ -28,8 +40,6 @@ runs:
           ~/.cache/pypoetry
           ~/.cache/pre-commit
         key: ci-hermit-env-${{ runner.os }}-${{ steps.hermit-hash.outputs.hash }}
-        restore-keys: |
-          ci-hermit-env-${{ runner.os }}
 
     - id: cache-go-deps
       uses: actions/cache@v4
@@ -37,8 +47,6 @@ runs:
         path: |
           ~/go/pkg/
         key: ci-go-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
-        restore-keys: |
-          ci-go-deps-${{ runner.os }}-${{ runner.arch }}
 
     - name: Initialize hermit
       shell: bash


### PR DESCRIPTION
### Summary of your changes
Disable GA cache restore and add `free-disk` step for each CI job.


### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
Fixes: https://github.com/elastic/cloudbeat/issues/2446

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
