### PR TITLE
Update install-agent.sh script

### DIFF
--- a/deploy/azure/ARM-for-single-account.json
+++ b/deploy/azure/ARM-for-single-account.json
@@ -341,7 +341,7 @@
                                 "typeHandlerVersion": "2.1",
                                 "settings": {
                                     "fileUris": [
-                                        "https://raw.githubusercontent.com/elastic/cloudbeat/dg-fix-az-install-script/deploy/azure/install-agent.sh"
+                                        "https://raw.githubusercontent.com/elastic/cloudbeat/main/deploy/azure/install-agent.sh"
                                     ],
                                     "commandToExecute": "[concat('bash install-agent.sh ', parameters('ElasticAgentVersion'), ' ', parameters('ElasticArtifactServer'), ' ', parameters('FleetUrl'), ' ', parameters('EnrollmentToken'))]"
                                 }

--- a/deploy/azure/ARM-for-single-account.json
+++ b/deploy/azure/ARM-for-single-account.json
@@ -341,7 +341,7 @@
                                 "typeHandlerVersion": "2.1",
                                 "settings": {
                                     "fileUris": [
-                                        "https://raw.githubusercontent.com/elastic/cloudbeat/main/deploy/azure/install-agent.sh"
+                                        "https://raw.githubusercontent.com/elastic/cloudbeat/dg-fix-az-install-script/deploy/azure/install-agent.sh"
                                     ],
                                     "commandToExecute": "[concat('bash install-agent.sh ', parameters('ElasticAgentVersion'), ' ', parameters('ElasticArtifactServer'), ' ', parameters('FleetUrl'), ' ', parameters('EnrollmentToken'))]"
                                 }

--- a/deploy/azure/install-agent-dev.sh
+++ b/deploy/azure/install-agent-dev.sh
@@ -7,10 +7,16 @@ ElasticArtifactServer=${2:?$usage}
 FleetUrl=${3:?$usage}
 EnrollmentToken=${4:?$usage}
 
+install_servers_opt=""
+major_version=$(echo "${ElasticAgentVersion}" | cut -d'.' -f1)
+if [ "$major_version" -ge 9 ]; then
+    install_servers_opt="--install-servers"
+fi
+
 ElasticAgentArtifact="elastic-agent-$ElasticAgentVersion-linux-x86_64"
 curl -L -O "${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz"
 tar xzf "${ElasticAgentArtifact}.tar.gz"
 cd "${ElasticAgentArtifact}"
-sudo ./elastic-agent install --non-interactive --install-servers --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
+sudo ./elastic-agent install --non-interactive --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}" ${install_servers_opt:+$install_servers_opt}
 
 wait

--- a/deploy/azure/install-agent.sh
+++ b/deploy/azure/install-agent.sh
@@ -15,10 +15,16 @@ ElasticArtifactServer=${2:?$usage}
 FleetUrl=${3:?$usage}
 EnrollmentToken=${4:?$usage}
 
+install_servers_opt=""
+major_version=$(echo "${ElasticAgentVersion}" | cut -d'.' -f1)
+if [ "$major_version" -ge 9 ]; then
+    install_servers_opt="--install-servers"
+fi
+
 ElasticAgentArtifact="elastic-agent-$ElasticAgentVersion-linux-x86_64"
 curl -L -O "${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz"
 tar xzf "${ElasticAgentArtifact}.tar.gz"
 cd "${ElasticAgentArtifact}"
-sudo ./elastic-agent install --non-interactive --install-servers --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}"
+sudo ./elastic-agent install --non-interactive --url="${FleetUrl}" --enrollment-token="${EnrollmentToken}" ${install_servers_opt:+$install_servers_opt}
 
 wait


### PR DESCRIPTION
### Summary of your changes

This PR updates the `install-agent.sh` script to support installing Elastic Agent from both 8.x and 9.x versions.

### Screenshot/Data

![Screenshot 2025-02-16 at 16 24 02](https://github.com/user-attachments/assets/dfcd952e-8782-42b3-b471-a51d8dd9c526)

![Screenshot 2025-02-16 at 16 39 12](https://github.com/user-attachments/assets/3e364c6f-ad0d-476c-bae0-d24e2ff0ff43)


### Related Issues

- https://github.com/elastic/security-team/issues/11500
