### PR TITLE
Enrich GCP asset types with ECS fields

### DIFF
--- a/internal/inventory/asset.go
+++ b/internal/inventory/asset.go
@@ -184,8 +184,6 @@ type Network struct {
 	Name      string `json:"name,omitempty"`
 	Direction string `json:"direction,omitempty"`
 	Type      string `json:"type,omitempty"`
-	// Protocol string `json:"protocol,omitempty"`
-	// Transport []string `json:"transport,omitempty"`
 }
 
 type Cloud struct {

--- a/internal/inventory/asset.go
+++ b/internal/inventory/asset.go
@@ -139,11 +139,31 @@ type AssetEvent struct {
 	Entity        Entity
 	Event         Event
 	Network       *Network
+	URL           *URL
+	Organization  *Organization
 	Cloud         *Cloud
+	Fass          *Fass
+	Orchestrator  *Orchestrator
+	Container     *Container
 	Host          *Host
 	User          *User
 	Labels        map[string]string
+	Tags          []string
 	RawAttributes *any
+}
+
+type Organization struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+type Fass struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+type URL struct {
+	Full string `json:"full"`
 }
 
 // Entity contains the identifiers of the asset
@@ -161,7 +181,11 @@ type Event struct {
 }
 
 type Network struct {
-	Name string `json:"name,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Direction string `json:"direction,omitempty"`
+	Type      string `json:"type,omitempty"`
+	// Protocol string `json:"protocol,omitempty"`
+	// Transport []string `json:"transport,omitempty"`
 }
 
 type Cloud struct {
@@ -188,8 +212,22 @@ type Host struct {
 }
 
 type User struct {
-	ID   string `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	ID    string   `json:"id,omitempty"`
+	Name  string   `json:"name,omitempty"`
+	Email string   `json:"email,omitempty"`
+	Roles []string `json:"roles,omitempty"`
+}
+
+type Orchestrator struct {
+	ClusterID   string `json:"cluster.id,omitempty"`
+	ClusterName string `json:"cluster.name,omitempty"`
+	Type        string `json:"type,omitempty"`
+}
+
+type Container struct {
+	ID        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	ImageName string `json:"image.name,omitempty"`
 }
 
 // AssetEnricher functional builder function
@@ -245,6 +283,16 @@ func WithLabels(labels map[string]string) AssetEnricher {
 	}
 }
 
+func WithTags(tags []string) AssetEnricher {
+	return func(a *AssetEvent) {
+		if len(tags) == 0 {
+			return
+		}
+
+		a.Tags = tags
+	}
+}
+
 func WithNetwork(network Network) AssetEnricher {
 	return func(a *AssetEvent) {
 		a.Network = &network
@@ -271,4 +319,34 @@ func WithUser(user User) AssetEnricher {
 
 func EmptyEnricher() AssetEnricher {
 	return func(_ *AssetEvent) {}
+}
+
+func WithOrganization(org Organization) AssetEnricher {
+	return func(a *AssetEvent) {
+		a.Organization = &org
+	}
+}
+
+func WithFass(fass Fass) AssetEnricher {
+	return func(a *AssetEvent) {
+		a.Fass = &fass
+	}
+}
+
+func WithURL(url URL) AssetEnricher {
+	return func(a *AssetEvent) {
+		a.URL = &url
+	}
+}
+
+func WithOrchestrator(orchestrator Orchestrator) AssetEnricher {
+	return func(a *AssetEvent) {
+		a.Orchestrator = &orchestrator
+	}
+}
+
+func WithContainer(container Container) AssetEnricher {
+	return func(a *AssetEvent) {
+		a.Container = &container
+	}
 }

--- a/internal/inventory/gcpfetcher/fetcher_assets.go
+++ b/internal/inventory/gcpfetcher/fetcher_assets.go
@@ -19,7 +19,9 @@ package gcpfetcher
 
 import (
 	"context"
+	"strings"
 
+	"github.com/mitchellh/mapstructure"
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -83,41 +85,61 @@ func (f *assetsInventory) fetch(ctx context.Context, assetChan chan<- inventory.
 	}
 
 	for _, item := range gcpAssets {
-		assetChan <- inventory.NewAssetEvent(
-			classification,
-			item.Name,
-			item.Name,
-			inventory.WithRawAsset(item),
-			inventory.WithRelatedAssetIds(
-				f.findRelatedAssetIds(classification.Type, item),
-			),
-			inventory.WithCloud(inventory.Cloud{
-				Provider:    inventory.GcpCloudProvider,
-				AccountID:   item.CloudAccount.AccountId,
-				AccountName: item.CloudAccount.AccountName,
-				ProjectID:   item.CloudAccount.OrganisationId,
-				ProjectName: item.CloudAccount.OrganizationName,
-				ServiceName: assetType,
-			}),
-		)
+		assetChan <- getAssetEvent(classification, item)
 	}
 }
 
-func (f *assetsInventory) findRelatedAssetIds(t inventory.AssetType, item *gcpinventory.ExtendedGcpAsset) []string {
+func getAssetEvent(classification inventory.AssetClassification, item *gcpinventory.ExtendedGcpAsset) inventory.AssetEvent {
+	// Common enrichers
+	enrichers := []inventory.AssetEnricher{
+		inventory.WithRawAsset(item),
+		inventory.WithLabels(getAssetLabels(item)),
+		inventory.WithTags(getAssetTags(item)),
+		inventory.WithRelatedAssetIds(
+			findRelatedAssetIds(classification.Type, item),
+		),
+		// Any asset type enrichers also setting Cloud fields will need to re-add these fields below
+		inventory.WithCloud(inventory.Cloud{
+			Provider:    inventory.GcpCloudProvider,
+			AccountID:   item.CloudAccount.AccountId,
+			AccountName: item.CloudAccount.AccountName,
+			ProjectID:   item.CloudAccount.OrganisationId,
+			ProjectName: item.CloudAccount.OrganizationName,
+			ServiceName: item.AssetType,
+		}),
+	}
+
+	// Asset type specific enrichers
+	if hasResourceData(item) {
+		fields := item.GetResource().GetData().GetFields()
+		if enricher, ok := assetEnrichers[item.AssetType]; ok {
+			enrichers = append(enrichers, enricher(item, fields)...)
+		}
+	}
+
+	return inventory.NewAssetEvent(
+		classification,
+		item.Name,
+		item.Name,
+		enrichers...,
+	)
+}
+
+func findRelatedAssetIds(t inventory.AssetType, item *gcpinventory.ExtendedGcpAsset) []string {
 	ids := []string{}
 	ids = append(ids, item.Ancestors...)
 	if item.Resource != nil {
 		ids = append(ids, item.Resource.Parent)
 	}
 
-	ids = append(ids, f.findRelatedAssetIdsForType(t, item)...)
+	ids = append(ids, findRelatedAssetIdsForType(t, item)...)
 
 	ids = lo.Compact(ids)
 	ids = lo.Uniq(ids)
 	return ids
 }
 
-func (f *assetsInventory) findRelatedAssetIdsForType(t inventory.AssetType, item *gcpinventory.ExtendedGcpAsset) []string {
+func findRelatedAssetIdsForType(t inventory.AssetType, item *gcpinventory.ExtendedGcpAsset) []string {
 	ids := []string{}
 
 	var fields map[string]*structpb.Value
@@ -171,4 +193,174 @@ func appendIfExists(slice []string, fields map[string]*structpb.Value, key strin
 		return slice
 	}
 	return append(slice, value.GetStringValue())
+}
+
+func hasResourceData(item *gcpinventory.ExtendedGcpAsset) bool {
+	return item.Resource != nil && item.Resource.Data != nil
+}
+
+func getAssetTags(item *gcpinventory.ExtendedGcpAsset) []string {
+	if !hasResourceData(item) {
+		return nil
+	}
+
+	tagsObj, ok := item.GetResource().GetData().GetFields()["tags"]
+	if !ok {
+		return nil
+	}
+
+	structValue := tagsObj.GetStructValue()
+	if structValue == nil {
+		return nil
+	}
+
+	items, ok := structValue.GetFields()["items"]
+	if !ok {
+		return nil
+	}
+
+	tagValues := items.GetListValue().GetValues()
+	tags := make([]string, len(tagValues))
+	for i, tag := range tagValues {
+		tags[i] = tag.GetStringValue()
+	}
+
+	return tags
+}
+
+func getAssetLabels(item *gcpinventory.ExtendedGcpAsset) map[string]string {
+	if !hasResourceData(item) {
+		return nil
+	}
+
+	labels, ok := item.GetResource().GetData().GetFields()["labels"]
+	if !ok {
+		return nil
+	}
+
+	labelsMap := make(map[string]string)
+	if err := mapstructure.Decode(labels.GetStructValue().AsMap(), &labelsMap); err != nil {
+		return nil
+	}
+
+	return labelsMap
+}
+
+var assetEnrichers = map[string]func(item *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher{
+	gcpinventory.IamRoleAssetType:               noopEnricher,
+	gcpinventory.CrmFolderAssetType:             noopEnricher,
+	gcpinventory.CrmProjectAssetType:            noopEnricher,
+	gcpinventory.StorageBucketAssetType:         noopEnricher,
+	gcpinventory.IamServiceAccountKeyAssetType:  noopEnricher,
+	gcpinventory.CloudRunService:                noopEnricher,
+	gcpinventory.CrmOrgAssetType:                enrichOrganization,
+	gcpinventory.ComputeInstanceAssetType:       enrichComputeInstance,
+	gcpinventory.ComputeFirewallAssetType:       enrichFirewall,
+	gcpinventory.ComputeSubnetworkAssetType:     enrichSubnetwork,
+	gcpinventory.IamServiceAccountAssetType:     enrichServiceAccount,
+	gcpinventory.GkeClusterAssetType:            enrichGkeCluster,
+	gcpinventory.ComputeForwardingRuleAssetType: enrichForwardingRule,
+	gcpinventory.CloudFunctionAssetType:         enrichCloudFunction,
+}
+
+func enrichOrganization(_ *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+	return []inventory.AssetEnricher{
+		inventory.WithOrganization(inventory.Organization{
+			Name: getStringValue("displayName", fields),
+		}),
+	}
+}
+
+func enrichComputeInstance(item *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+	return []inventory.AssetEnricher{
+		inventory.WithCloud(inventory.Cloud{
+			// This will override the default Cloud fields, so we re-add the common ones
+			Provider:         inventory.GcpCloudProvider,
+			AccountID:        item.CloudAccount.AccountId,
+			AccountName:      item.CloudAccount.AccountName,
+			ProjectID:        item.CloudAccount.OrganisationId,
+			ProjectName:      item.CloudAccount.OrganizationName,
+			ServiceName:      item.AssetType,
+			InstanceID:       getStringValue("id", fields),
+			InstanceName:     getStringValue("name", fields),
+			MachineType:      getStringValue("machineType", fields),
+			AvailabilityZone: getStringValue("zone", fields),
+		}),
+		inventory.WithHost(inventory.Host{
+			ID: getStringValue("id", fields),
+		}),
+	}
+}
+
+func enrichFirewall(_ *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+	return []inventory.AssetEnricher{
+		inventory.WithNetwork(inventory.Network{
+			Name:      getStringValue("name", fields),
+			Direction: getStringValue("direction", fields),
+		}),
+	}
+}
+
+func enrichSubnetwork(_ *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+	return []inventory.AssetEnricher{
+		inventory.WithNetwork(inventory.Network{
+			Name: getStringValue("name", fields),
+			Type: strings.ToLower(getStringValue("stackType", fields)),
+		}),
+	}
+}
+
+func enrichServiceAccount(_ *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+	return []inventory.AssetEnricher{
+		inventory.WithUser(inventory.User{
+			Email: getStringValue("email", fields),
+			Name:  getStringValue("displayName", fields),
+		}),
+	}
+}
+
+func enrichGkeCluster(_ *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+	return []inventory.AssetEnricher{
+		inventory.WithOrchestrator(inventory.Orchestrator{
+			Type:        "kubernetes",
+			ClusterName: getStringValue("name", fields),
+			ClusterID:   getStringValue("id", fields),
+		}),
+	}
+}
+
+func enrichForwardingRule(_ *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+	return []inventory.AssetEnricher{
+		inventory.WithCloud(inventory.Cloud{
+			Region: getStringValue("region", fields),
+		}),
+	}
+}
+
+func enrichCloudFunction(_ *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+	var revision string
+	if serviceConfig, ok := fields["serviceConfig"]; ok {
+		serviceConfigFields := serviceConfig.GetStructValue().GetFields()
+		revision = getStringValue("revision", serviceConfigFields)
+	}
+	return []inventory.AssetEnricher{
+		inventory.WithURL(inventory.URL{
+			Full: getStringValue("url", fields),
+		}),
+		inventory.WithFass(inventory.Fass{
+			Name:    getStringValue("name", fields),
+			Version: revision,
+		}),
+	}
+}
+
+func noopEnricher(_ *gcpinventory.ExtendedGcpAsset, _ map[string]*structpb.Value) []inventory.AssetEnricher {
+	return []inventory.AssetEnricher{}
+}
+
+func getStringValue(key string, f map[string]*structpb.Value) string {
+	if value, ok := f[key]; ok {
+		return value.GetStringValue()
+	}
+	return ""
 }

--- a/internal/inventory/gcpfetcher/fetcher_assets_test.go
+++ b/internal/inventory/gcpfetcher/fetcher_assets_test.go
@@ -22,7 +22,9 @@ import (
 
 	"cloud.google.com/go/asset/apiv1/assetpb"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
@@ -69,4 +71,203 @@ func TestAccountFetcher_Fetch_Assets(t *testing.T) {
 	provider.EXPECT().ListAllAssetTypesByName(mock.Anything, mock.AnythingOfType("[]string")).Return(assets, nil)
 	fetcher := newAssetsInventoryFetcher(logger, provider)
 	testutil.CollectResourcesAndMatch(t, fetcher, expected)
+}
+
+func TestAccountFetcher_EnrichAsset(t *testing.T) {
+	var data = map[string]struct {
+		resource    *assetpb.Resource    // input of GCP asset resource data
+		enrichments inventory.AssetEvent // output of inventory asset ECS fields
+	}{
+		gcpinventory.IamRoleAssetType:   {},
+		gcpinventory.CrmFolderAssetType: {},
+		gcpinventory.CrmProjectAssetType: {
+			resource: &assetpb.Resource{
+				Data: NewStructMap(map[string]any{
+					"labels": map[string]any{"org": "security"},
+				}),
+			},
+			enrichments: inventory.AssetEvent{
+				Labels: map[string]string{"org": "security"},
+			},
+		},
+		gcpinventory.StorageBucketAssetType:        {},
+		gcpinventory.IamServiceAccountKeyAssetType: {},
+		gcpinventory.CrmOrgAssetType: {
+			resource: &assetpb.Resource{
+				Data: NewStructMap(map[string]any{
+					"displayName": "org",
+				}),
+			},
+			enrichments: inventory.AssetEvent{
+				Organization: &inventory.Organization{
+					Name: "org",
+				},
+			},
+		},
+		gcpinventory.ComputeInstanceAssetType: {
+			resource: &assetpb.Resource{
+				Data: NewStructMap(map[string]any{
+					"id":          "id",
+					"name":        "name",
+					"machineType": "machineType",
+					"zone":        "zone",
+					"labels":      map[string]any{"key": "value"},
+				}),
+			},
+			enrichments: inventory.AssetEvent{
+				Cloud: &inventory.Cloud{
+					InstanceID:       "id",
+					InstanceName:     "name",
+					MachineType:      "machineType",
+					AvailabilityZone: "zone",
+				},
+				Host: &inventory.Host{
+					ID: "id",
+				},
+				Labels: map[string]string{"key": "value"},
+			},
+		},
+		gcpinventory.ComputeFirewallAssetType: {
+			resource: &assetpb.Resource{
+				Data: NewStructMap(map[string]any{
+					"direction": "INGRESS",
+					"name":      "default-allow-ssh",
+				}),
+			},
+			enrichments: inventory.AssetEvent{
+				Network: &inventory.Network{
+					Direction: "INGRESS",
+					Name:      "default-allow-ssh",
+				},
+			},
+		},
+		gcpinventory.ComputeSubnetworkAssetType: {
+			resource: &assetpb.Resource{
+				Data: NewStructMap(map[string]any{
+					"name":      "subnetwork",
+					"stackType": "IPV4_ONLY",
+				}),
+			},
+			enrichments: inventory.AssetEvent{
+				Network: &inventory.Network{
+					Name: "subnetwork",
+					Type: "ipv4_only",
+				},
+			},
+		},
+		gcpinventory.IamServiceAccountAssetType: {
+			resource: &assetpb.Resource{
+				Data: NewStructMap(map[string]any{
+					"displayName": "service-account",
+					"email":       "service-account@<project UUID>.iam.gserviceaccount.com",
+				}),
+			},
+			enrichments: inventory.AssetEvent{
+				User: &inventory.User{
+					Name:  "service-account",
+					Email: "service-account@<project UUID>.iam.gserviceaccount.com",
+				},
+			},
+		},
+		gcpinventory.GkeClusterAssetType: {
+			resource: &assetpb.Resource{
+				Data: NewStructMap(map[string]any{
+					"name": "cluster",
+					"id":   "cluster-id",
+				}),
+			},
+			enrichments: inventory.AssetEvent{
+				Orchestrator: &inventory.Orchestrator{
+					Type:        "kubernetes",
+					ClusterName: "cluster",
+					ClusterID:   "cluster-id",
+				},
+			},
+		},
+		gcpinventory.ComputeForwardingRuleAssetType: {
+			resource: &assetpb.Resource{
+				Data: NewStructMap(map[string]any{
+					"region": "region1",
+				}),
+			},
+			enrichments: inventory.AssetEvent{
+				Cloud: &inventory.Cloud{
+					Region: "region1",
+				},
+			},
+		},
+		gcpinventory.CloudFunctionAssetType: {
+			resource: &assetpb.Resource{
+				Data: NewStructMap(map[string]any{
+					"name": "cloud-function",
+					"url":  "https://cloud-function.com",
+					"serviceConfig": map[string]any{
+						"revision": "1",
+					},
+				}),
+			},
+			enrichments: inventory.AssetEvent{
+				Fass: &inventory.Fass{
+					Name:    "cloud-function",
+					Version: "1",
+				},
+				URL: &inventory.URL{
+					Full: "https://cloud-function.com",
+				},
+			},
+		},
+		gcpinventory.CloudRunService: {},
+	}
+
+	for _, r := range ResourcesToFetch {
+		item, ok := data[r.assetType]
+		if !ok {
+			t.Errorf("Missing case for %s", r.assetType)
+		}
+
+		gcpAsset := &gcpinventory.ExtendedGcpAsset{
+			Asset: &assetpb.Asset{
+				Name:      "/projects/<project UUID>/some_resource",
+				AssetType: r.assetType,
+				Resource:  item.resource,
+			},
+			CloudAccount: &fetching.CloudAccountMetadata{
+				AccountId:        "<project UUID>",
+				AccountName:      "<project name>",
+				OrganisationId:   "<org UUID>",
+				OrganizationName: "<org name>",
+			},
+		}
+		actual := getAssetEvent(r.classification, gcpAsset)
+		expected := item.enrichments
+
+		// Set the common fields that are not set in the enrichments
+		expected.Event = actual.Event
+		expected.Entity = actual.Entity
+		expected.RawAttributes = actual.RawAttributes
+
+		// Cloud is the only field where we have both common and enriched fields
+		if expected.Cloud == nil {
+			// Use the actual cloud fields when there are no cloud enrichments
+			expected.Cloud = actual.Cloud
+		} else {
+			// Use common cloud fields when there are cloud enrichments
+			expected.Cloud.Provider = actual.Cloud.Provider
+			expected.Cloud.AccountID = actual.Cloud.AccountID
+			expected.Cloud.AccountName = actual.Cloud.AccountName
+			expected.Cloud.ProjectID = actual.Cloud.ProjectID
+			expected.Cloud.ProjectName = actual.Cloud.ProjectName
+			expected.Cloud.ServiceName = actual.Cloud.ServiceName
+		}
+
+		assert.Equalf(t, expected, actual, "%v failed", "EnrichAsset")
+	}
+}
+
+func NewStructMap(data map[string]any) *structpb.Struct {
+	dataStruct, err := structpb.NewStruct(data)
+	if err != nil {
+		panic(err)
+	}
+	return dataStruct
 }

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -141,6 +141,12 @@ func (a *AssetInventory) publish(assets []AssetEvent) {
 				"user":           e.User,
 				"Attributes":     e.RawAttributes,
 				"labels":         e.Labels,
+				"tags":           e.Tags,
+				"organization":   e.Organization,
+				"fass":           e.Fass,
+				"url":            e.URL,
+				"orchestrator":   e.Orchestrator,
+				"container":      e.Container,
 				"related.entity": relatedEntity,
 			},
 		}

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -71,7 +71,21 @@ func TestAssetInventory_Run(t *testing.T) {
 					Name: "name",
 				},
 				"related.entity": []string{"arn:aws:ec2:us-east::ec2/234567890"},
-				"Attributes":     emptyRef,
+				"tags":           []string{"foo", "bar"},
+				"orchestrator": &Orchestrator{
+					Type: "kubernetes",
+				},
+				"container": &Container{},
+				"organization": &Organization{
+					ID: "org-id",
+				},
+				"fass": &Fass{
+					Name: "fass",
+				},
+				"url": &URL{
+					Full: "https://example.com",
+				},
+				"Attributes": emptyRef,
 			},
 		},
 	}
@@ -108,6 +122,20 @@ func TestAssetInventory_Run(t *testing.T) {
 			WithNetwork(Network{
 				Name: "vpc-id",
 			}),
+			WithContainer(Container{}),
+			WithOrchestrator(Orchestrator{
+				Type: "kubernetes",
+			}),
+			WithOrganization(Organization{
+				ID: "org-id",
+			}),
+			WithFass(Fass{
+				Name: "fass",
+			}),
+			WithURL(URL{
+				Full: "https://example.com",
+			}),
+			WithTags([]string{"foo", "bar"}),
 		)
 	})
 


### PR DESCRIPTION
### Summary of your changes

- adds specific asset type enrichers
- collects `tags` and `labels` for all assets (if available)

### Screenshot/Data

see [comment](https://github.com/elastic/security-team/issues/10435#issuecomment-2629356829)


### Related Issues
- closes https://github.com/elastic/security-team/issues/10435

