### PR TITLE
Fix GCP asset inventory CI

### DIFF
--- a/.github/actions/gcp-asset-inventory-ci/action.yml
+++ b/.github/actions/gcp-asset-inventory-ci/action.yml
@@ -35,9 +35,10 @@ runs:
       run: |
         ./cloudbeat -c deploy/asset-inventory/cloudbeat-gcp-asset-inventory.yml -d '*' &
 
-    - name: Wait for cloudbeat to send some events
-      shell: bash
-      run: sleep 20
+    - name: Wait for data
+      uses: ./.github/actions/wait-for-es-data
+      with:
+        index: .ds-logs-cloud_asset_inventory.asset_inventory-*
 
     - name: Check for assets
       working-directory: ./tests

--- a/.github/actions/wait-for-es-data/action.yml
+++ b/.github/actions/wait-for-es-data/action.yml
@@ -1,0 +1,35 @@
+name: "Wait for ES Data"
+description: "Waits for data on ES indices"
+inputs:
+  index:
+    description: "Which ES index to look at"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for data
+      env:
+        ES_HOST: http://localhost:9200
+      shell: bash
+      run: |
+        URL="${ES_HOST}/${{ inputs.index }}/_search?size=0"
+        HEADER="Content-Type: application/json"
+        MAX_RETRIES=100
+
+        echo "Checking index: ${{ inputs.index }}"
+
+        for ((i = 1; i <= MAX_RETRIES; i++)); do
+            result=$(curl -s -X GET "$URL" -H "$HEADER" | jq '.hits.total.value')
+
+            if [ "$result" -gt 0 ]; then
+                echo "Data found: $result documents in index ${{ inputs.index }}"
+                exit 0
+            fi
+
+            echo "No data yet. Retrying in 1s... ($i/$MAX_RETRIES)"
+            sleep 1
+        done
+
+        echo "No data found after $MAX_RETRIES retries."
+        exit 1

--- a/.github/actions/wait-for-es-data/action.yml
+++ b/.github/actions/wait-for-es-data/action.yml
@@ -4,18 +4,22 @@ inputs:
   index:
     description: "Which ES index to look at"
     required: true
+  es_host:
+    description: "the ES host URL"
+    default: "http://localhost:9200"
+  retries:
+    description: "How many times to retry checking for data. (1s interval)"
+    default: "100"
 
 runs:
   using: composite
   steps:
     - name: Wait for data
-      env:
-        ES_HOST: http://localhost:9200
       shell: bash
       run: |
-        URL="${ES_HOST}/${{ inputs.index }}/_search?size=0"
+        URL="${{inputs.es_host}}/${{ inputs.index }}/_search?size=0"
         HEADER="Content-Type: application/json"
-        MAX_RETRIES=100
+        MAX_RETRIES=${{inputs.retries}}
 
         echo "Checking index: ${{ inputs.index }}"
 


### PR DESCRIPTION
### Summary of your changes

the failing test case seems to be a matter of timing. 

checking for data after 20 seconds - [fails](https://github.com/elastic/cloudbeat/actions/runs/10870390768/job/30162939379?pr=2528#step:4:438)
checking for data after 40 seconds - [succeeds](https://github.com/elastic/cloudbeat/actions/runs/10870322998/job/30162805992)

not sure why this started happening consistently just now, could be [gcp updates](https://github.com/elastic/cloudbeat/pull/2486/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R92) but i'm not sure i see something definitive in the [changelog](https://github.com/googleapis/google-cloud-go/releases?q=auth&expanded=true)

instead of just bumping the sleep period, i've added a new action - `wait-for-es-data` which is essentially the same thing but checks the index every 1s and if we have data it goes on to the next step (run the tests).  - [successful run](https://github.com/elastic/cloudbeat/actions/runs/10878341142/job/30181124690?pr=2528)


