### PR TITLE
fix gh artifacts upload with the latest action version

### DIFF
--- a/.github/actions/docker-images/action.yml
+++ b/.github/actions/docker-images/action.yml
@@ -26,7 +26,7 @@ inputs:
   docker-images-folder:
     description: 'Docker build cache folder'
     required: false
-    default: '/tmp/.docker-images'
+    default: .docker-images
 
   goos:
     description: 'GOOS environment variable'
@@ -118,16 +118,16 @@ runs:
       name: Rotate cache
       shell: bash
       run: |
-        ls -lahR /tmp/ || true
+        ls -lahR ${{ inputs.docker-images-folder }} || true
         [[ -d ${{ inputs.docker-build-cache-folder }}-new ]] && rm -rf ${{ inputs.docker-build-cache-folder }} && mv ${{ inputs.docker-build-cache-folder }}-new ${{ inputs.docker-build-cache-folder }}
 
     - if: ${{ inputs.build-docker-images == 'true' }}
       name: Upload docker images
-      # Pin action version to 4.3.4 See https://github.com/actions/upload-artifact/issues/589
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v4
       with:
         name: docker-images
-        path: ${{ inputs.docker-images-folder }}
+        path: |
+          ${{ inputs.docker-images-folder }}/*.tar
         if-no-files-found: error
         retention-days: 2
         overwrite: true

--- a/.github/actions/k8s-ci/action.yml
+++ b/.github/actions/k8s-ci/action.yml
@@ -19,7 +19,7 @@ inputs:
   docker-images-folder:
     description: 'Docker build cache folder'
     required: false
-    default: '/tmp/.docker-images'
+    default: .docker-images
 runs:
   using: composite
   steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
   #     - main
   #     - "[0-9]+.[0-9]+"
   #   types: [opened, synchronize, reopened]
+  pull_request:
+    branches:
+      - main
+      - "[0-9]+.[0-9]+"
+    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
@@ -230,6 +235,7 @@ jobs:
         uses: ./.github/actions/docker-images
         with:
           build-docker-images: 'true'
+          docker-images-folder: .docker-images
 
   ci-k8s:
     needs: [ init-hermit, docker-images ]
@@ -280,7 +286,7 @@ jobs:
         uses: ./.github/actions/docker-images
         with:
           build-docker-images: 'false'
-          docker-images-folder: '/tmp/.docker-images'
+          docker-images-folder: .docker-images
 
       - name: Run k8s integration tests
         uses: ./.github/actions/k8s-ci
@@ -288,7 +294,7 @@ jobs:
           kind-config: ${{ matrix.kind-config }}
           test-target: ${{ matrix.test-target }}
           values-file: ${{ matrix.values-file }}
-          docker-images-folder: '/tmp/.docker-images'
+          docker-images-folder: .docker-images
 
   upload-allure-results:
     needs:


### PR DESCRIPTION
### Summary of your changes
It seems that after a version update of [upload-artifact](https://github.com/actions/upload-artifact) something is wrong when we give a folder as a path to upload. 

In our CI, we upload the produced Docker images as artifacts, which are later downloaded and used for kspm testing. 

I didn't investigate the action code to find out why, but as a workaround, I changed the upload path from folder to wildcard pattern, and it works.


```yml
        path: |
          ${{ inputs.docker-images-folder }}/*.tar
```

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->
https://github.com/elastic/cloudbeat/actions/runs/11340902754?pr=2605

### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
