### PR TITLE
Add missing client to posture flavor

### DIFF
--- a/internal/flavors/posture.go
+++ b/internal/flavors/posture.go
@@ -86,6 +86,7 @@ func newPostureFromCfg(b *beat.Beat, cfg *config.Config) (*posture, error) {
 			publisher: publisher,
 			config:    cfg,
 			log:       log,
+			client:    client,
 		},
 		benchmark: bench,
 	}, nil

--- a/internal/flavors/vulnerability.go
+++ b/internal/flavors/vulnerability.go
@@ -93,6 +93,7 @@ func NewVulnerability(b *beat.Beat, cfg *agentconfig.C) (beat.Beater, error) {
 		publisher: publisher,
 		config:    c,
 		log:       log,
+		client:    client,
 	}
 
 	bt := &vulnerability{


### PR DESCRIPTION
https://github.com/elastic/cloudbeat/blob/main/internal/flavors/posture.go#L111 is panic once a config update is received.

Tested by adding the following snippet to simulate a real update:

`internal/launcher/launcher.go:134`
```go

	go func() {
		l.log.Info("Starting force reload")
		time.Sleep(2 * time.Minute)
		l.log.Info("Force reloading")
		l.reloader.(*Listener).Reload([]*reload.ConfigWithMeta{{Config: config.NewConfig()}})
	}()

```

By debugging I noticed the client was `nil`, and once I assigned it, posture would stop as expected (and config be updated).

### Related
- Closes https://github.com/elastic/cloudbeat/issues/2217