### PR TITLE
Fix cspm gcp installation script

### DIFF
--- a/tests/integrations_setup/install_cspm_gcp_integration.py
+++ b/tests/integrations_setup/install_cspm_gcp_integration.py
@@ -75,6 +75,14 @@ if __name__ == "__main__":
             service_account_json = read_json(json_path)
             INTEGRATION_INPUT["vars"]["gcp.credentials.json"] = json.dumps(service_account_json)
 
+    if version.parse(package_version) > version.parse("1.12"):
+        INTEGRATION_INPUT["vars"].update(
+            {
+                "gcp.project_id": cnfg.gcp_dm_config.project_id,
+                "gcp.credentials.type": "credentials-json",
+            },
+        )
+
     logger.info(f"Starting installation of {INTEGRATION_NAME} integration.")
     agent_data, package_data = load_data(
         cfg=cnfg.elk_config,


### PR DESCRIPTION
### Summary of your changes

After adding input vars validation, all required vars must now be provided in the package policy.
This PR updates the CSPM GCP installation script to include the necessary vars.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
