### PR TITLE
Ensure cloudbeat is installed with >= 9.x elastic-agent

### DIFF
--- a/deploy/asset-inventory-arm/install-agent-dev.sh
+++ b/deploy/asset-inventory-arm/install-agent-dev.sh
@@ -11,6 +11,6 @@ ElasticAgentArtifact="elastic-agent-$ElasticAgentVersion-linux-x86_64"
 curl -L -O "${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz"
 tar xzf "${ElasticAgentArtifact}.tar.gz"
 cd "${ElasticAgentArtifact}"
-sudo ./elastic-agent install --non-interactive --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
+sudo ./elastic-agent install --non-interactive --install-servers --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
 
 wait

--- a/deploy/asset-inventory-arm/install-agent.sh
+++ b/deploy/asset-inventory-arm/install-agent.sh
@@ -19,6 +19,6 @@ ElasticAgentArtifact="elastic-agent-$ElasticAgentVersion-linux-x86_64"
 curl -L -O "${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz"
 tar xzf "${ElasticAgentArtifact}.tar.gz"
 cd "${ElasticAgentArtifact}"
-sudo ./elastic-agent install --non-interactive --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
+sudo ./elastic-agent install --non-interactive --install-servers --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
 
 wait

--- a/deploy/asset-inventory-cloudformation/elastic-agent-ec2-organization.yml
+++ b/deploy/asset-inventory-cloudformation/elastic-agent-ec2-organization.yml
@@ -174,7 +174,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/asset-inventory-cloudformation/elastic-agent-ec2.yml
+++ b/deploy/asset-inventory-cloudformation/elastic-agent-ec2.yml
@@ -134,7 +134,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/azure/install-agent-dev.sh
+++ b/deploy/azure/install-agent-dev.sh
@@ -11,6 +11,6 @@ ElasticAgentArtifact="elastic-agent-$ElasticAgentVersion-linux-x86_64"
 curl -L -O "${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz"
 tar xzf "${ElasticAgentArtifact}.tar.gz"
 cd "${ElasticAgentArtifact}"
-sudo ./elastic-agent install --non-interactive --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
+sudo ./elastic-agent install --non-interactive --install-servers --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
 
 wait

--- a/deploy/azure/install-agent.sh
+++ b/deploy/azure/install-agent.sh
@@ -19,6 +19,6 @@ ElasticAgentArtifact="elastic-agent-$ElasticAgentVersion-linux-x86_64"
 curl -L -O "${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz"
 tar xzf "${ElasticAgentArtifact}.tar.gz"
 cd "${ElasticAgentArtifact}"
-sudo ./elastic-agent install --non-interactive --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
+sudo ./elastic-agent install --non-interactive --install-servers --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
 
 wait

--- a/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
@@ -150,7 +150,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cnvm-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cnvm-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
@@ -174,7 +174,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/cloudformation/elastic-agent-ec2-cspm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm.yml
@@ -135,7 +135,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/deployment-manager/compute_engine.py
+++ b/deploy/deployment-manager/compute_engine.py
@@ -90,7 +90,7 @@ def generate_config(context):
                                 "tar xzvf $ElasticAgentArtifact.tar.gz\n",
                                 "cd $ElasticAgentArtifact\n",
                                 f"sudo ./elastic-agent install "
-                                f"--non-interactive --url={fleet_url} --enrollment-token={enrollment_token}",
+                                f"--non-interactive --install-servers --url={fleet_url} --enrollment-token={enrollment_token}",
                             ],
                         ),
                     },

--- a/deploy/deployment-manager/compute_engine.py
+++ b/deploy/deployment-manager/compute_engine.py
@@ -89,8 +89,9 @@ def generate_config(context):
                                 f"curl -L -O {artifact_server}/$ElasticAgentArtifact.tar.gz\n",
                                 "tar xzvf $ElasticAgentArtifact.tar.gz\n",
                                 "cd $ElasticAgentArtifact\n",
-                                f"sudo ./elastic-agent install "
-                                f"--non-interactive --install-servers --url={fleet_url} --enrollment-token={enrollment_token}",
+                                "sudo ./elastic-agent install ",
+                                "--non-interactive --install-servers ",
+                                f"--url={fleet_url} --enrollment-token={enrollment_token}",
                             ],
                         ),
                     },


### PR DESCRIPTION
### Summary of your changes

> [!warning] 
> Do **not** backport this PR to 8.x

Adding `--install-servers` flag to deployment templates so that cloudbeat is installed in v9.x elastic-agent.

### Screenshot/Data

<img width="1231" alt="Screenshot 2025-02-13 at 10 36 20" src="https://github.com/user-attachments/assets/640ac0f2-d75d-4b5d-9d0a-5667caa8699b" />

_1. Showcasing the new `elastic-agent install` flag in 9.x_

<img width="2560" alt="Screenshot 2025-02-13 at 13 55 08" src="https://github.com/user-attachments/assets/1b8a3dea-4a11-46eb-bede-7deb37d924a7" />

_2. Showing installed v9.0.0-beta1 agent_

### Related Issues

Towards https://github.com/elastic/security-team/issues/11500
