### PR TITLE
Fix EKS cluster deployment

### DIFF
--- a/deploy/test-environments/modules/aws/eks/oidc.tf
+++ b/deploy/test-environments/modules/aws/eks/oidc.tf
@@ -7,5 +7,15 @@ resource "aws_eks_identity_provider_config" "eks_oidc" {
 
   }
 
+  depends_on = [module.eks, null_resource.wait_for_cluster]
+}
+
+resource "null_resource" "wait_for_cluster" {
   depends_on = [module.eks]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      aws eks wait cluster-active --name ${local.cluster_name} --region ${var.region}
+    EOT
+  }
 }


### PR DESCRIPTION
### Summary of your changes

This PR adds a new resource that checks the EKS cluster status and waits until the cluster becomes active.

[AWS docs reference](https://docs.aws.amazon.com/cli/latest/reference/eks/wait/cluster-active.html#description)


### Screenshot/Data

[Successful run](https://github.com/elastic/cloudbeat/actions/runs/13833462722/job/38702886455) after the fix.


![Screenshot 2025-03-13 at 14 26 55](https://github.com/user-attachments/assets/4269b7c9-ce4e-4c0d-989e-ad8b381a3bf7)

### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

