### PR TITLE
Fix CloudFormation ci workflow execution failure

### DIFF
--- a/.github/workflows/cloudformation-ci.yml
+++ b/.github/workflows/cloudformation-ci.yml
@@ -1,16 +1,14 @@
 name: CloudFormation-CI
 
 on:
-  # TODO: comment pull_request_targer block after testing
   # pull_request_target:
-  pull_request:
-    branches:
-      - main
-      - "[0-9]+.[0-9]+"
-    types: [opened, synchronize, reopened]
-    # paths:
-    #   - deploy/cloudformation/*.yml
-    #   - .github/workflows/cloudformation-ci.yml
+  #   branches:
+  #     - main
+  #     - "[0-9]+.[0-9]+"
+  #   types: [opened, synchronize, reopened]
+  #   paths:
+  #     - deploy/cloudformation/*.yml
+  #     - .github/workflows/cloudformation-ci.yml
   push:
     branches:
       - main


### PR DESCRIPTION
### Summary of your changes

The CloudFormation CI is [failing](https://github.com/elastic/cloudbeat/actions/runs/14594319103/job/40936496086) due to a missing environment variable: `AGENT_VERSION`. This PR adds the missing variable to resolve the issue.


