### PR TITLE
Add more GCP assets inventory classifications

### DIFF
--- a/internal/inventory/ASSETS.md
+++ b/internal/inventory/ASSETS.md
@@ -162,9 +162,9 @@ Infrastructure: 27% (12/43)
 
 ## GCP Resources
 
-**Progress: 36% (9/25)**
-Identity: 50% (2/4)
-Infrastructure: 35% (7/20)
+**Progress: 56% (14/25)**
+Identity: 75% (3/4)
+Infrastructure: 55% (11/20)
 Management: 0% (0/1)
 
 <details> <summary>Full table</summary>
@@ -172,12 +172,12 @@ Management: 0% (0/1)
 | Category | SubCategory | Type | SubType | Implemented? |
 |---|---|---|---|---|
 | Identity | Access Management | IAM Policy | GCP IAM Policy | No ❌ |
-| Identity | Access Management | IAM Role | GCP IAM Role | No ❌ |
+| Identity | Access Management | IAM Role | GCP IAM Role | Yes ✅ |
 | Identity | Service Identity | Service Account Key | GCP Service Account Key | Yes ✅ |
 | Identity | Service Identity | Service Account | GCP Service Account | Yes ✅ |
 | Infrastructure | Compute | Virtual Machine | GCP Instance | Yes ✅ |
-| Infrastructure | Container | Orchestration | GKE Cluster | No ❌ |
-| Infrastructure | Container | Serverless | GCP Cloud Run Service | No ❌ |
+| Infrastructure | Container | Orchestration | GKE Cluster | Yes ✅ |
+| Infrastructure | Container | Serverless | GCP Cloud Run Service | Yes ✅ |
 | Infrastructure | Management | Cloud Account | GCP Organization | Yes ✅ |
 | Infrastructure | Management | Cloud Account | GCP Project | Yes ✅ |
 | Infrastructure | Management | Resource Hierarchy | GCP Folder | Yes ✅ |
@@ -188,12 +188,12 @@ Management: 0% (0/1)
 | Infrastructure | Network | Firewall | GCP Network Tag | No ❌ |
 | Infrastructure | Network | IP Address Range | IP Range | No ❌ |
 | Infrastructure | Network | Load Balancing | GCP Compute Target Pool | No ❌ |
-| Infrastructure | Network | Load Balancing | GCP Forwarding Rule | No ❌ |
+| Infrastructure | Network | Load Balancing | GCP Forwarding Rule | Yes ✅ |
 | Infrastructure | Network | Network Interface | GCP Network Interface | No ❌ |
 | Infrastructure | Network | Network Interface | GCP Network Interface Access Config | No ❌ |
 | Infrastructure | Network | Subnet | GCP Subnet | Yes ✅ |
 | Infrastructure | Network | Virtual Network | GCP VPC | No ❌ |
-| Infrastructure | Serverless | Function | GCP Cloud Function | No ❌ |
+| Infrastructure | Serverless | Function | GCP Cloud Function | Yes ✅ |
 | Infrastructure | Storage | Object Storage | GCP Bucket | Yes ✅ |
 | Management | Resource Management | Label | GCP Bucket Label | No ❌ |
 

--- a/internal/inventory/asset.go
+++ b/internal/inventory/asset.go
@@ -29,18 +29,20 @@ const (
 type AssetSubCategory string
 
 const (
-	SubCategoryApplication     AssetSubCategory = "application"
-	SubCategoryAuthorization   AssetSubCategory = "authorization"
-	SubCategoryCompute         AssetSubCategory = "compute"
-	SubCategoryContainer       AssetSubCategory = "container"
-	SubCategoryDatabase        AssetSubCategory = "database"
-	SubCategoryDigitalIdentity AssetSubCategory = "digital-identity"
-	SubCategoryIntegration     AssetSubCategory = "integration"
-	SubCategoryManagement      AssetSubCategory = "management"
-	SubCategoryMessaging       AssetSubCategory = "messaging"
-	SubCategoryNetwork         AssetSubCategory = "network"
-	SubCategoryStorage         AssetSubCategory = "storage"
-	SubCategoryServiceIdentity AssetSubCategory = "service-identity"
+	SubCategoryApplication      AssetSubCategory = "application"
+	SubCategoryAuthorization    AssetSubCategory = "authorization"
+	SubCategoryCompute          AssetSubCategory = "compute"
+	SubCategoryContainer        AssetSubCategory = "container"
+	SubCategoryDatabase         AssetSubCategory = "database"
+	SubCategoryDigitalIdentity  AssetSubCategory = "digital-identity"
+	SubCategoryIntegration      AssetSubCategory = "integration"
+	SubCategoryManagement       AssetSubCategory = "management"
+	SubCategoryMessaging        AssetSubCategory = "messaging"
+	SubCategoryNetwork          AssetSubCategory = "network"
+	SubCategoryStorage          AssetSubCategory = "storage"
+	SubCategoryServiceIdentity  AssetSubCategory = "service-identity"
+	SubCategoryAccessManagement AssetSubCategory = "access-management"
+	SubCategoryServerless       AssetSubCategory = "serverless"
 )
 
 // AssetType is used to build the document index. Use only numbers, letters and dashes (-)
@@ -76,6 +78,10 @@ const (
 	TypeServiceAccount      AssetType = "service-account"
 	TypeServiceAccountKey   AssetType = "service-account-key"
 	TypeResourceHierarchy   AssetType = "resource-hierarchy"
+	TypeOrchestration       AssetType = "orchestration"
+	TypeFunction            AssetType = "function"
+	TypeLoadBalancing       AssetType = "load-balancing"
+	TypeIamRole             AssetType = "iam-role"
 )
 
 // AssetSubType is used to build the document index. Use only numbers, letters and dashes (-)
@@ -128,6 +134,11 @@ const (
 	SubTypeGcpFolder                AssetSubType = "gcp-folder"
 	SubTypeGcpServiceAccount        AssetSubType = "gcp-service-account"
 	SubTypeGcpServiceAccountKey     AssetSubType = "gcp-service-account-key"
+	SubTypeGcpGkeCluster            AssetSubType = "gke-cluster"
+	SubTypeGcpForwardingRule        AssetSubType = "gcp-forwarding-rule"
+	SubTypeGcpCloudFunction         AssetSubType = "gcp-cloud-function"
+	SubTypeGcpCloudRunService       AssetSubType = "gcp-cloud-run-service"
+	SubTypeGcpIamRole               AssetSubType = "gcp-iam-role"
 )
 
 const (
@@ -196,6 +207,12 @@ var (
 	AssetClassificationGcpSubnet            = AssetClassification{Category: CategoryInfrastructure, SubCategory: SubCategoryNetwork, Type: TypeSubnet, SubType: SubTypeGcpSubnet}
 	AssetClassificationGcpServiceAccount    = AssetClassification{Category: CategoryIdentity, SubCategory: SubCategoryServiceIdentity, Type: TypeServiceAccount, SubType: SubTypeGcpServiceAccount}
 	AssetClassificationGcpServiceAccountKey = AssetClassification{Category: CategoryIdentity, SubCategory: SubCategoryServiceIdentity, Type: TypeServiceAccountKey, SubType: SubTypeGcpServiceAccountKey}
+
+	AssetClassificationGcpGkeCluster      = AssetClassification{Category: CategoryInfrastructure, SubCategory: SubCategoryContainer, Type: TypeOrchestration, SubType: SubTypeGcpGkeCluster}
+	AssetClassificationGcpForwardingRule  = AssetClassification{Category: CategoryInfrastructure, SubCategory: SubCategoryNetwork, Type: TypeLoadBalancing, SubType: SubTypeGcpForwardingRule}
+	AssetClassificationGcpIamRole         = AssetClassification{Category: CategoryIdentity, SubCategory: SubCategoryAccessManagement, Type: TypeIamRole, SubType: SubTypeGcpIamRole}
+	AssetClassificationGcpCloudFunction   = AssetClassification{Category: CategoryInfrastructure, SubCategory: SubCategoryServerless, Type: TypeFunction, SubType: SubTypeGcpCloudFunction}
+	AssetClassificationGcpCloudRunService = AssetClassification{Category: CategoryInfrastructure, SubCategory: SubCategoryContainer, Type: TypeServerless, SubType: SubTypeGcpCloudRunService}
 )
 
 // AssetEvent holds the whole asset

--- a/internal/inventory/gcpfetcher/fetcher_assets.go
+++ b/internal/inventory/gcpfetcher/fetcher_assets.go
@@ -50,6 +50,10 @@ var ResourcesToFetch = []ResourcesClassification{
 	{gcpinventory.ComputeSubnetworkAssetType, inventory.AssetClassificationGcpSubnet},
 	{gcpinventory.IamServiceAccountAssetType, inventory.AssetClassificationGcpServiceAccount},
 	{gcpinventory.IamServiceAccountKeyAssetType, inventory.AssetClassificationGcpServiceAccountKey},
+	{gcpinventory.GkeClusterAssetType, inventory.AssetClassificationGcpGkeCluster},
+	{gcpinventory.ComputeForwardingRuleAssetType, inventory.AssetClassificationGcpForwardingRule},
+	{gcpinventory.CloudFunctionAssetType, inventory.AssetClassificationGcpCloudFunction},
+	{gcpinventory.CloudRunService, inventory.AssetClassificationGcpCloudRunService},
 }
 
 func newAssetsInventoryFetcher(logger *logp.Logger, provider inventoryProvider) inventory.AssetFetcher {

--- a/internal/resources/providers/gcplib/inventory/asset.go
+++ b/internal/resources/providers/gcplib/inventory/asset.go
@@ -43,4 +43,9 @@ const (
 	MonitoringAlertPolicyAssetType = "monitoring.googleapis.com/AlertPolicy"
 	DnsPolicyAssetType             = "dns.googleapis.com/Policy"
 	ServiceUsageAssetType          = "serviceusage.googleapis.com/Service"
+	GkeClusterAssetType            = "container.googleapis.com/Cluster"
+	ComputeForwardingRuleAssetType = "compute.googleapis.com/ForwardingRule"
+	IamRoleAssetType               = "iam.googleapis.com/Role"
+	CloudFunctionAssetType         = "cloudfunctions.googleapis.com/CloudFunction"
+	CloudRunService                = "run.googleapis.com/Service"
 )


### PR DESCRIPTION
### Summary of your changes

adds the rest of assets types `gcplib` can fetch using GCP assets inventory api

### Related Issues
- needs to be merged first https://github.com/elastic/cloudbeat/pull/2460
- closes https://github.com/elastic/security-team/issues/10431

