### PR TITLE
github-actions: ubuntu-20.04 will be fully retired by April 1, 2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,7 @@ jobs:
     # Since we build the cloudbeat in the worker's OS and as non static,
     # we need to keep the OS version same as elastic-agent docker image base.
     # docker run --interactive --tty --rm --entrypoint bash docker.elastic.co/elastic-agent/elastic-agent-complete:8.14.0-SNAPSHOT -c 'cat /etc/os-release'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/cloudformation-ci.yml
+++ b/.github/workflows/cloudformation-ci.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   Deploy-CloudFormation:
     name: "Deploy CloudFormation"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     defaults:
       run:

--- a/.github/workflows/destroy-environment.yml
+++ b/.github/workflows/destroy-environment.yml
@@ -42,7 +42,7 @@ env:
 
 jobs:
   Destroy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     # Add "id-token" with the intended permissions.
     permissions:

--- a/.github/workflows/eks-ci.yml
+++ b/.github/workflows/eks-ci.yml
@@ -171,7 +171,7 @@ jobs:
             k8s_context: "test-eks-config-2"
             label: "EKS functional tests: config 2"
     name: ${{ matrix.label }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:
       - name: Check out the repo
@@ -227,7 +227,7 @@ jobs:
     name: Publish Results
     needs: Test_Matrix
     if: always()
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   package_beat:
     name: Package Cloudbeat
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-cloudformation.yml
+++ b/.github/workflows/publish-cloudformation.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   publish_cloudformation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -135,7 +135,7 @@ env:
 
 jobs:
   Deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 120
     defaults:
       run:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -23,7 +23,7 @@ jobs:
 
   manifest_tests:
     name: Manifest Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
       - name: Check out the repo

--- a/.github/workflows/upgrade-environment.yml
+++ b/.github/workflows/upgrade-environment.yml
@@ -41,7 +41,7 @@ env:
 
 jobs:
   init:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       base-stack-version: ${{ steps.set-previous-version.outputs.PREVIOUS_VERSION }}
       ess-region: ${{ env.TF_VAR_ess_region }}
@@ -88,7 +88,7 @@ jobs:
       serverless_mode: false
     secrets: inherit
   upgrade:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [init, deploy]
     timeout-minutes: 120
     defaults:


### PR DESCRIPTION
### Summary of your changes

See [github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/)

Let's use `ubuntu-22`.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
