### PR TITLE
[Asset Inventory][Azure] Fix empty `entity.name` field for some resources

### DIFF
--- a/internal/inventory/azurefetcher/common.go
+++ b/internal/inventory/azurefetcher/common.go
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package azurefetcher
+
+func pickName(sortedOptions ...string) string {
+	for _, option := range sortedOptions {
+		if option != "" {
+			return option
+		}
+	}
+	return ""
+}

--- a/internal/inventory/azurefetcher/fetcher_account.go
+++ b/internal/inventory/azurefetcher/fetcher_account.go
@@ -75,7 +75,7 @@ func (f *accountFetcher) fetch(ctx context.Context, resourceName string, functio
 		assetChan <- inventory.NewAssetEvent(
 			classification,
 			item.Id,
-			item.DisplayName,
+			pickName(item.DisplayName, item.Name, item.Id),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.Cloud{
 				Provider:    inventory.AzureCloudProvider,

--- a/internal/inventory/azurefetcher/fetcher_activedirectory.go
+++ b/internal/inventory/azurefetcher/fetcher_activedirectory.go
@@ -74,7 +74,7 @@ func (f *activedirectoryFetcher) fetchServicePrincipals(ctx context.Context, ass
 		assetChan <- inventory.NewAssetEvent(
 			inventory.AssetClassificationAzureServicePrincipal,
 			pointers.Deref(item.GetId()),
-			pointers.Deref(item.GetDisplayName()),
+			pickName(pointers.Deref(item.GetDisplayName()), pointers.Deref(item.GetId())),
 			inventory.WithRawAsset(
 				item.GetBackingStore().Enumerate(),
 			),
@@ -101,7 +101,7 @@ func (f *activedirectoryFetcher) fetchDirectoryRoles(ctx context.Context, assetC
 		assetChan <- inventory.NewAssetEvent(
 			inventory.AssetClassificationAzureRoleDefinition,
 			pointers.Deref(item.GetId()),
-			pointers.Deref(item.GetDisplayName()),
+			pickName(pointers.Deref(item.GetDisplayName()), pointers.Deref(item.GetId())),
 			inventory.WithRawAsset(
 				item.GetBackingStore().Enumerate(),
 			),
@@ -136,7 +136,7 @@ func (f *activedirectoryFetcher) fetchGroups(ctx context.Context, assetChan chan
 		assetChan <- inventory.NewAssetEvent(
 			inventory.AssetClassificationAzureEntraGroup,
 			pointers.Deref(item.GetId()),
-			pointers.Deref(item.GetDisplayName()),
+			pickName(pointers.Deref(item.GetDisplayName()), pointers.Deref(item.GetId())),
 			inventory.WithRawAsset(
 				item.GetBackingStore().Enumerate(),
 			),
@@ -167,7 +167,7 @@ func (f *activedirectoryFetcher) fetchUsers(ctx context.Context, assetChan chan<
 		assetChan <- inventory.NewAssetEvent(
 			inventory.AssetClassificationAzureEntraUser,
 			pointers.Deref(item.GetId()),
-			pointers.Deref(item.GetDisplayName()),
+			pickName(pointers.Deref(item.GetDisplayName()), pointers.Deref(item.GetId())),
 			inventory.WithRawAsset(
 				item.GetBackingStore().Enumerate(),
 			),

--- a/internal/inventory/azurefetcher/fetcher_resource_graph.go
+++ b/internal/inventory/azurefetcher/fetcher_resource_graph.go
@@ -83,14 +83,10 @@ func (f *resourceGraphFetcher) fetch(ctx context.Context, resourceName, resource
 	}
 
 	for _, item := range azureAssets {
-		name := item.Name
-		if name == "" {
-			name = item.DisplayName
-		}
 		asset := inventory.NewAssetEvent(
 			classification,
 			item.Id,
-			name,
+			pickName(item.Name, item.DisplayName, item.Id),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.Cloud{
 				Provider:    inventory.AzureCloudProvider,

--- a/internal/inventory/azurefetcher/fetcher_storage.go
+++ b/internal/inventory/azurefetcher/fetcher_storage.go
@@ -116,7 +116,7 @@ func (f *storageFetcher) fetch(ctx context.Context, storageAccounts []azurelib.A
 		assetChan <- inventory.NewAssetEvent(
 			classification,
 			item.Id,
-			item.DisplayName,
+			pickName(item.DisplayName, item.Name, item.Id),
 			inventory.WithRawAsset(item),
 			inventory.WithCloud(inventory.Cloud{
 				Provider:    inventory.AzureCloudProvider,


### PR DESCRIPTION
### Summary of your changes

This fixes missing resource names for some Storage services and Tenants.

### Screenshot/Data

<img width="2560" alt="Screenshot 2025-02-21 at 12 34 09" src="https://github.com/user-attachments/assets/0c771b9d-7f9c-407e-8faa-458719e4845b" />

_Before_

<img width="2560" alt="Screenshot 2025-02-21 at 12 34 51" src="https://github.com/user-attachments/assets/4dc915eb-4988-4738-9553-e56fb25c6fa8" />

_After_


### Related Issues

From 9.0 QA Cycle
