### PR TITLE
Update deployment name

### DIFF
--- a/.github/workflows/test-e2e-flow.yml
+++ b/.github/workflows/test-e2e-flow.yml
@@ -38,7 +38,8 @@ jobs:
         run: |
           prefix="ech"
           if [[ "$IS_SERVERLESS" == "true" ]]; then
-            prefix="serverless"
+            # Short name due to deployment name length limit
+            prefix="proj"
           fi
 
           branch="${BRANCH}"


### PR DESCRIPTION
### Summary of your changes

Test-runner workflow is failing on the `run-serverless-main` job due to a deployment name that is too long. This PR shortens the deployment name to resolve the issue.


### Screenshot/Data

![Screenshot 2025-04-02 at 14 57 36](https://github.com/user-attachments/assets/fc2ee7f3-e4cb-48ea-bbeb-fcf38a192843)

