### PR TITLE
Add cloudbeat.spec to DRA

### DIFF
--- a/cloudbeat.spec.yml
+++ b/cloudbeat.spec.yml
@@ -1,0 +1,95 @@
+version: 2
+inputs:
+  - name: cloudbeat
+    description: "Cloudbeat"
+    platforms: &platforms
+      - linux/amd64
+      - linux/arm64
+      - darwin/amd64
+      - darwin/arm64
+      - container/amd64
+      - container/arm64
+    outputs: &outputs
+      - elasticsearch
+      - kafka
+      - logstash
+      - redis
+    command: &command
+      restart_monitoring_period: 5s
+      maximum_restarts_per_period: 1
+      timeouts:
+        restart: 1s
+      args:
+        - "-E"
+        - "setup.ilm.enabled=false"
+        - "-E"
+        - "setup.template.enabled=false"
+        - "-E"
+        - "management.enabled=true"
+        - "-E"
+        - "management.restart_on_output_change=true"
+        - "-E"
+        - "logging.level=info"
+        - "-E"
+        - "logging.to_stderr=true"
+        - "-E"
+        - "gc_percent=${CLOUDBEAT_GOGC:100}"
+        - "-E"
+        - "logging.event_data.to_stderr=true"
+        - "-E"
+        - "logging.event_data.to_files=false"
+    isolate_units: true
+  - name: cloudbeat/cis_k8s
+    description: "CIS Kubernetes monitoring"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+    isolate_units: true
+  - name: cloudbeat/cis_eks
+    description: "CIS elastic Kubernetes monitoring"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+    isolate_units: true
+  - name: cloudbeat/cis_aws
+    description: "CIS AWS monitoring"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+    isolate_units: true
+  - name: cloudbeat/cis_gcp
+    description: "CIS GCP monitoring"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+    isolate_units: true
+  - name: cloudbeat/cis_azure
+    description: "CIS AZURE monitoring"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+    isolate_units: true
+  - name: cloudbeat/vuln_mgmt_aws
+    description: "AWS Vulnerabilities management"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+    isolate_units: true
+  - name: cloudbeat/asset_inventory_aws
+    description: "AWS Asset Inventory Discovery"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+    isolate_units: true
+  - name: cloudbeat/asset_inventory_azure
+    description: "Azure Asset Inventory Discovery"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+    isolate_units: true
+  - name: cloudbeat/asset_inventory_gcp
+    description: "GCP Asset Inventory Discovery"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+    isolate_units: true

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -7,6 +7,7 @@ RUN set -x && \
 
 COPY ./cloudbeat /cloudbeat
 COPY ./cloudbeat.yml /cloudbeat.yml
+COPY ./cloudbeat.spec.yml /cloudbeat.spec.yml
 COPY ./bundle.tar.gz /bundle.tar.gz
 
 ENTRYPOINT ["/cloudbeat"]

--- a/deploy/Dockerfile.debug
+++ b/deploy/Dockerfile.debug
@@ -11,6 +11,7 @@ EXPOSE 8080
 
 COPY ./cloudbeat /cloudbeat
 COPY ./cloudbeat.yml /cloudbeat.yml
+COPY ./cloudbeat.spec.yml /cloudbeat.spec.yml
 COPY ./bundle.tar.gz /bundle.tar.gz
 
 ENTRYPOINT ["/go/bin/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "--wd=/", "exec", "/cloudbeat"]

--- a/scripts/packaging/docker/elastic-agent/Dockerfile
+++ b/scripts/packaging/docker/elastic-agent/Dockerfile
@@ -4,6 +4,7 @@ FROM ${ELASTIC_AGENT_IMAGE} as elastic_agent_cloudbeat
 COPY --chown=elastic-agent:elastic-agent --chmod=755 cloudbeat /tmp/components/cloudbeat
 COPY --chown=elastic-agent:elastic-agent --chmod=666 bundle.tar.gz /tmp/components/bundle.tar.gz
 COPY --chown=elastic-agent:elastic-agent --chmod=644 cloudbeat.yml /tmp/components/cloudbeat.yml
+COPY --chown=elastic-agent:elastic-agent --chmod=644 cloudbeat.spec.yml /tmp/components/cloudbeat.spec.yml
 
 RUN mv /tmp/components/* "$(dirname "$(realpath "$(which elastic-agent)")")"/components/
 


### PR DESCRIPTION
### Summary of your changes

it's better to maintain this file in our repo than on the elastic-agent repo
[came up](https://github.com/elastic/elastic-agent/pull/5422#discussion_r1747713828) during an update to add `cloudbeat/asset_inventory_gcp` input, which is also included in this PR 

### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

