### PR TITLE
Ensure cloudbeat is installed with >= 9.x elastic-agent

### DIFF
--- a/deploy/asset-inventory-arm/install-agent-dev.sh
+++ b/deploy/asset-inventory-arm/install-agent-dev.sh
@@ -11,6 +11,6 @@ ElasticAgentArtifact="elastic-agent-$ElasticAgentVersion-linux-x86_64"
 curl -L -O "${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz"
 tar xzf "${ElasticAgentArtifact}.tar.gz"
 cd "${ElasticAgentArtifact}"
-sudo ./elastic-agent install --non-interactive --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
+sudo ./elastic-agent install --non-interactive --install-servers --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
 
 wait

--- a/deploy/asset-inventory-arm/install-agent.sh
+++ b/deploy/asset-inventory-arm/install-agent.sh
@@ -19,6 +19,6 @@ ElasticAgentArtifact="elastic-agent-$ElasticAgentVersion-linux-x86_64"
 curl -L -O "${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz"
 tar xzf "${ElasticAgentArtifact}.tar.gz"
 cd "${ElasticAgentArtifact}"
-sudo ./elastic-agent install --non-interactive --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
+sudo ./elastic-agent install --non-interactive --install-servers --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
 
 wait

--- a/deploy/asset-inventory-cloudformation/elastic-agent-ec2-organization.yml
+++ b/deploy/asset-inventory-cloudformation/elastic-agent-ec2-organization.yml
@@ -174,7 +174,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/asset-inventory-cloudformation/elastic-agent-ec2.yml
+++ b/deploy/asset-inventory-cloudformation/elastic-agent-ec2.yml
@@ -134,7 +134,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/azure/install-agent-dev.sh
+++ b/deploy/azure/install-agent-dev.sh
@@ -11,6 +11,6 @@ ElasticAgentArtifact="elastic-agent-$ElasticAgentVersion-linux-x86_64"
 curl -L -O "${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz"
 tar xzf "${ElasticAgentArtifact}.tar.gz"
 cd "${ElasticAgentArtifact}"
-sudo ./elastic-agent install --non-interactive --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
+sudo ./elastic-agent install --non-interactive --install-servers --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
 
 wait

--- a/deploy/azure/install-agent.sh
+++ b/deploy/azure/install-agent.sh
@@ -19,6 +19,6 @@ ElasticAgentArtifact="elastic-agent-$ElasticAgentVersion-linux-x86_64"
 curl -L -O "${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz"
 tar xzf "${ElasticAgentArtifact}.tar.gz"
 cd "${ElasticAgentArtifact}"
-sudo ./elastic-agent install --non-interactive --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
+sudo ./elastic-agent install --non-interactive --install-servers --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
 
 wait

--- a/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
@@ -150,7 +150,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cnvm-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cnvm-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
@@ -174,7 +174,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/cloudformation/elastic-agent-ec2-cspm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm.yml
@@ -135,7 +135,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/deployment-manager/compute_engine.py
+++ b/deploy/deployment-manager/compute_engine.py
@@ -90,7 +90,7 @@ def generate_config(context):
                                 "tar xzvf $ElasticAgentArtifact.tar.gz\n",
                                 "cd $ElasticAgentArtifact\n",
                                 f"sudo ./elastic-agent install "
-                                f"--non-interactive --url={fleet_url} --enrollment-token={enrollment_token}",
+                                f"--non-interactive --install-servers --url={fleet_url} --enrollment-token={enrollment_token}",
                             ],
                         ),
                     },

--- a/deploy/deployment-manager/compute_engine.py
+++ b/deploy/deployment-manager/compute_engine.py
@@ -89,8 +89,9 @@ def generate_config(context):
                                 f"curl -L -O {artifact_server}/$ElasticAgentArtifact.tar.gz\n",
                                 "tar xzvf $ElasticAgentArtifact.tar.gz\n",
                                 "cd $ElasticAgentArtifact\n",
-                                f"sudo ./elastic-agent install "
-                                f"--non-interactive --install-servers --url={fleet_url} --enrollment-token={enrollment_token}",
+                                "sudo ./elastic-agent install ",
+                                "--non-interactive --install-servers ",
+                                f"--url={fleet_url} --enrollment-token={enrollment_token}",
                             ],
                         ),
                     },

--- a/deploy/deployment-manager/compute_engine.py
+++ b/deploy/deployment-manager/compute_engine.py
@@ -89,9 +89,8 @@ def generate_config(context):
                                 f"curl -L -O {artifact_server}/$ElasticAgentArtifact.tar.gz\n",
                                 "tar xzvf $ElasticAgentArtifact.tar.gz\n",
                                 "cd $ElasticAgentArtifact\n",
-                                "sudo ./elastic-agent install ",
-                                "--non-interactive --install-servers ",
-                                f"--url={fleet_url} --enrollment-token={enrollment_token}",
+                                f"sudo ./elastic-agent install "
+                                f"--non-interactive --install-servers --url={fleet_url} --enrollment-token={enrollment_token}",
                             ],
                         ),
                     },

--- a/tests/integration/tests/test_sanity_checks.py
+++ b/tests/integration/tests/test_sanity_checks.py
@@ -22,7 +22,7 @@ from configuration import elasticsearch
 from loguru import logger
 
 CONFIG_TIMEOUT = 120
-GCP_CONFIG_TIMEOUT = 600
+GCP_CONFIG_TIMEOUT = 1200
 CNVM_CONFIG_TIMEOUT = 3600
 
 # The timeout and backoff for waiting all agents are running the specified component.

--- a/tests/integration/tests/test_sanity_checks.py
+++ b/tests/integration/tests/test_sanity_checks.py
@@ -10,8 +10,6 @@ verifying that there are findings of 'resource.type' for each feature.
 import time
 
 import pytest
-from loguru import logger
-
 from commonlib.agents_map import (
     CIS_AWS_COMPONENT,
     CIS_AZURE_COMPONENT,
@@ -21,6 +19,7 @@ from commonlib.agents_map import (
 )
 from commonlib.utils import get_findings
 from configuration import elasticsearch
+from loguru import logger
 
 CONFIG_TIMEOUT = 120
 GCP_CONFIG_TIMEOUT = 1200

--- a/tests/integration/tests/test_sanity_checks.py
+++ b/tests/integration/tests/test_sanity_checks.py
@@ -304,14 +304,14 @@ def wait_components_list(actual: AgentComponentMapping, expected: AgentExpectedM
     if not elasticsearch.kibana_url:
         return [""]
 
-    actual.load_map()
+    try_loading_map(actual)
     start_time = time.time()
     while time.time() - start_time < COMPONENTS_TIMEOUT:
         if len(actual.component_map[component]) == expected.expected_map[component]:
             break
 
         time.sleep(COMPONENTS_BACKOFF)
-        actual.load_map()
+        try_loading_map(actual)
 
     assert expected.expected_map[component] == len(
         actual.component_map[component],
@@ -319,3 +319,9 @@ def wait_components_list(actual: AgentComponentMapping, expected: AgentExpectedM
  {component}, but got {len(actual.component_map[component])}"
 
     return actual.component_map[component]
+
+def try_loading_map(actual: AgentComponentMapping) -> None:
+    try:
+        actual.load_map()
+    except Exception as ex:
+        logger.warning(ex)

--- a/tests/integration/tests/test_sanity_checks.py
+++ b/tests/integration/tests/test_sanity_checks.py
@@ -10,6 +10,8 @@ verifying that there are findings of 'resource.type' for each feature.
 import time
 
 import pytest
+from loguru import logger
+
 from commonlib.agents_map import (
     CIS_AWS_COMPONENT,
     CIS_AZURE_COMPONENT,
@@ -19,7 +21,6 @@ from commonlib.agents_map import (
 )
 from commonlib.utils import get_findings
 from configuration import elasticsearch
-from loguru import logger
 
 CONFIG_TIMEOUT = 120
 GCP_CONFIG_TIMEOUT = 1200
@@ -320,8 +321,13 @@ def wait_components_list(actual: AgentComponentMapping, expected: AgentExpectedM
 
     return actual.component_map[component]
 
+
 def try_loading_map(actual: AgentComponentMapping) -> None:
+    """
+    A convenient wrapper to catch errors when the actual map that is supposed to be loaded
+    is not ready yet.
+    """
     try:
         actual.load_map()
-    except Exception as ex:
+    except (AttributeError, KeyError, IndexError) as ex:
         logger.warning(ex)

--- a/tests/integration/tests/test_sanity_checks.py
+++ b/tests/integration/tests/test_sanity_checks.py
@@ -22,7 +22,7 @@ from configuration import elasticsearch
 from loguru import logger
 
 CONFIG_TIMEOUT = 120
-GCP_CONFIG_TIMEOUT = 1200
+GCP_CONFIG_TIMEOUT = 600
 CNVM_CONFIG_TIMEOUT = 3600
 
 # The timeout and backoff for waiting all agents are running the specified component.


### PR DESCRIPTION
### Summary of your changes

> [!warning] 
> Do **not** backport this PR to 8.x

Adding `--install-servers` flag to deployment templates so that cloudbeat is installed in v9.x elastic-agent.

### Screenshot/Data

<img width="1231" alt="Screenshot 2025-02-13 at 10 36 20" src="https://github.com/user-attachments/assets/640ac0f2-d75d-4b5d-9d0a-5667caa8699b" />

_1. Showcasing the new `elastic-agent install` flag in 9.x_

<img width="2560" alt="Screenshot 2025-02-13 at 13 55 08" src="https://github.com/user-attachments/assets/1b8a3dea-4a11-46eb-bede-7deb37d924a7" />

_2. Showing installed v9.0.0-beta1 agent_

### Related Issues

Towards https://github.com/elastic/security-team/issues/11500
