### PR TITLE
Handle password policy not found error

### DIFF
--- a/internal/resources/providers/awslib/iam/password_policy.go
+++ b/internal/resources/providers/awslib/iam/password_policy.go
@@ -41,10 +41,7 @@ func (p Provider) GetPasswordPolicy(ctx context.Context) (awslib.AwsResource, er
 			return &PasswordPolicy{}, nil
 		}
 
-		p.log.Infof("Debug the error %+v", err)
-
 		return nil, err
-
 	}
 
 	policy := output.PasswordPolicy

--- a/internal/resources/providers/awslib/iam/password_policy.go
+++ b/internal/resources/providers/awslib/iam/password_policy.go
@@ -19,8 +19,10 @@ package iam
 
 import (
 	"context"
+	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 
 	"github.com/elastic/cloudbeat/internal/resources/fetching"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
@@ -30,7 +32,19 @@ func (p Provider) GetPasswordPolicy(ctx context.Context) (awslib.AwsResource, er
 	output, err := p.client.GetAccountPasswordPolicy(ctx, &iam.GetAccountPasswordPolicyInput{})
 	if err != nil {
 		p.log.Debug("Failed to get account password policy: %v", err)
+
+		// AWS error reference https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetAccountPasswordPolicy.html
+		var awsErr *types.NoSuchEntityException
+		if errors.As(err, &awsErr) {
+			// Reasoning behind this debug line https://github.com/elastic/cloudbeat/issues/1751
+			p.log.Debug("Returning empty password policy because 'password policy not found' is not a valid response. The account has a default password policy")
+			return &PasswordPolicy{}, nil
+		}
+
+		p.log.Infof("Debug the error %+v", err)
+
 		return nil, err
+
 	}
 
 	policy := output.PasswordPolicy

--- a/internal/resources/providers/awslib/iam/password_policy_test.go
+++ b/internal/resources/providers/awslib/iam/password_policy_test.go
@@ -24,9 +24,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/smithy-go/ptr"
-	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 )
 
 func Test_GetPasswordPolicy(t *testing.T) {

--- a/internal/resources/providers/awslib/iam/password_policy_test.go
+++ b/internal/resources/providers/awslib/iam/password_policy_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package iam
 
 import (

--- a/internal/resources/providers/awslib/iam/password_policy_test.go
+++ b/internal/resources/providers/awslib/iam/password_policy_test.go
@@ -1,0 +1,89 @@
+package iam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/smithy-go/ptr"
+	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GetPasswordPolicy(t *testing.T) {
+	tcs := []struct {
+		tcName    string
+		expectErr bool
+		mockErr   error
+		mockRes   *iam.GetAccountPasswordPolicyOutput
+		expected  awslib.AwsResource
+	}{
+		{
+			tcName:    "Happy path",
+			expectErr: false,
+			mockErr:   nil,
+			mockRes: &iam.GetAccountPasswordPolicyOutput{
+				PasswordPolicy: &types.PasswordPolicy{
+					PasswordReusePrevention:    ptr.Int32(24),
+					MaxPasswordAge:             ptr.Int32(90),
+					MinimumPasswordLength:      ptr.Int32(16),
+					RequireLowercaseCharacters: true,
+					RequireUppercaseCharacters: true,
+					RequireNumbers:             true,
+					RequireSymbols:             true,
+				},
+			},
+			expected: &PasswordPolicy{
+				ReusePreventionCount: 24,
+				RequireLowercase:     true,
+				RequireUppercase:     true,
+				RequireNumbers:       true,
+				RequireSymbols:       true,
+				MaxAgeDays:           90,
+				MinimumLength:        16,
+			},
+		},
+
+		{
+			tcName:    "NoSuchEntityException",
+			expectErr: false,
+			mockErr:   &types.NoSuchEntityException{},
+			mockRes:   nil,
+			expected:  &PasswordPolicy{},
+		},
+
+		{
+			tcName:    "MalformedPolicyDocumentException",
+			expectErr: true,
+			mockErr:   &types.MalformedPolicyDocumentException{},
+			mockRes:   nil,
+			expected:  nil,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.tcName, func(t *testing.T) {
+			ctx := context.Background()
+			log := logp.NewLogger("test")
+			client := &MockClient{}
+			provider := Provider{
+				log:                   log,
+				client:                client,
+				accessAnalyzerClients: nil,
+			}
+
+			client.EXPECT().GetAccountPasswordPolicy(ctx, &iam.GetAccountPasswordPolicyInput{}).Return(tc.mockRes, tc.mockErr)
+			pp, err := provider.GetPasswordPolicy(ctx)
+
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expected, pp)
+		})
+	}
+}


### PR DESCRIPTION
### Summary of your changes

There is a bug on aws (based on After reading https://github.com/aws/aws-cli/issues/7265 and https://github.com/aws/aws-cli/issues/8402 reading), which in case of a user deleting the password policy, an `NoSuchEntityException ` will be thrown - while that isn't true because password policies have default values in place.

The impact of such a bug to us is that we receive the API error, log the error and doesn't evaluate the policy on OPA layer, missing this finding on such case.

This PR handles the error, and in case of `NoSuchEntityException`, creates an empty password policy, which will then fail on the OPA layer.

it's important to notice, tho that an empty password policy doesn't represent reality, because there is a password policy in place, it just isn't returned

### Screenshot/Data
Manual Test of the aws bug
![image](https://github.com/user-attachments/assets/7e516526-80ec-4e58-b8ca-7b81066871b9)

Proof that we have a failing finding if the password policy is deleted
<img width="1912" alt="image" src="https://github.com/user-attachments/assets/2b756465-a157-4005-9e56-1b4f99882477">


### Related Issues
- Related: https://github.com/elastic/cloudbeat/issues/1751

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works