### PR TITLE
Update references from 8.x to 8.19 following branch deprecation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,13 +40,13 @@ updates:
     schedule:
       interval: "monthly"
 
-  # Maintain dependencies for go.mod 8.x branch
+  # Maintain dependencies for go.mod 8.19 branch
   - package-ecosystem: "gomod"
-    target-branch: "8.x"
+    target-branch: "8.19"
     directory: "/"
     commit-message:
       include: scope
-      prefix: "8.x"
+      prefix: "8.19"
     groups:
       azure:
         patterns:
@@ -102,7 +102,7 @@ updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
-    target-branch: "8.x"
+    target-branch: "8.19"
     schedule:
       interval: "monthly"
     labels:

--- a/.github/workflows/arm-template-lint.yml
+++ b/.github/workflows/arm-template-lint.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - main
-      - "8.x"
+      - "8.19"
     paths:
       - "deploy/azure/*.json"
 

--- a/.github/workflows/ci-pull_request.yml
+++ b/.github/workflows/ci-pull_request.yml
@@ -5,13 +5,11 @@ on:
     branches:
       - main
       - "[0-9]+.[0-9]+"
-      - "8.x"
     types: [opened, synchronize, reopened]
   push:
     branches:
       - main
       - "[0-9]+.[0-9]+"
-      - "8.x"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ on:
     branches:
       - main
       - "[0-9]+.[0-9]+"
-      - "8.x"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/cloudformation-ci.yml
+++ b/.github/workflows/cloudformation-ci.yml
@@ -5,7 +5,6 @@ on:
   #   branches:
   #     - main
   #     - "[0-9]+.[0-9]+"
-  #     - "8.x"
   #   types: [opened, synchronize, reopened]
   #   paths:
   #     - deploy/cloudformation/*.yml
@@ -14,7 +13,6 @@ on:
     branches:
       - main
       - "[0-9]+.[0-9]+"
-      - "8.x"
     paths:
       - deploy/cloudformation/*.yml
       - .github/workflows/cloudformation-ci.yml

--- a/.github/workflows/eks-ci.yml
+++ b/.github/workflows/eks-ci.yml
@@ -14,7 +14,6 @@ on:
     branches:
       - main
       - "[0-9]+.[0-9]+"
-      - "8.x"
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_TEST_ACC }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - "[0-9]+.[0-9]+"
-      - "8.x"
     types: [opened, synchronize, reopened]
 
 env:

--- a/.github/workflows/publish-cloudformation.yml
+++ b/.github/workflows/publish-cloudformation.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - 8.x
       - "[0-9]+.[0-9]+"
     paths:
       - deploy/asset-inventory-cloudformation/*.yml

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,12 +5,10 @@ on:
     branches:
       - main
       - "[0-9]+.[0-9]+"
-      - "8.x"
     types: [opened, synchronize, reopened]
   push:
     branches:
       - main
-      - "8.x"
 
 env:
   K8S_MANIFEST_DIR: deploy

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         pipeline-name: [ beats, golang, hermit, mods ]
-        git-branch: [ main, 8.x ]
+        git-branch: [ main, 8.19 ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Init Hermit

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -223,7 +223,7 @@ to `false`.
 
 #### Nightly Deployment and Testing
 
-A scheduled `test-runner` workflow is triggered daily at 02:00. This workflow executes `test-e2e-flow`, which includes setup, deployment (along with integration test execution), and environment teardown for the main and 8.x versions (currently in development).
+A scheduled `test-runner` workflow is triggered daily at 02:00. This workflow executes `test-e2e-flow`, which includes setup, deployment (along with integration test execution), and environment teardown for the main and 8.19 versions (currently in development).
 This workflow can also be triggered manually.
 
 #### Environment Deletion


### PR DESCRIPTION
### Summary of your changes

This PR reflects the deprecation of the 8.x branch by updating all relevant files across the repository. The following changes are included:
- Removed any remaining references to 8.x.
- Replaced 8.x with 8.19, which is now the final branch for version 8.
