### PR TITLE
[buildkite]: get version qualifier from google bucket

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,36 +5,31 @@ agents:
   image: "family/platform-ingest-beats-ubuntu-2204"
 
 steps:
-  # TODO remove && build.env('VERSION_QUALIFIER') == null
   - label: ":package: Package Cloudbeat - Snapshot"
-    if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env("RUN_RELEASE") == "true") && build.env('VERSION_QUALIFIER') == null
+    if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env("RUN_RELEASE") == "true"
     env:
       WORKFLOW: "snapshot"
     key: "package-snapshot"
     command: "./.buildkite/scripts/package.sh"
     artifact_paths: "build/distributions/*"
 
-  # TODO remove && build.env('VERSION_QUALIFIER') == null
   - label: ":rocket: Publishing Snapshot DRA artifacts"
-    if: (build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env("RUN_RELEASE") == "true") && build.env('VERSION_QUALIFIER') == null
+    if: build.branch == 'main' || build.branch =~ /^[0-9]+\.[0-9x]+\$/ || build.env("RUN_RELEASE") == "true"
     depends_on: "package-snapshot"
     command: "./.buildkite/scripts/publish.sh"
     env:
       WORKFLOW: "snapshot"
 
-    # Allow building staging from main when VERSION_QUALIFIER is set (allow prerelease testing)
-    # TODO remove || build.env('VERSION_QUALIFIER') != null
   - label: ":package: Package Cloudbeat - Staging"
-    if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true" || build.env('VERSION_QUALIFIER') != null
+    if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true"
     env:
       WORKFLOW: "staging"
     key: "package-staging"
     command: "./.buildkite/scripts/package.sh"
     artifact_paths: "build/distributions/*"
 
-  # TODO remove || build.env('VERSION_QUALIFIER') != null
   - label: ":rocket: Publishing Staging DRA artifacts"
-    if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true" || build.env('VERSION_QUALIFIER') != null
+    if: build.branch =~ /^[0-9]+\.[0-9]+\$/ || build.env("RUN_RELEASE") == "true"
     depends_on: "package-staging"
     command: "./.buildkite/scripts/publish.sh"
     env:

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -14,6 +14,7 @@ echo "VERSION_QUALIFIER: ${VERSION_QUALIFIER}"
 
 if [ "$WORKFLOW" = "snapshot" ]; then
     export SNAPSHOT="true"
+    VERSION_QUALIFIER=''
 fi
 
 # debug command to verify

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -11,6 +11,7 @@ PYTHON=$PYTHON_BIN/python
 
 source .buildkite/scripts/qualifier.sh
 echo "VERSION_QUALIFIER: ${VERSION_QUALIFIER}"
+export VERSION_QUALIFIER
 
 if [ "$WORKFLOW" = "snapshot" ]; then
     export SNAPSHOT="true"

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -8,7 +8,9 @@ source ./bin/activate-hermit
 CLOUDBEAT_VERSION=$(grep defaultBeatVersion version/version.go | cut -d'=' -f2 | tr -d '" ')
 PYTHON_BIN=./build/ve/$(go env GOOS)/bin
 PYTHON=$PYTHON_BIN/python
-VERSION_QUALIFIER="${VERSION_QUALIFIER:-""}"
+
+source .buildkite/scripts/qualifier.sh
+echo "VERSION_QUALIFIER: ${VERSION_QUALIFIER}"
 
 if [ "$WORKFLOW" = "snapshot" ]; then
     export SNAPSHOT="true"
@@ -22,7 +24,7 @@ mage package
 
 CSV_FILE="build/dependencies-${CLOUDBEAT_VERSION}"
 [ -n "${SNAPSHOT+x}" ] && CSV_FILE+="-SNAPSHOT"
-if [[ -n "$VERSION_QUALIFIER" ]]; then
+if [[ -n "${VERSION_QUALIFIER}" ]]; then
     CSV_FILE+="-${VERSION_QUALIFIER}"
 fi
 

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -14,7 +14,6 @@ echo "VERSION_QUALIFIER: ${VERSION_QUALIFIER}"
 
 if [ "$WORKFLOW" = "snapshot" ]; then
     export SNAPSHOT="true"
-    VERSION_QUALIFIER=''
 fi
 
 # debug command to verify

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -16,6 +16,9 @@ fi
 
 source .buildkite/scripts/qualifier.sh
 echo "VERSION_QUALIFIER: ${VERSION_QUALIFIER}"
+if [ "$WORKFLOW" = "snapshot" ]; then
+    VERSION_QUALIFIER=''
+fi
 
 # Download artifacts from other stages
 echo "Downloading artifacts..."

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -16,9 +16,6 @@ fi
 
 source .buildkite/scripts/qualifier.sh
 echo "VERSION_QUALIFIER: ${VERSION_QUALIFIER}"
-if [ "$WORKFLOW" = "snapshot" ]; then
-    VERSION_QUALIFIER=''
-fi
 
 # Download artifacts from other stages
 echo "Downloading artifacts..."

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -13,7 +13,9 @@ elif [ -n "$(git ls-remote --heads origin $MAJOR.x)" ]; then
 else
     BRANCH=main
 fi
-VERSION_QUALIFIER="${VERSION_QUALIFIER:-""}"
+
+source .buildkite/scripts/qualifier.sh
+echo "VERSION_QUALIFIER: ${VERSION_QUALIFIER}"
 
 # Download artifacts from other stages
 echo "Downloading artifacts..."

--- a/.buildkite/scripts/qualifier.sh
+++ b/.buildkite/scripts/qualifier.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# this file should be sourced from inside the package and publish script.
+
+fetch_elastic_qualifier() {
+    local branch="${1}"
+    local url="https://storage.googleapis.com/dra-qualifier/${branch}"
+    local qualifier=""
+    if curl -sf -o /dev/null "${url}"; then
+        qualifier=$(curl -s "${url}")
+    fi
+    echo "${qualifier}"
+}
+
+# If the VERSION_QUALIFIER is already set (e.g. buildkite custom run), use that
+# else try to fetch from google bucket for the current branch
+if [ -z "${VERSION_QUALIFIER+x}" ]; then
+    # VERSION_QUALIFIER is not set, get from bucket
+    VERSION_QUALIFIER="$(fetch_elastic_qualifier "${BUILDKITE_BRANCH}")"
+fi

--- a/.buildkite/scripts/qualifier.sh
+++ b/.buildkite/scripts/qualifier.sh
@@ -18,3 +18,8 @@ if [ -z "${VERSION_QUALIFIER+x}" ]; then
     # VERSION_QUALIFIER is not set, get from bucket
     VERSION_QUALIFIER="$(fetch_elastic_qualifier "${BUILDKITE_BRANCH}")"
 fi
+
+# If this is a snapshot build, omit VERSION_QUALIFIER
+if [ "${WORKFLOW}" = "snapshot" ]; then
+    VERSION_QUALIFIER=''
+fi

--- a/.buildkite/scripts/qualifier.sh
+++ b/.buildkite/scripts/qualifier.sh
@@ -12,14 +12,13 @@ fetch_elastic_qualifier() {
     echo "${qualifier}"
 }
 
-# If the VERSION_QUALIFIER is already set (e.g. buildkite custom run), use that
-# else try to fetch from google bucket for the current branch
-if [ -z "${VERSION_QUALIFIER+x}" ]; then
-    # VERSION_QUALIFIER is not set, get from bucket
-    VERSION_QUALIFIER="$(fetch_elastic_qualifier "${BUILDKITE_BRANCH}")"
-fi
-
 # If this is a snapshot build, omit VERSION_QUALIFIER
 if [ "${WORKFLOW}" = "snapshot" ]; then
     VERSION_QUALIFIER=''
+
+# If the VERSION_QUALIFIER is already set (e.g. buildkite custom run), don't modify it.
+# Else try to fetch from google bucket for the current branch
+elif [ -z "${VERSION_QUALIFIER+x}" ]; then
+    # VERSION_QUALIFIER is not set, get from bucket
+    VERSION_QUALIFIER="$(fetch_elastic_qualifier "${BUILDKITE_BRANCH}")"
 fi


### PR DESCRIPTION
### Summary of your changes
In buildkite pipeline scripts (package and publish) get VERSION_QUALIFIER from google bucket (if not already set) for the current branch.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
