### PR TITLE
[Go] Fix a flaky Kubernetes test setup

### DIFF
--- a/internal/dataprovider/providers/k8s/cluster_name_provider_test.go
+++ b/internal/dataprovider/providers/k8s/cluster_name_provider_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
@@ -64,7 +64,7 @@ func (s *KubernetesClusterNameProviderTestSuite) TestGetClusterName() {
 		},
 		BinaryData: nil,
 	}
-	cfg := &config.Config{}
+	cfg := &config.Config{KubeConfig: "!invalidkubeconfig"}
 	client := fake.NewSimpleClientset(ns, cfgMap)
 	provider := KubernetesClusterNameProvider{KubeClient: client}
 
@@ -81,7 +81,7 @@ func (s *KubernetesClusterNameProviderTestSuite) TestGetClusterMetadataNoCluster
 			UID:  types.UID(kubeSystemNamespaceId),
 		},
 	}
-	cfg := &config.Config{}
+	cfg := &config.Config{KubeConfig: "!invalidkubeconfig"}
 	client := fake.NewSimpleClientset(ns)
 	provider := KubernetesClusterNameProvider{KubeClient: client}
 

--- a/internal/dataprovider/providers/k8s/cluster_name_provider_test.go
+++ b/internal/dataprovider/providers/k8s/cluster_name_provider_test.go
@@ -64,7 +64,7 @@ func (s *KubernetesClusterNameProviderTestSuite) TestGetClusterName() {
 		},
 		BinaryData: nil,
 	}
-	cfg := &config.Config{KubeConfig: "!invalidkubeconfig"}
+	cfg := &config.Config{KubeConfig: "/dev/null"}
 	client := fake.NewSimpleClientset(ns, cfgMap)
 	provider := KubernetesClusterNameProvider{KubeClient: client}
 
@@ -81,7 +81,7 @@ func (s *KubernetesClusterNameProviderTestSuite) TestGetClusterMetadataNoCluster
 			UID:  types.UID(kubeSystemNamespaceId),
 		},
 	}
-	cfg := &config.Config{KubeConfig: "!invalidkubeconfig"}
+	cfg := &config.Config{KubeConfig: "/dev/null"}
 	client := fake.NewSimpleClientset(ns)
 	provider := KubernetesClusterNameProvider{KubeClient: client}
 

--- a/internal/dataprovider/providers/k8s/cluster_name_provider_test.go
+++ b/internal/dataprovider/providers/k8s/cluster_name_provider_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"


### PR DESCRIPTION
### Summary of your changes

One of the k8s suite tests was flaky. In case a valid `kubeconfig` is present on the machine that runs the test, the suite will fail, getting the data from default `kubeconfig` path. As a solution, I set the `KubeConfig` path to something non-existent to ensure we get the expected result and true `kubeconfig` does not interfere.

### Screenshot/Data

<img width="1449" alt="Screenshot 2025-02-04 at 10 19 49" src="https://github.com/user-attachments/assets/b6a318c0-85c6-4136-bce8-57c3e00f75e4" />

_The test failing before the fix; Please note an actual cluster name from my `kubeconfig`: `production`._

### Related Issues

None, found randomly on my machine.

