### PR TITLE
Update version compatibility handling

### DIFF
--- a/.github/workflows/weekly-serverless.yml
+++ b/.github/workflows/weekly-serverless.yml
@@ -30,7 +30,7 @@ jobs:
       deployment_name: ${{ needs.naming.outputs.deployment_name }}
       # For now, the region is not used because it's overridden in the tf, but it's here for future compatibility.
       ess-region: "aws-us-east-1"
-      elk-stack-version: 8.12.0
+      elk-stack-version: 8.15.3
       serverless_mode: true
       run-sanity-tests: true
       expiration_days: 0

--- a/deploy/azure/install_agent_az_cli.sh
+++ b/deploy/azure/install_agent_az_cli.sh
@@ -33,11 +33,17 @@
 # Exit immediately if a command exits with a non-zero status, print each command before executing it, and fail pipelines if any command fails.
 set -euo pipefail
 
+# Extract major and minor versions
+MAJOR_VERSION=$(echo "${STACK_VERSION}" | cut -d'.' -f1)
 MINOR_VERSION=$(echo "${STACK_VERSION}" | cut -d'.' -f2)
-# Check if minor version is less than 12, ie. 8.11 and below
-if ((MINOR_VERSION < 12)); then
-    echo "Versions 8.11 and below are not supported. Please use versions 8.12+"
-    exit 0
+
+# Check for unsupported versions
+if [[ "$MAJOR_VERSION" -eq 8 && "$MINOR_VERSION" -lt 12 ]]; then
+    echo "Versions 8.11 and below are not supported. Please use versions 8.12+."
+    exit 1
+elif [[ "$MAJOR_VERSION" -lt 8 ]]; then
+    echo "Unsupported version: ${STACK_VERSION}. Please use versions 8.12+ or 9.x.x and above."
+    exit 1
 fi
 
 # Create a resource group with the name DEPLOYMENT_NAME


### PR DESCRIPTION
### Summary of your changes

The Azure installation script previously handled only the minor versions of 8.x branches. With the transition to 9.x, major version handling is now required. This PR adds support for both major and minor version handling.
