### PR TITLE
Remove duplicated backport skip label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,6 @@ updates:
         patterns:
           - "github.com/aquasecurity/*"
     labels:
-      - "backport-skip"
       - "dependency"
       - "backport-skip"
       - "go"


### PR DESCRIPTION
Somehow 8.x already had backport-skip there and when backporting, it got duplicated.