### PR TITLE
Fix CloudFormation templates to support installation on both 8.x and 9.x versions

### DIFF
--- a/deploy/asset-inventory-cloudformation/elastic-agent-ec2-organization.yml
+++ b/deploy/asset-inventory-cloudformation/elastic-agent-ec2-organization.yml
@@ -179,7 +179,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive ${install_servers_opt:+$install_servers_opt} --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive $install_servers_opt --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/asset-inventory-cloudformation/elastic-agent-ec2-organization.yml
+++ b/deploy/asset-inventory-cloudformation/elastic-agent-ec2-organization.yml
@@ -170,11 +170,16 @@ Resources:
             sudo yum install -y aws-cfn-bootstrap || { sudo apt-get update && sudo apt-get -y install python3-pip && sudo pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz; }
             cfn-signal --exit-code "$1" --stack ${AWS::StackName} --resource ElasticAgentEc2Instance --region ${AWS::Region}
           }
+          install_servers_opt=""
+          major_version=$(echo "${ElasticAgentVersion}" | cut -d'.' -f1)
+          if [ "$major_version" -ge 9 ]; then
+              install_servers_opt="--install-servers"
+          fi
           ElasticAgentArtifact=elastic-agent-${ElasticAgentVersion}-linux-arm64
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive ${install_servers_opt:+$install_servers_opt} --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/asset-inventory-cloudformation/elastic-agent-ec2.yml
+++ b/deploy/asset-inventory-cloudformation/elastic-agent-ec2.yml
@@ -130,11 +130,16 @@ Resources:
             sudo yum install -y aws-cfn-bootstrap || { sudo apt-get update && sudo apt-get -y install python3-pip && sudo pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz; }
             cfn-signal --exit-code "$1" --stack ${AWS::StackName} --resource ElasticAgentEc2Instance --region ${AWS::Region}
           }
+          install_servers_opt=""
+          major_version=$(echo "${ElasticAgentVersion}" | cut -d'.' -f1)
+          if [ "$major_version" -ge 9 ]; then
+              install_servers_opt="--install-servers"
+          fi
           ElasticAgentArtifact=elastic-agent-${ElasticAgentVersion}-linux-arm64
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive ${install_servers_opt:+$install_servers_opt} --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/asset-inventory-cloudformation/elastic-agent-ec2.yml
+++ b/deploy/asset-inventory-cloudformation/elastic-agent-ec2.yml
@@ -139,7 +139,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive ${install_servers_opt:+$install_servers_opt} --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive $install_servers_opt --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-asset-inventory-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
@@ -155,7 +155,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive ${install_servers_opt:+$install_servers_opt} --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cnvm-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive $install_servers_opt --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cnvm-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cnvm.yml
@@ -146,11 +146,16 @@ Resources:
             sudo yum install -y aws-cfn-bootstrap || { sudo apt-get update && sudo apt-get -y install python3-pip && sudo pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz; }
             cfn-signal --exit-code "$1" --stack ${AWS::StackName} --resource ElasticAgentEc2Instance --region ${AWS::Region}
           }
+          install_servers_opt=""
+          major_version=$(echo "${ElasticAgentVersion}" | cut -d'.' -f1)
+          if [ "$major_version" -ge 9 ]; then
+              install_servers_opt="--install-servers"
+          fi
           ElasticAgentArtifact=elastic-agent-${ElasticAgentVersion}-linux-arm64
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cnvm-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive ${install_servers_opt:+$install_servers_opt} --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cnvm-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
@@ -179,7 +179,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive ${install_servers_opt:+$install_servers_opt} --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive $install_servers_opt --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
@@ -170,11 +170,16 @@ Resources:
             sudo yum install -y aws-cfn-bootstrap || { sudo apt-get update && sudo apt-get -y install python3-pip && sudo pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz; }
             cfn-signal --exit-code "$1" --stack ${AWS::StackName} --resource ElasticAgentEc2Instance --region ${AWS::Region}
           }
+          install_servers_opt=""
+          major_version=$(echo "${ElasticAgentVersion}" | cut -d'.' -f1)
+          if [ "$major_version" -ge 9 ]; then
+              install_servers_opt="--install-servers"
+          fi
           ElasticAgentArtifact=elastic-agent-${ElasticAgentVersion}-linux-arm64
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive ${install_servers_opt:+$install_servers_opt} --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-organization-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/cloudformation/elastic-agent-ec2-cspm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm.yml
@@ -140,7 +140,7 @@ Resources:
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive ${install_servers_opt:+$install_servers_opt} --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive $install_servers_opt --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda

--- a/deploy/cloudformation/elastic-agent-ec2-cspm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm.yml
@@ -131,11 +131,16 @@ Resources:
             sudo yum install -y aws-cfn-bootstrap || { sudo apt-get update && sudo apt-get -y install python3-pip && sudo pip3 install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz; }
             cfn-signal --exit-code "$1" --stack ${AWS::StackName} --resource ElasticAgentEc2Instance --region ${AWS::Region}
           }
+          install_servers_opt=""
+          major_version=$(echo "${ElasticAgentVersion}" | cut -d'.' -f1)
+          if [ "$major_version" -ge 9 ]; then
+              install_servers_opt="--install-servers"
+          fi
           ElasticAgentArtifact=elastic-agent-${ElasticAgentVersion}-linux-arm64
           curl -L -O ${ElasticArtifactServer}/$ElasticAgentArtifact.tar.gz
           tar xzvf $ElasticAgentArtifact.tar.gz
           cd $ElasticAgentArtifact
-          sudo ./elastic-agent install --non-interactive --install-servers --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
+          sudo ./elastic-agent install --non-interactive ${install_servers_opt:+$install_servers_opt} --url=${FleetUrl} --enrollment-token=${EnrollmentToken} --tag=cft_version:cloudformation-cspm-single-account-CFT_VERSION.yml --tag=cft_arn:${AWS::StackId}
           signal $?
       BlockDeviceMappings:
         - DeviceName: /dev/xvda


### PR DESCRIPTION
### Summary of your changes

This PR updates the internal script to support Elastic Agent installation on both 8.x and 9.x versions.

### Screenshot/Data

![Screenshot 2025-02-18 at 9 25 09](https://github.com/user-attachments/assets/8e6d7b29-009c-4601-b9e7-9fd03fac3886)
![Screenshot 2025-02-18 at 9 26 48](https://github.com/user-attachments/assets/213ee560-f809-4a67-8bee-c4503cceaa40)



### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
