### PR TITLE
azure: add integration tests cases

### DIFF
--- a/internal/inventory/gcpfetcher/fetcher_assets.go
+++ b/internal/inventory/gcpfetcher/fetcher_assets.go
@@ -54,6 +54,7 @@ var ResourcesToFetch = []ResourcesClassification{
 	{gcpinventory.ComputeForwardingRuleAssetType, inventory.AssetClassificationGcpForwardingRule},
 	{gcpinventory.CloudFunctionAssetType, inventory.AssetClassificationGcpCloudFunction},
 	{gcpinventory.CloudRunService, inventory.AssetClassificationGcpCloudRunService},
+	{gcpinventory.IamRoleAssetType, inventory.AssetClassificationGcpIamRole},
 }
 
 func newAssetsInventoryFetcher(logger *logp.Logger, provider inventoryProvider) inventory.AssetFetcher {

--- a/tests/product/tests/data/gcp_asset_inventory/test_cases.py
+++ b/tests/product/tests/data/gcp_asset_inventory/test_cases.py
@@ -29,12 +29,12 @@ test_cases = {
         type_="subnet",
         sub_type="gcp-subnet",
     ),
-    # "[Asset Inventory][GCP][Project] assets found": AssetInventoryCase(
-    #     category="infrastructure",
-    #     sub_category="management",
-    #     type_="cloud-account",
-    #     sub_type="gcp-project",
-    # ),
+    "[Asset Inventory][GCP][Project] assets found": AssetInventoryCase(
+        category="infrastructure",
+        sub_category="management",
+        type_="cloud-account",
+        sub_type="gcp-project",
+    ),
     # "[Asset Inventory][GCP][Organization] assets found": AssetInventoryCase(
     #     category="infrastructure",
     #     sub_category="management",
@@ -47,18 +47,18 @@ test_cases = {
     #     type_="resource-hierarchy",
     #     sub_type="gcp-folder",
     # ),
-    # "[Asset Inventory][GCP][Bucket] assets found": AssetInventoryCase(
-    #     category="infrastructure",
-    #     sub_category="storage",
-    #     type_="object-storage",
-    #     sub_type="gcp-bucket",
-    # ),
-    # "[Asset Inventory][GCP][Firewall] assets found": AssetInventoryCase(
-    #     category="infrastructure",
-    #     sub_category="network",
-    #     type_="firewall",
-    #     sub_type="gcp-firewall",
-    # ),
+    "[Asset Inventory][GCP][Bucket] assets found": AssetInventoryCase(
+        category="infrastructure",
+        sub_category="storage",
+        type_="object-storage",
+        sub_type="gcp-bucket",
+    ),
+    "[Asset Inventory][GCP][Firewall] assets found": AssetInventoryCase(
+        category="infrastructure",
+        sub_category="network",
+        type_="firewall",
+        sub_type="gcp-firewall",
+    ),
     # "[Asset Inventory][GCP][GKE Cluster] assets found": AssetInventoryCase(
     #     category="infrastructure",
     #     sub_category="container",
@@ -71,22 +71,22 @@ test_cases = {
     #     type_="load-balancing",
     #     sub_type="gcp-forwarding-rule",
     # ),
-    # "[Asset Inventory][GCP][IAM Role] assets found": AssetInventoryCase(
-    #     category="identity",
-    #     sub_category="access-management",
-    #     type_="iam-role",
-    #     sub_type="gcp-iam-role",
-    # ),
+    "[Asset Inventory][GCP][IAM Role] assets found": AssetInventoryCase(
+        category="identity",
+        sub_category="access-management",
+        type_="iam-role",
+        sub_type="gcp-iam-role",
+    ),
     # "[Asset Inventory][GCP][Cloud Function] assets found": AssetInventoryCase(
     #     category="infrastructure",
     #     sub_category="serverless",
     #     type_="function",
     #     sub_type="gcp-cloud-function",
     # ),
-    # "[Asset Inventory][GCP][Cloud Run Service] assets found": AssetInventoryCase(
-    #     category="infrastructure",
-    #     sub_category="container",
-    #     type_="serverless",
-    #     sub_type="gcp-cloud-run-service",
-    # ),
+    "[Asset Inventory][GCP][Cloud Run Service] assets found": AssetInventoryCase(
+        category="infrastructure",
+        sub_category="container",
+        type_="serverless",
+        sub_type="gcp-cloud-run-service",
+    ),
 }


### PR DESCRIPTION
### Summary of your changes

adds test cases for: `project`, `cloud-run service`, `iam role`, `bucket` and `firewall`

remaining test cases: 
- `org`: we don't have a suitable org account for CI tests yet
- `gke cluster`: going to figure out costs before enabling this
- `cloud function`: API not enabled for our account, need to discuss this. 

### Related Issues

- closes https://github.com/elastic/cloudbeat/issues/2560


---

<details><summary>for future reference - script to quickly run gcp integration tests locally</summary>

```bash
#!/bin/bash

echo 'Start ES'
docker run -d \
    --name es2 \
    -e "discovery.type=single-node" \
    -e "xpack.security.enabled=false" \
    -e "xpack.security.http.ssl.enabled=false" \
    -p 9200:9200 \
    docker.elastic.co/elasticsearch/elasticsearch:8.15.0

sleep 10

export ES_HOST=http://localhost:9200
export ES_USERNAME=elastic
export ES_PASSWORD=changeme
export GCP_PROJECT_ID=elastic-security-test
export GCP_CREDENTIALS_JSON=STRINGIFIED_JSON_DATA
export GCP_ACCOUNT_TYPE=single-account

echo 'Start cloudbeat'
./cloudbeat -c deploy/asset-inventory/cloudbeat-gcp-asset-inventory.yml -d '*' &

URL="http://localhost:9200/.ds-logs-cloud_asset_inventory.asset_inventory-*/_search?size=0"
HEADER="Content-Type: application/json"

MAX_RETRIES=1000

for ((i = 1; i <= MAX_RETRIES; i++)); do
    result=$(curl -s -X GET "$URL" -H "$HEADER" | jq '.hits.total.value')

    if [ "$result" -gt 0 ]; then
        echo "Result is greater than 0: $result"
        break
    fi

    echo "Result is 0, retrying in 1 second... ($i/$MAX_RETRIES)"
    sleep 1
done


if [ "$i" -gt "$MAX_RETRIES" ]; then
    echo "Max retries reached. Result is still 0."
else
    export USE_K8S=false
    export ES_HOST=localhost
    export ES_PORT=9200
    export ES_USER=elastic
    export ES_PASSWORD=changeme
    export ES_SSL=false
    export ES_PROTOCOL=http

    cd tests
    poetry run pytest -k "asset_inventory_gcp" --alluredir=./allure/results/ --clean-alluredir

fi

docker stop es2
docker rm es2
pkill -f cloudbeat

```


</details> 
