### PR TITLE
Update workflow to fix running UI sanity tests.

### DIFF
--- a/.github/actions/elk-stack/action.yml
+++ b/.github/actions/elk-stack/action.yml
@@ -108,11 +108,11 @@ runs:
         es_url_stripped="${es_url//https:\/\//}"
 
         # Create test URLs with credentials
-        test_kibana_url="https://${ES_USER}:${ES_PASSWORD}@${kibana_url_stripped}"
+        test_kibana_url="https://${es_user}:${es_password}@${kibana_url_stripped}"
         echo "::add-mask::${test_kibana_url}"
         echo "test-kibana-url=${test_kibana_url}" >> "$GITHUB_OUTPUT"
 
-        test_es_url="https://${ES_USER}:${ES_PASSWORD}@${es_url_stripped}"
+        test_es_url="https://${es_user}:${es_password}@${es_url_stripped}"
         echo "::add-mask::${test_es_url}"
         echo "test-es-url=${test_es_url}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
### Summary of your changes

This PR fixes the Kibana links used for running UI sanity tests.
This [attempt](https://github.com/elastic/cloudbeat/actions/runs/13519520355/job/37775453787) confirms that UI tests were executed, with one test failing due to recent [UI changes](https://github.com/elastic/kibana/pull/207155), which will be addressed in a separate [fix](https://github.com/elastic/kibana/pull/212368).

Related Changes
- https://github.com/elastic/kibana/pull/212368
