### PR TITLE
Fix SNS topics fetch panics on errors

### DIFF
--- a/internal/resources/providers/awslib/sns/provider.go
+++ b/internal/resources/providers/awslib/sns/provider.go
@@ -49,6 +49,7 @@ func (p *Provider) ListTopics(ctx context.Context) ([]types.Topic, error) {
 			output, err := c.ListTopics(ctx, input)
 			if err != nil {
 				p.log.Errorf("Could not list SNS Topics. Error: %s", err)
+				return nil, err
 			}
 			all = append(all, output.Topics...)
 			if output.NextToken == nil {
@@ -93,6 +94,7 @@ func (p *Provider) ListTopicsWithSubscriptions(ctx context.Context) ([]awslib.Aw
 			output, err := c.ListTopics(ctx, input)
 			if err != nil {
 				p.log.Errorf("Could not list SNS Topics. Error: %s", err)
+				return nil, err
 			}
 
 			for _, topic := range output.Topics {

--- a/internal/resources/providers/awslib/sns/provider_test.go
+++ b/internal/resources/providers/awslib/sns/provider_test.go
@@ -25,13 +25,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/aws-sdk-go-v2/service/sns/types"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 type (


### PR DESCRIPTION
### Summary of your changes
Agentless agents were having panics on fetching SNS topics.

### Related Issues
- Fixes: https://github.com/elastic/cloudbeat/issues/2640

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
