### PR TITLE
Fix GCP deployment manager formatting

### DIFF
--- a/deploy/deployment-manager/deploy_service_account.sh
+++ b/deploy/deployment-manager/deploy_service_account.sh
@@ -35,7 +35,7 @@ fi
 
 result="$(gcloud deployment-manager deployments create --automatic-rollback-on-error "${DEPLOYMENT_NAME}" --project "${PROJECT_NAME}" \
     --template service_account.py \
-    --properties scope:"${SCOPE}",parentId:"${PARENT_ID}",serviceAccountName:"${SERVICE_ACCOUNT_NAME}")"
+    --properties "scope:'${SCOPE}',parentId:'${PARENT_ID}',serviceAccountName:'${SERVICE_ACCOUNT_NAME}'")"
 
 key="$(echo "$result" | awk '/serviceAccountKey/{getline; print}' | awk '{print $2}')"
 

--- a/deploy/deployment-manager/service_account.py
+++ b/deploy/deployment-manager/service_account.py
@@ -14,7 +14,7 @@ def generate_config(context):
         "name": sa_name,
         "type": "iam.v1.serviceAccount",
         "properties": {
-            "accountId": sa_name,
+            "accountId": f"{sa_name}-id",
             "displayName": "Elastic agent service account for CSPM",
             "projectId": context.env["project"],
         },


### PR DESCRIPTION
### Summary of your changes

there were 2 issues preventing GCP CSPM on agentless from successfully deploying a service account for organizations. the first was a slightly off copy-paste command in [kibana](https://github.com/elastic/kibana/pull/192959) which ended up not passing `ORG_ID` to the deployment script, so the deployment assumed it's for a project. the second issue, after providing `ORG_ID`, the deployment script complained about it being a number and not a string (as per its schema). this is what this PR fixes.

after fixing both of these, i've deployed GCP CSPM on agentless and got findings for an organization account:

### Screenshot/Data
![Screenshot 2024-09-15 at 17 59 46](https://github.com/user-attachments/assets/fa5addce-9817-4e77-97ab-6a566644f6ad)


### Related Issues
 - fixes https://github.com/elastic/cloudbeat/issues/2502

