### PR TITLE
 Update serverless workflow to use correct stack version

### DIFF
--- a/.github/workflows/weekly-serverless.yml
+++ b/.github/workflows/weekly-serverless.yml
@@ -30,7 +30,7 @@ jobs:
       deployment_name: ${{ needs.naming.outputs.deployment_name }}
       # For now, the region is not used because it's overridden in the tf, but it's here for future compatibility.
       ess-region: "aws-us-east-1"
-      elk-stack-version: ${{ env.ELK_VERSION}}
+      elk-stack-version: 9.0.0-SNAPSHOT
       serverless_mode: true
       run-sanity-tests: true
       expiration_days: 0

--- a/.github/workflows/weekly-serverless.yml
+++ b/.github/workflows/weekly-serverless.yml
@@ -30,7 +30,7 @@ jobs:
       deployment_name: ${{ needs.naming.outputs.deployment_name }}
       # For now, the region is not used because it's overridden in the tf, but it's here for future compatibility.
       ess-region: "aws-us-east-1"
-      elk-stack-version: 8.15.3
+      elk-stack-version: ${{ env.ELK_VERSION}}
       serverless_mode: true
       run-sanity-tests: true
       expiration_days: 0

--- a/tests/integrations_setup/configuration_fleet.py
+++ b/tests/integrations_setup/configuration_fleet.py
@@ -53,6 +53,7 @@ gcp_dm_config.zone = os.getenv("ZONE", "us-central1-a")
 gcp_dm_config.allow_ssh = os.getenv("ALLOW_SSH", "false") == "true"
 gcp_dm_config.credentials_file = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
 gcp_dm_config.service_account_json_path = os.getenv("SERVICE_ACCOUNT_JSON_PATH", "")
+gcp_dm_config.project_id = os.getenv("GOOGLE_CLOUD_PROJECT", "")
 
 gcp_audit_config = Munch()
 gcp_audit_config.credentials_file = os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")

--- a/tests/integrations_setup/install_agentless_integrations.py
+++ b/tests/integrations_setup/install_agentless_integrations.py
@@ -14,6 +14,7 @@ from fleet_api.agent_policy_api import create_agent_policy
 from fleet_api.package_policy_api import create_cspm_integration
 from loguru import logger
 from package_policy import generate_policy_template, generate_random_name, load_data
+from state_file_manager import HostType, PolicyState, state_manager
 
 
 def generate_aws_integration_data():
@@ -66,6 +67,7 @@ def generate_gcp_integration_data():
         "posture": "cspm",
         "deployment": "gcp",
         "vars": {
+            "gcp.project_id": cnfg.gcp_dm_config.project_id,
             "gcp.account_type": "single-account",
             "gcp.credentials.type": "credentials-json",
             "gcp.credentials.json": credentials_json,
@@ -107,6 +109,17 @@ if __name__ == "__main__":
             pkg_policy=package_data,
             agent_policy_id=agent_policy_id,
             cspm_data={},
+        )
+
+        state_manager.add_policy(
+            PolicyState(
+                agent_policy_id,
+                package_policy_id,
+                1,
+                [],
+                HostType.KUBERNETES.value,
+                integration_data["name"],
+            ),
         )
 
         logger.info(f"Installation of {INTEGRATION_NAME} integration is done")


### PR DESCRIPTION
### Summary of your changes

This PR updates the stack version used for installing integrations in the serverless environment and fixes the installation of agentless integration for GCP, which was missing the `project ID`. Additionally, support for saving the state of agentless agents has been added to ensure proper enrollment verification.

### Tests

[Successful workflow run](https://github.com/elastic/cloudbeat/actions/runs/12250792293)
