### PR TITLE
[CI] Avoid Trivy DB image pull quota issues

### DIFF
--- a/internal/vulnerability/runner.go
+++ b/internal/vulnerability/runner.go
@@ -60,8 +60,8 @@ func NewVulnerabilityRunner(log *logp.Logger) (VulnerabilityRunner, error) {
 		},
 		DBOptions: flag.DBOptions{
 			NoProgress:       true,
-			DBRepository:     name.MustParseReference("ghcr.io/aquasecurity/trivy-db:2"),
-			JavaDBRepository: name.MustParseReference("ghcr.io/aquasecurity/trivy-java-db:1"),
+			DBRepository:     name.MustParseReference("public.ecr.aws/aquasecurity/trivy-db:2"),
+			JavaDBRepository: name.MustParseReference("public.ecr.aws/aquasecurity/trivy-java-db:1"),
 		},
 	}
 


### PR DESCRIPTION
### Summary of your changes

Avoid Trivy DB image pull quota errors by switching container registries from GHCR to ECR. It is still an official image, just from a mirror.

### Related Issues

- Fixes: https://github.com/elastic/cloudbeat/issues/2653
- Related: https://github.com/aquasecurity/trivy/discussions/7538

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)
