### PR TITLE
Fix `too-many-positional-arguments` error

### DIFF
--- a/tests/pylintrc
+++ b/tests/pylintrc
@@ -163,6 +163,7 @@ disable=raw-checker-failed,
         too-many-instance-attributes,
         too-many-branches,
         too-many-arguments,
+        too-many-positional-arguments,
         too-many-locals,
         W1514 # we use default encoding from the env var
 


### PR DESCRIPTION
After updating pylint, we started to get `too-many-positional-arguments` error. E.g https://github.com/elastic/cloudbeat/actions/runs/10991206099/job/30513107030?pr=2550

It was added on latest release https://github.com/pylint-dev/pylint/releases/tag/v3.3.0.

Based we already had the `too-many-arguments` I ignored the `too-many-positional-arguments` too