### PR TITLE
Update GCP label in GCP Deployment Manager workflow

### DIFF
--- a/.github/workflows/test-gcp-dm.yml
+++ b/.github/workflows/test-gcp-dm.yml
@@ -26,7 +26,7 @@ env:
   DEPLOYMENT_MANAGER_DIR: deploy/deployment-manager
   TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
   TF_VAR_ess_region: gcp-us-west2 # default region for testing deployments
-  GCP_LABELS: "ci=integration,owner=${{ github.actor }}"
+  GCP_LABELS: "ci=integration"
 
 jobs:
   # Test a GCP Deployment Manager deployment using Application Default Credentials


### PR DESCRIPTION
### Summary of your changes

This PR removes `github.actor` from the GCP label, as GCP deployment enforces strict labeling rules. Since `github.actor` can have unpredictable values, removing it reduces the risk of deployment failures like [there](https://github.com/elastic/cloudbeat/actions/runs/13410325369/job/37459503924).
