### PR TITLE
Remove Azure Username and Password authentication because it's deprecated on 1.9.0

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,12 +109,11 @@ type AzureClientOpt struct {
 }
 
 const (
-	AzureClientCredentialsTypeARMTemplate      = "arm_template"
-	AzureClientCredentialsTypeManagedIdentity  = "managed_identity"
-	AzureClientCredentialsTypeManual           = "manual"
-	AzureClientCredentialsTypeSecret           = "service_principal_with_client_secret"
-	AzureClientCredentialsTypeCertificate      = "service_principal_with_client_certificate"
-	AzureClientCredentialsTypeUsernamePassword = "service_principal_with_client_username_and_password"
+	AzureClientCredentialsTypeARMTemplate     = "arm_template"
+	AzureClientCredentialsTypeManagedIdentity = "managed_identity"
+	AzureClientCredentialsTypeManual          = "manual"
+	AzureClientCredentialsTypeSecret          = "service_principal_with_client_secret"
+	AzureClientCredentialsTypeCertificate     = "service_principal_with_client_certificate"
 )
 
 const (

--- a/internal/resources/providers/azurelib/auth/auth_provider.go
+++ b/internal/resources/providers/azurelib/auth/auth_provider.go
@@ -28,7 +28,6 @@ type AzureAuthProvider struct{}
 
 type AzureAuthProviderAPI interface {
 	FindDefaultCredentials(options *azidentity.DefaultAzureCredentialOptions) (*azidentity.DefaultAzureCredential, error)
-	FindUsernamePasswordCredentials(tenantID string, clientID string, username string, password string, options *azidentity.UsernamePasswordCredentialOptions) (*azidentity.UsernamePasswordCredential, error)
 	FindClientSecretCredentials(tenantID string, clientID string, clientSecret string, options *azidentity.ClientSecretCredentialOptions) (*azidentity.ClientSecretCredential, error)
 	FindCertificateCredential(tenantID string, clientID string, certPath string, password string, options *azidentity.ClientCertificateCredentialOptions) (*azidentity.ClientCertificateCredential, error)
 }
@@ -36,11 +35,6 @@ type AzureAuthProviderAPI interface {
 // FindDefaultCredentials is a wrapper around azidentity.NewDefaultAzureCredential to make it easier to mock
 func (a *AzureAuthProvider) FindDefaultCredentials(options *azidentity.DefaultAzureCredentialOptions) (*azidentity.DefaultAzureCredential, error) {
 	return azidentity.NewDefaultAzureCredential(options)
-}
-
-// FindUsernamePasswordCredentials is a wrapper around azidentity.NewUsernamePasswordCredential to make it easier to mock
-func (a *AzureAuthProvider) FindUsernamePasswordCredentials(tenantID string, clientID string, username string, password string, options *azidentity.UsernamePasswordCredentialOptions) (*azidentity.UsernamePasswordCredential, error) {
-	return azidentity.NewUsernamePasswordCredential(tenantID, clientID, username, password, options)
 }
 
 // FindClientSecretCredentials is a wrapper around azidentity.NewClientSecretCredential to make it easier to mock

--- a/internal/resources/providers/azurelib/auth/credentials.go
+++ b/internal/resources/providers/azurelib/auth/credentials.go
@@ -44,11 +44,6 @@ func (p *ConfigProvider) GetAzureClientConfig(cfg config.AzureConfig) (*AzureFac
 		return p.getSecretCredentialsConfig(cfg)
 	case config.AzureClientCredentialsTypeCertificate:
 		return p.getCertificateCredentialsConfig(cfg)
-	case config.AzureClientCredentialsTypeUsernamePassword:
-		if cfg.Credentials.ClientUsername == "" || cfg.Credentials.ClientPassword == "" {
-			return nil, ErrIncompleteUsernamePassword
-		}
-		return p.getUsernamePasswordCredentialsConfig(cfg)
 	case "", config.AzureClientCredentialsTypeManagedIdentity, config.AzureClientCredentialsTypeARMTemplate, config.AzureClientCredentialsTypeManual:
 		return p.getDefaultCredentialsConfig()
 	}
@@ -93,23 +88,6 @@ func (p *ConfigProvider) getCertificateCredentialsConfig(cfg config.AzureConfig)
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret credentials: %w", err)
-	}
-
-	return &AzureFactoryConfig{
-		Credentials: creds,
-	}, nil
-}
-
-func (p *ConfigProvider) getUsernamePasswordCredentialsConfig(cfg config.AzureConfig) (*AzureFactoryConfig, error) {
-	creds, err := p.AuthProvider.FindUsernamePasswordCredentials(
-		cfg.Credentials.TenantID,
-		cfg.Credentials.ClientID,
-		cfg.Credentials.ClientUsername,
-		cfg.Credentials.ClientPassword,
-		nil,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get username and password credentials: %w", err)
 	}
 
 	return &AzureFactoryConfig{

--- a/internal/resources/providers/azurelib/auth/credentials_test.go
+++ b/internal/resources/providers/azurelib/auth/credentials_test.go
@@ -114,58 +114,6 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Should return a UsernamePasswordCredential",
-			config: config.AzureConfig{
-				Credentials: config.AzureClientOpt{
-					ClientCredentialsType: config.AzureClientCredentialsTypeUsernamePassword,
-					TenantID:              "tenant_a",
-					ClientID:              "client_id",
-					ClientUsername:        "username",
-					ClientPassword:        "password",
-				},
-			},
-			authProviderInitFn: func(m *MockAzureAuthProviderAPI) {
-				m.EXPECT().
-					FindUsernamePasswordCredentials("tenant_a", "client_id", "username", "password", mock.Anything).
-					Return(&azidentity.UsernamePasswordCredential{}, nil).
-					Once()
-			},
-			want: &AzureFactoryConfig{
-				Credentials: &azidentity.UsernamePasswordCredential{},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Should return error on incomplete Username Password Credential (missing password)",
-			config: config.AzureConfig{
-				Credentials: config.AzureClientOpt{
-					ClientCredentialsType: config.AzureClientCredentialsTypeUsernamePassword,
-					TenantID:              "tenant_a",
-					ClientID:              "client_id",
-					ClientUsername:        "username",
-					ClientPassword:        "",
-				},
-			},
-			authProviderInitFn: func(_ *MockAzureAuthProviderAPI) {},
-			want:               nil,
-			wantErr:            true,
-		},
-		{
-			name: "Should return error on incomplete Username Password Credential (missing username)",
-			config: config.AzureConfig{
-				Credentials: config.AzureClientOpt{
-					ClientCredentialsType: config.AzureClientCredentialsTypeUsernamePassword,
-					TenantID:              "tenant_a",
-					ClientID:              "client_id",
-					ClientUsername:        "",
-					ClientPassword:        "password",
-				},
-			},
-			authProviderInitFn: func(_ *MockAzureAuthProviderAPI) {},
-			want:               nil,
-			wantErr:            true,
-		},
-		{
 			name: "Should return a ClientCertificateCredential",
 			config: config.AzureConfig{
 				Credentials: config.AzureClientOpt{

--- a/internal/resources/providers/azurelib/auth/mock_azure_auth_provider_api.go
+++ b/internal/resources/providers/azurelib/auth/mock_azure_auth_provider_api.go
@@ -218,68 +218,6 @@ func (_c *MockAzureAuthProviderAPI_FindDefaultCredentials_Call) RunAndReturn(run
 	return _c
 }
 
-// FindUsernamePasswordCredentials provides a mock function with given fields: tenantID, clientID, username, password, options
-func (_m *MockAzureAuthProviderAPI) FindUsernamePasswordCredentials(tenantID string, clientID string, username string, password string, options *azidentity.UsernamePasswordCredentialOptions) (*azidentity.UsernamePasswordCredential, error) {
-	ret := _m.Called(tenantID, clientID, username, password, options)
-
-	if len(ret) == 0 {
-		panic("no return value specified for FindUsernamePasswordCredentials")
-	}
-
-	var r0 *azidentity.UsernamePasswordCredential
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, *azidentity.UsernamePasswordCredentialOptions) (*azidentity.UsernamePasswordCredential, error)); ok {
-		return rf(tenantID, clientID, username, password, options)
-	}
-	if rf, ok := ret.Get(0).(func(string, string, string, string, *azidentity.UsernamePasswordCredentialOptions) *azidentity.UsernamePasswordCredential); ok {
-		r0 = rf(tenantID, clientID, username, password, options)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*azidentity.UsernamePasswordCredential)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(string, string, string, string, *azidentity.UsernamePasswordCredentialOptions) error); ok {
-		r1 = rf(tenantID, clientID, username, password, options)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockAzureAuthProviderAPI_FindUsernamePasswordCredentials_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindUsernamePasswordCredentials'
-type MockAzureAuthProviderAPI_FindUsernamePasswordCredentials_Call struct {
-	*mock.Call
-}
-
-// FindUsernamePasswordCredentials is a helper method to define mock.On call
-//   - tenantID string
-//   - clientID string
-//   - username string
-//   - password string
-//   - options *azidentity.UsernamePasswordCredentialOptions
-func (_e *MockAzureAuthProviderAPI_Expecter) FindUsernamePasswordCredentials(tenantID interface{}, clientID interface{}, username interface{}, password interface{}, options interface{}) *MockAzureAuthProviderAPI_FindUsernamePasswordCredentials_Call {
-	return &MockAzureAuthProviderAPI_FindUsernamePasswordCredentials_Call{Call: _e.mock.On("FindUsernamePasswordCredentials", tenantID, clientID, username, password, options)}
-}
-
-func (_c *MockAzureAuthProviderAPI_FindUsernamePasswordCredentials_Call) Run(run func(tenantID string, clientID string, username string, password string, options *azidentity.UsernamePasswordCredentialOptions)) *MockAzureAuthProviderAPI_FindUsernamePasswordCredentials_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string), args[3].(string), args[4].(*azidentity.UsernamePasswordCredentialOptions))
-	})
-	return _c
-}
-
-func (_c *MockAzureAuthProviderAPI_FindUsernamePasswordCredentials_Call) Return(_a0 *azidentity.UsernamePasswordCredential, _a1 error) *MockAzureAuthProviderAPI_FindUsernamePasswordCredentials_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockAzureAuthProviderAPI_FindUsernamePasswordCredentials_Call) RunAndReturn(run func(string, string, string, string, *azidentity.UsernamePasswordCredentialOptions) (*azidentity.UsernamePasswordCredential, error)) *MockAzureAuthProviderAPI_FindUsernamePasswordCredentials_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewMockAzureAuthProviderAPI creates a new instance of MockAzureAuthProviderAPI. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockAzureAuthProviderAPI(t interface {


### PR DESCRIPTION
Enables https://github.com/elastic/cloudbeat/pull/3227 and https://github.com/elastic/cloudbeat/pull/3226 to be merged