### PR TITLE
Add support for VERSION_QUALIFIER DRA

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,16 +20,19 @@ steps:
     env:
       WORKFLOW: "snapshot"
 
+    # Allow building staging from main when VERSION_QUALIFIER is set (allow prerelease testing)
+    # TODO remove || build.env('VERSION_QUALIFIER') != null
   - label: ":package: Package Cloudbeat - Staging"
-    if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true"
+    if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true" || build.env('VERSION_QUALIFIER') != null
     env:
       WORKFLOW: "staging"
     key: "package-staging"
     command: "./.buildkite/scripts/package.sh"
     artifact_paths: "build/distributions/*"
 
+  # TODO remove || build.env('VERSION_QUALIFIER') != null
   - label: ":rocket: Publishing Staging DRA artifacts"
-    if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true"
+    if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true" || build.env('VERSION_QUALIFIER') != null
     depends_on: "package-staging"
     command: "./.buildkite/scripts/publish.sh"
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,13 @@ agents:
   image: "family/platform-ingest-beats-ubuntu-2204"
 
 steps:
+  # TODO: this will be removed/changed for 9.0 branch
+  - label: ":writing_hand: Conditionally set VERSION_QUALIFIER for main branch"
+    if: build.branch == "main"
+    env:
+      VERSION_QUALIFIER: "alpha1"
+    command: "echo 'Setting VERSION_QUALIFIER for branch main'"
+
   - label: ":package: Package Cloudbeat - Snapshot"
     if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env("RUN_RELEASE") == "true"
     env:

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -8,6 +8,7 @@ source ./bin/activate-hermit
 CLOUDBEAT_VERSION=$(grep defaultBeatVersion version/version.go | cut -d'=' -f2 | tr -d '" ')
 PYTHON_BIN=./build/ve/$(go env GOOS)/bin
 PYTHON=$PYTHON_BIN/python
+VERSION_QUALIFIER="${VERSION_QUALIFIER:-""}"
 
 if [ "$WORKFLOW" = "snapshot" ]; then
     export SNAPSHOT="true"
@@ -21,6 +22,9 @@ mage package
 
 CSV_FILE="build/dependencies-${CLOUDBEAT_VERSION}"
 [ -n "${SNAPSHOT+x}" ] && CSV_FILE+="-SNAPSHOT"
+if [[ -n "$VERSION_QUALIFIER" ]]; then
+  CSV_FILE+="-${VERSION_QUALIFIER}"
+fi
 
 echo "Generating $CSV_FILE.csv"
 $PYTHON ./.buildkite/scripts/generate_notice.py --csv "$CSV_FILE.csv"

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -23,7 +23,7 @@ mage package
 CSV_FILE="build/dependencies-${CLOUDBEAT_VERSION}"
 [ -n "${SNAPSHOT+x}" ] && CSV_FILE+="-SNAPSHOT"
 if [[ -n "$VERSION_QUALIFIER" ]]; then
-  CSV_FILE+="-${VERSION_QUALIFIER}"
+    CSV_FILE+="-${VERSION_QUALIFIER}"
 fi
 
 echo "Generating $CSV_FILE.csv"

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -13,6 +13,7 @@ elif [ -n "$(git ls-remote --heads origin $MAJOR.x)" ]; then
 else
     BRANCH=main
 fi
+VERSION_QUALIFIER="${VERSION_QUALIFIER:=""}"
 
 # Download artifacts from other stages
 echo "Downloading artifacts..."
@@ -38,4 +39,5 @@ docker run --rm \
     --commit "${BUILDKITE_COMMIT}" \
     --workflow "${WORKFLOW}" \
     --version "${VERSION}" \
-    --artifact-set main
+    --artifact-set main \
+    --qualifier "${VERSION_QUALIFIER}"

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -13,7 +13,7 @@ elif [ -n "$(git ls-remote --heads origin $MAJOR.x)" ]; then
 else
     BRANCH=main
 fi
-VERSION_QUALIFIER="${VERSION_QUALIFIER:=""}"
+VERSION_QUALIFIER="${VERSION_QUALIFIER:-""}"
 
 # Download artifacts from other stages
 echo "Downloading artifacts..."

--- a/magefile.go
+++ b/magefile.go
@@ -49,8 +49,9 @@ import (
 )
 
 const (
-	snapshotEnv   = "SNAPSHOT"
-	agentDropPath = "AGENT_DROP_PATH"
+	snapshotEnv         = "SNAPSHOT"
+	agentDropPath       = "AGENT_DROP_PATH"
+	cloudbeatModulePath = "github.com/elastic/cloudbeat"
 )
 
 func init() {
@@ -80,6 +81,9 @@ func Build() error {
 
 	args := devtools.DefaultBuildArgs()
 	args.CGO = false
+	if versionQualifier, versionQualified := os.LookupEnv("VERSION_QUALIFIER"); versionQualified {
+		args.Vars[cloudbeatModulePath+"/version.qualifier"] = versionQualifier
+	}
 	return devtools.Build(args)
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -99,6 +99,9 @@ func Clean() error {
 func GolangCrossBuild() error {
 	args := devtools.DefaultGolangCrossBuildArgs()
 	args.CGO = false
+	if versionQualifier, versionQualified := os.LookupEnv("VERSION_QUALIFIER"); versionQualified {
+		args.Vars[cloudbeatModulePath+"/version.qualifier"] = versionQualifier
+	}
 	return devtools.GolangCrossBuild(args)
 }
 

--- a/version/settings.go
+++ b/version/settings.go
@@ -52,6 +52,9 @@ func cloudbeatCommitTime() string {
 
 // CloudbeatSemanticVersion returns the current cloudbeat version.
 func CloudbeatSemanticVersion() string {
+	if qualifier != "" {
+		return defaultBeatVersion + "-" + qualifier
+	}
 	return defaultBeatVersion
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -20,6 +20,8 @@ package version
 // name matches github.com/elastic/beats/v7/dev-tools/mage/settings.go parseBeatVersion
 const defaultBeatVersion = "9.0.0"
 
+var qualifier = ""
+
 // Version represents version information for a package
 type Version struct {
 	Version    string `mapstructure:"version,omitempty"`     // Version is the semantic version of the package


### PR DESCRIPTION
### Summary of your changes
Add Support for VERSION_QUALIFIER argument during DRA production. 

Add a temporary condition to staging artifacts so can be triggered even from main branch when VERSION_QUALIFIER is passed. (required to upload the first `alpha1` pre release). 


Test for artifacts generation done locally, but the buildkite pipeline will be tested after merge. 


### Screenshot/Data
Screenshots after running what buildkite pipeline runs plus VERSION_QUALIFIER env var.
```bash
export VERSION_QUALIFIER='alpha1'
export WORKFLOW='staging'
bash ./.buildkite/scripts/package.sh 
```
<img width="1007" alt="Screenshot 2025-01-16 at 12 42 19 PM" src="https://github.com/user-attachments/assets/e9f3132f-936c-4b3c-9dff-03ecf440033e" />
<img width="805" alt="Screenshot 2025-01-16 at 12 42 07 PM" src="https://github.com/user-attachments/assets/c98410fa-a640-4cff-b096-159aea3912b9" />
<img width="1080" alt="Screenshot 2025-01-16 at 2 38 51 PM" src="https://github.com/user-attachments/assets/b63a883b-e6cc-4795-a1c6-ef6e6da701e2" />
<img width="1418" alt="Screenshot 2025-01-16 at 2 43 05 PM" src="https://github.com/user-attachments/assets/ddb14708-33ca-4745-910a-a88d1739d324" />


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
Fixes: https://github.com/elastic/security-team/issues/11536

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
