### PR TITLE
Install poetry export

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,8 +4,6 @@ WORKDIR /usr/src/app
 
 RUN pip install poetry
 
-RUN poetry --version
-
 RUN pip install poetry-plugin-export
 
 COPY pyproject.toml poetry.lock ./

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /usr/src/app
 
 RUN pip install poetry
 
+RUN poetry --version
+
 RUN pip install poetry-plugin-export
 
 COPY pyproject.toml poetry.lock ./

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /usr/src/app
 
 RUN pip install poetry
 
+RUN pip install poetry-plugin-export
+
 COPY pyproject.toml poetry.lock ./
 
 RUN poetry export --without-hashes -f requirements.txt --output requirements.txt

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -28,6 +28,9 @@ packages = [
     {include="fleet_api"}
 ]
 
+[tool.poetry.requires-plugins]
+poetry-plugin-export = ">1.8"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The `poetry export` [command is no longer a default command from poetry ](https://python-poetry.org/docs/cli/#export) (poetry >=2.0).

Therefore this PR install the plugin before running it, and also reference it in the test `pyproject.toml`