### PR TITLE
Increase azure fetcher timeout

### DIFF
--- a/internal/flavors/benchmark/azure.go
+++ b/internal/flavors/benchmark/azure.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -50,7 +51,7 @@ func (a *Azure) NewBenchmark(ctx context.Context, log *logp.Logger, cfg *config.
 
 	return builder.New(
 		builder.WithBenchmarkDataProvider(bdp),
-		builder.WithManagerTimeout(17*time.Hour),
+		builder.WithManagerTimeout(calculateFetcherTimeout(cfg.Period)),
 	).Build(ctx, log, cfg, resourceCh, reg)
 }
 
@@ -94,4 +95,17 @@ func (a *Azure) checkDependencies() error {
 		return errors.New("azure asset inventory is uninitialized")
 	}
 	return nil
+}
+
+// calculateFetcherTimeout calculates the timeout for each fetcher based on period as ~70% of the period duration. If less than 3 hours, it returns 3 hours.
+func calculateFetcherTimeout(period time.Duration) time.Duration {
+	roundedHours := math.Round(period.Hours() * 0.7)
+	to := time.Duration(roundedHours) * time.Hour
+
+	const min = 3 * time.Hour
+	if to < min {
+		return min
+	}
+
+	return to
 }

--- a/internal/flavors/benchmark/azure.go
+++ b/internal/flavors/benchmark/azure.go
@@ -50,7 +50,7 @@ func (a *Azure) NewBenchmark(ctx context.Context, log *logp.Logger, cfg *config.
 
 	return builder.New(
 		builder.WithBenchmarkDataProvider(bdp),
-		builder.WithManagerTimeout(20*time.Minute),
+		builder.WithManagerTimeout(17*time.Hour),
 	).Build(ctx, log, cfg, resourceCh, reg)
 }
 


### PR DESCRIPTION
### Summary of your changes
<!--
Please provide a detailed description of the changes introduced by this Pull Request.
Provide a description of the main changes, as well as any additional information the code reviewer should be aware of before beginning the review process.
-->
Increase Azure fetcher timeout to 70% of cycle period duration.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
Related: https://github.com/elastic/cloudbeat/issues/2624

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
