### PR TITLE
Increase gcp ListAssets timeout and page size

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -272,7 +272,8 @@ func overwritesFromEnvVars(c *Config) {
 	logErr := func(name string, value string, err error) {
 		log.Errorw(
 			"error trying to parse config env variable",
-			logp.String(name, value),
+			logp.String("name", name),
+			logp.String("value", value),
 			logp.Error(err),
 		)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 	"github.com/elastic/elastic-agent-libs/config"
 
+	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/launcher"
 )
 
@@ -266,15 +267,24 @@ const (
 )
 
 func overwritesFromEnvVars(c *Config) {
+	log := clog.NewLogger("config")
+	logErr := func(name string, value string, err error) {
+		log.Errorf("error trying to parse variable %s with value %s: %s", name, value, err.Error())
+	}
+
 	if v, exists := os.LookupEnv(CloudbeatGCPListAssetPageSizeEnvVar); exists {
 		if i, err := strconv.ParseInt(v, 10, 32); err == nil {
 			c.CloudConfig.Gcp.GcpCallOpt.ListAssetsPageSize = int32(i)
+		} else {
+			logErr(CloudbeatGCPListAssetPageSizeEnvVar, v, err)
 		}
 	}
 
 	if v, exists := os.LookupEnv(CloudbeatGCPListAssetTimeoutEnvVar); exists {
 		if d, err := time.ParseDuration(v); err == nil {
 			c.CloudConfig.Gcp.GcpCallOpt.ListAssetsTimeout = d
+		} else {
+			logErr(CloudbeatGCPListAssetPageSizeEnvVar, v, err)
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/elastic/beats/v7/libbeat/processors"
@@ -155,6 +156,9 @@ func New(cfg *config.C) (*Config, error) {
 		}
 	}
 
+	// apply env var overwrites
+	overwritesFromEnvVars(c)
+
 	switch c.CloudConfig.Aws.AccountType {
 	case "":
 	case SingleAccount:
@@ -204,9 +208,9 @@ func defaultConfig() (*Config, error) {
 func defaultGCPConfig() GcpConfig {
 	return GcpConfig{
 		GcpCallOpt: GcpCallOpt{
-			// default value on a par with gcp sdk
+			// default value from sdk is 1m; we use 4m to exceed quota window.
 			// https://github.com/googleapis/google-cloud-go/blob/952cd7fd419af9eb74f5d30a111ae936094b0645/asset/apiv1/asset_client.go#L96
-			ListAssetsTimeout: 60 * time.Second,
+			ListAssetsTimeout: 4 * time.Minute,
 
 			// default value from sdk is 100; we use 200
 			// https://github.com/googleapis/google-cloud-go/blob/a6c85f6387ee6aa291e786c882637fb03f3302f4/asset/apiv1/assetpb/asset_service.pb.go#L767-L769
@@ -253,5 +257,24 @@ func newCloudConnectorsConfig() CloudConnectorsConfig {
 		LocalRoleARN:  os.Getenv(CloudConnectorsLocalRoleEnvVar),
 		GlobalRoleARN: os.Getenv(CloudConnectorsGlobalRoleEnvVar),
 		ResourceID:    os.Getenv(CloudResourceIDEnvVar),
+	}
+}
+
+const (
+	CloudbeatGCPListAssetPageSizeEnvVar = "CLOUDBEAT_GCP_LIST_ASSETS_PAGE_SIZE"
+	CloudbeatGCPListAssetTimeoutEnvVar  = "CLOUDBEAT_GCP_LIST_ASSETS_TIMEOUT"
+)
+
+func overwritesFromEnvVars(c *Config) {
+	if v, exists := os.LookupEnv(CloudbeatGCPListAssetPageSizeEnvVar); exists {
+		if i, err := strconv.ParseInt(v, 10, 32); err == nil {
+			c.CloudConfig.Gcp.GcpCallOpt.ListAssetsPageSize = int32(i)
+		}
+	}
+
+	if v, exists := os.LookupEnv(CloudbeatGCPListAssetTimeoutEnvVar); exists {
+		if d, err := time.ParseDuration(v); err == nil {
+			c.CloudConfig.Gcp.GcpCallOpt.ListAssetsTimeout = d
+		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/processors"
 	"github.com/elastic/beats/v7/x-pack/libbeat/common/aws"
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 
 	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/launcher"
@@ -269,7 +270,11 @@ const (
 func overwritesFromEnvVars(c *Config) {
 	log := clog.NewLogger("config")
 	logErr := func(name string, value string, err error) {
-		log.Errorf("error trying to parse variable %s with value %s: %s", name, value, err.Error())
+		log.Errorw(
+			"error trying to parse config env variable",
+			logp.String(name, value),
+			logp.Error(err),
+		)
 	}
 
 	if v, exists := os.LookupEnv(CloudbeatGCPListAssetPageSizeEnvVar); exists {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -126,6 +126,39 @@ config:
 				},
 			},
 		},
+		{ // GCP config with call_options.
+			config: `
+config:
+  v1:
+    type: cspm
+    deployment: gcp
+    benchmark: cis_gcp
+    gcp:
+      project_id: abc123
+      organization_id: efg456
+      account_type: organization-account
+      credentials:
+        credentials_file_path: /tmp/creds.json
+      call_options:
+        list_assets_timeout: 6m
+        list_assets_page_size: 500
+`,
+			expectedType: "cis_gcp",
+			expectedCloudConfig: CloudConfig{
+				Gcp: GcpConfig{
+					ProjectId:      "abc123",
+					OrganizationId: "efg456",
+					AccountType:    "organization-account",
+					GcpClientOpt: GcpClientOpt{
+						CredentialsFilePath: "/tmp/creds.json",
+					},
+					GcpCallOpt: GcpCallOpt{
+						ListAssetsTimeout:  6 * time.Minute,
+						ListAssetsPageSize: 500,
+					},
+				},
+			},
+		},
 		{ // GCP with overwrite env vars
 			overwriteEnvs: func(t *testing.T) {
 				t.Helper()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -53,7 +53,7 @@ config:
     benchmark: cis_k8s
 `,
 			expectedType:        "cis_k8s",
-			expectedCloudConfig: CloudConfig{},
+			expectedCloudConfig: CloudConfig{Gcp: defaultGCPConfig()},
 		},
 		{
 			config: `
@@ -62,7 +62,7 @@ config:
     benchmark: cis_azure
 `,
 			expectedType:        "cis_azure",
-			expectedCloudConfig: CloudConfig{},
+			expectedCloudConfig: CloudConfig{Gcp: defaultGCPConfig()},
 		},
 		{
 			config: `
@@ -91,6 +91,37 @@ config:
 						RoleArn:              "role_arn",
 					},
 					AccountType: "organization-account",
+				},
+				Gcp: defaultGCPConfig(),
+			},
+		},
+		{
+			config: `
+config:
+  v1:
+    type: cspm
+    deployment: gcp
+    benchmark: cis_gcp
+    gcp:
+      project_id: abc123
+      organization_id: efg456
+      account_type: organization-account
+      credentials:
+        credentials_file_path: /tmp/creds.json
+`,
+			expectedType: "cis_gcp",
+			expectedCloudConfig: CloudConfig{
+				Gcp: GcpConfig{
+					ProjectId:      "abc123",
+					OrganizationId: "efg456",
+					AccountType:    "organization-account",
+					GcpClientOpt: GcpClientOpt{
+						CredentialsFilePath: "/tmp/creds.json",
+					},
+					GcpCallOpt: GcpCallOpt{
+						ListAssetsTimeout:  60 * time.Second,
+						ListAssetsPageSize: 200,
+					},
 				},
 			},
 		},
@@ -256,6 +287,7 @@ config:
 					},
 					CloudConnectorsConfig: CloudConnectorsConfig{},
 				},
+				Gcp: defaultGCPConfig(),
 			},
 		},
 		"happy path cloud connectors enabled - attempt overwrite roles": {
@@ -282,6 +314,7 @@ config:
 					},
 					CloudConnectorsConfig: CloudConnectorsConfig{},
 				},
+				Gcp: defaultGCPConfig(),
 			},
 		},
 		"happy path cloud connectors enabled - env vars set": {
@@ -315,6 +348,7 @@ config:
 						ResourceID:    "abc789",
 					},
 				},
+				Gcp: defaultGCPConfig(),
 			},
 		},
 	}

--- a/internal/flavors/assetinventory/strategy.go
+++ b/internal/flavors/assetinventory/strategy.go
@@ -104,7 +104,7 @@ func (s *strategy) initGcpFetchers(ctx context.Context) ([]inventory.AssetFetche
 		return nil, fmt.Errorf("failed to initialize gcp config: %w", err)
 	}
 	inventoryInitializer := &gcp_inventory.ProviderInitializer{}
-	provider, err := inventoryInitializer.Init(ctx, s.logger, *gcpConfig)
+	provider, err := inventoryInitializer.Init(ctx, s.logger, *gcpConfig, s.cfg.CloudConfig.Gcp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize gcp asset inventory: %v", err)
 	}

--- a/internal/flavors/benchmark/gcp.go
+++ b/internal/flavors/benchmark/gcp.go
@@ -63,7 +63,7 @@ func (g *GCP) initialize(ctx context.Context, log *clog.Logger, cfg *config.Conf
 		return nil, nil, nil, fmt.Errorf("failed to initialize gcp config: %w", err)
 	}
 
-	assetProvider, err := g.inventoryInitializer.Init(ctx, log, *gcpConfig)
+	assetProvider, err := g.inventoryInitializer.Init(ctx, log, *gcpConfig, cfg.CloudConfig.Gcp)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to initialize gcp asset inventory: %v", err)
 	}

--- a/internal/flavors/benchmark/gcp_test.go
+++ b/internal/flavors/benchmark/gcp_test.go
@@ -132,7 +132,7 @@ func mockInventoryInitializerService(err error) inventory.ProviderInitializerAPI
 	initializer := &inventory.MockProviderInitializerAPI{}
 	inventoryService := &inventory.MockServiceAPI{}
 	inventoryService.EXPECT().Close().Maybe().Return(nil)
-	initializerMock := initializer.EXPECT().Init(mock.Anything, mock.Anything, mock.Anything)
+	initializerMock := initializer.EXPECT().Init(mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 	if err == nil {
 		initializerMock.Return(
 			inventoryService,

--- a/internal/resources/providers/gcplib/inventory/grpc_rate_limiter.go
+++ b/internal/resources/providers/gcplib/inventory/grpc_rate_limiter.go
@@ -21,13 +21,13 @@ import (
 	"context"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/googleapis/gax-go/v2"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
 	"github.com/elastic/cloudbeat/internal/infra/clog"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // retryer wraps another gax Retryer and logs each retry attempt.

--- a/internal/resources/providers/gcplib/inventory/grpc_rate_limiter.go
+++ b/internal/resources/providers/gcplib/inventory/grpc_rate_limiter.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/elastic/cloudbeat/internal/infra/clog"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // retryer wraps another gax Retryer and logs each retry attempt.
@@ -44,7 +45,11 @@ func (r retryer) Retry(err error) (time.Duration, bool) {
 		if err != nil {
 			s = err.Error()
 		}
-		r.log.Debugf("gax Retryer retries based on error (%s) pause %s", s, pause.String())
+		r.log.Debugw(
+			"gax retryer attempt",
+			logp.String("error", s),
+			logp.Duration("pause", pause),
+		)
 	}
 
 	return pause, shouldRetry

--- a/internal/resources/providers/gcplib/inventory/grpc_rate_limiter.go
+++ b/internal/resources/providers/gcplib/inventory/grpc_rate_limiter.go
@@ -29,14 +29,43 @@ import (
 	"github.com/elastic/cloudbeat/internal/infra/clog"
 )
 
-// a gax.CallOption that defines a retry strategy which retries the request on ResourceExhausted error.
-var RetryOnResourceExhausted = gax.WithRetry(func() gax.Retryer {
-	return gax.OnCodes([]codes.Code{codes.ResourceExhausted}, gax.Backoff{
-		Initial:    1 * time.Second,
-		Max:        1 * time.Minute,
-		Multiplier: 1.2,
+// retryer wraps another gax Retryer and logs each retry attempt.
+type retryer struct {
+	gaxRetryer gax.Retryer
+	log        *clog.Logger
+}
+
+func (r retryer) Retry(err error) (time.Duration, bool) {
+	pause, shouldRetry := r.gaxRetryer.Retry(err)
+
+	if shouldRetry {
+		s := ""
+		// This should always be not nil, but let's be extra cautious.
+		if err != nil {
+			s = err.Error()
+		}
+		r.log.Debugf("gax Retryer retries based on error (%s) pause %s", s, pause.String())
+	}
+
+	return pause, shouldRetry
+}
+
+func GAXCallOptionRetrier(log *clog.Logger) gax.CallOption {
+	return gax.WithRetry(func() gax.Retryer {
+		return retryer{
+			log: log,
+			gaxRetryer: gax.OnCodes([]codes.Code{
+				codes.ResourceExhausted,
+				codes.DeadlineExceeded,
+				codes.Unavailable,
+			}, gax.Backoff{
+				Initial:    1 * time.Second,
+				Max:        1 * time.Minute,
+				Multiplier: 1.2,
+			}),
+		}
 	})
-})
+}
 
 type AssetsInventoryRateLimiter struct {
 	methods map[string]*rate.Limiter

--- a/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
+++ b/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
@@ -96,6 +96,6 @@ func TestGAXCallOptionRetrier(t *testing.T) {
 		require.Equal(t, time.Duration(0), pause)
 	}
 
-	logs := logp.ObserverLogs().FilterMessageSnippet("gax Retryer retries based on error").All()
+	logs := logp.ObserverLogs().FilterMessageSnippet("gax retryer attempt").All()
 	assert.Len(t, logs, len(c))
 }

--- a/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
+++ b/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
@@ -21,17 +21,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/googleapis/gax-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/time/rate"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
-	"github.com/elastic/elastic-agent-libs/logp"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type RateLimiterTestSuite struct {

--- a/internal/resources/providers/gcplib/inventory/mock_provider_initializer_api.go
+++ b/internal/resources/providers/gcplib/inventory/mock_provider_initializer_api.go
@@ -23,6 +23,8 @@ import (
 	clog "github.com/elastic/cloudbeat/internal/infra/clog"
 	auth "github.com/elastic/cloudbeat/internal/resources/providers/gcplib/auth"
 
+	config "github.com/elastic/cloudbeat/internal/config"
+
 	context "context"
 
 	mock "github.com/stretchr/testify/mock"
@@ -41,9 +43,9 @@ func (_m *MockProviderInitializerAPI) EXPECT() *MockProviderInitializerAPI_Expec
 	return &MockProviderInitializerAPI_Expecter{mock: &_m.Mock}
 }
 
-// Init provides a mock function with given fields: ctx, log, gcpConfig
-func (_m *MockProviderInitializerAPI) Init(ctx context.Context, log *clog.Logger, gcpConfig auth.GcpFactoryConfig) (ServiceAPI, error) {
-	ret := _m.Called(ctx, log, gcpConfig)
+// Init provides a mock function with given fields: ctx, log, gcpConfig, cfg
+func (_m *MockProviderInitializerAPI) Init(ctx context.Context, log *clog.Logger, gcpConfig auth.GcpFactoryConfig, cfg config.GcpConfig) (ServiceAPI, error) {
+	ret := _m.Called(ctx, log, gcpConfig, cfg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Init")
@@ -51,19 +53,19 @@ func (_m *MockProviderInitializerAPI) Init(ctx context.Context, log *clog.Logger
 
 	var r0 ServiceAPI
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *clog.Logger, auth.GcpFactoryConfig) (ServiceAPI, error)); ok {
-		return rf(ctx, log, gcpConfig)
+	if rf, ok := ret.Get(0).(func(context.Context, *clog.Logger, auth.GcpFactoryConfig, config.GcpConfig) (ServiceAPI, error)); ok {
+		return rf(ctx, log, gcpConfig, cfg)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *clog.Logger, auth.GcpFactoryConfig) ServiceAPI); ok {
-		r0 = rf(ctx, log, gcpConfig)
+	if rf, ok := ret.Get(0).(func(context.Context, *clog.Logger, auth.GcpFactoryConfig, config.GcpConfig) ServiceAPI); ok {
+		r0 = rf(ctx, log, gcpConfig, cfg)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(ServiceAPI)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *clog.Logger, auth.GcpFactoryConfig) error); ok {
-		r1 = rf(ctx, log, gcpConfig)
+	if rf, ok := ret.Get(1).(func(context.Context, *clog.Logger, auth.GcpFactoryConfig, config.GcpConfig) error); ok {
+		r1 = rf(ctx, log, gcpConfig, cfg)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -80,13 +82,14 @@ type MockProviderInitializerAPI_Init_Call struct {
 //   - ctx context.Context
 //   - log *clog.Logger
 //   - gcpConfig auth.GcpFactoryConfig
-func (_e *MockProviderInitializerAPI_Expecter) Init(ctx interface{}, log interface{}, gcpConfig interface{}) *MockProviderInitializerAPI_Init_Call {
-	return &MockProviderInitializerAPI_Init_Call{Call: _e.mock.On("Init", ctx, log, gcpConfig)}
+//   - cfg config.GcpConfig
+func (_e *MockProviderInitializerAPI_Expecter) Init(ctx interface{}, log interface{}, gcpConfig interface{}, cfg interface{}) *MockProviderInitializerAPI_Init_Call {
+	return &MockProviderInitializerAPI_Init_Call{Call: _e.mock.On("Init", ctx, log, gcpConfig, cfg)}
 }
 
-func (_c *MockProviderInitializerAPI_Init_Call) Run(run func(ctx context.Context, log *clog.Logger, gcpConfig auth.GcpFactoryConfig)) *MockProviderInitializerAPI_Init_Call {
+func (_c *MockProviderInitializerAPI_Init_Call) Run(run func(ctx context.Context, log *clog.Logger, gcpConfig auth.GcpFactoryConfig, cfg config.GcpConfig)) *MockProviderInitializerAPI_Init_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*clog.Logger), args[2].(auth.GcpFactoryConfig))
+		run(args[0].(context.Context), args[1].(*clog.Logger), args[2].(auth.GcpFactoryConfig), args[3].(config.GcpConfig))
 	})
 	return _c
 }
@@ -96,7 +99,7 @@ func (_c *MockProviderInitializerAPI_Init_Call) Return(_a0 ServiceAPI, _a1 error
 	return _c
 }
 
-func (_c *MockProviderInitializerAPI_Init_Call) RunAndReturn(run func(context.Context, *clog.Logger, auth.GcpFactoryConfig) (ServiceAPI, error)) *MockProviderInitializerAPI_Init_Call {
+func (_c *MockProviderInitializerAPI_Init_Call) RunAndReturn(run func(context.Context, *clog.Logger, auth.GcpFactoryConfig, config.GcpConfig) (ServiceAPI, error)) *MockProviderInitializerAPI_Init_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/resources/providers/gcplib/inventory/provider.go
+++ b/internal/resources/providers/gcplib/inventory/provider.go
@@ -137,7 +137,7 @@ func (p *ProviderInitializer) Init(ctx context.Context, log *clog.Logger, gcpCon
 			if req.PageSize == 0 {
 				req.PageSize = cfg.GcpCallOpt.ListAssetsPageSize
 			}
-			return client.ListAssets(ctx, req, append(opts, RetryOnResourceExhausted, gax.WithTimeout(cfg.GcpCallOpt.ListAssetsTimeout))...)
+			return client.ListAssets(ctx, req, append(opts, GAXCallOptionRetrier(log), gax.WithTimeout(cfg.GcpCallOpt.ListAssetsTimeout))...)
 		},
 	}
 

--- a/internal/resources/providers/gcplib/inventory/provider.go
+++ b/internal/resources/providers/gcplib/inventory/provider.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/elastic/cloudbeat/internal/config"
 	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/resources/fetching"
 	"github.com/elastic/cloudbeat/internal/resources/providers/gcplib/auth"
@@ -119,10 +120,10 @@ type ServiceAPI interface {
 
 type ProviderInitializerAPI interface {
 	// Init initializes the GCP asset client
-	Init(ctx context.Context, log *clog.Logger, gcpConfig auth.GcpFactoryConfig) (ServiceAPI, error)
+	Init(ctx context.Context, log *clog.Logger, gcpConfig auth.GcpFactoryConfig, cfg config.GcpConfig) (ServiceAPI, error)
 }
 
-func (p *ProviderInitializer) Init(ctx context.Context, log *clog.Logger, gcpConfig auth.GcpFactoryConfig) (ServiceAPI, error) {
+func (p *ProviderInitializer) Init(ctx context.Context, log *clog.Logger, gcpConfig auth.GcpFactoryConfig, cfg config.GcpConfig) (ServiceAPI, error) {
 	limiter := NewAssetsInventoryRateLimiter(log)
 	// initialize GCP assets inventory client
 	client, err := asset.NewClient(ctx, append(gcpConfig.ClientOpts, option.WithGRPCDialOption(limiter.GetInterceptorDialOption()))...)
@@ -133,7 +134,10 @@ func (p *ProviderInitializer) Init(ctx context.Context, log *clog.Logger, gcpCon
 	assetsInventoryWrapper := &AssetsInventoryWrapper{
 		Close: client.Close,
 		ListAssets: func(ctx context.Context, req *assetpb.ListAssetsRequest, opts ...gax.CallOption) Iterator {
-			return client.ListAssets(ctx, req, append(opts, RetryOnResourceExhausted)...)
+			if req.PageSize == 0 {
+				req.PageSize = cfg.GcpCallOpt.ListAssetsPageSize
+			}
+			return client.ListAssets(ctx, req, append(opts, RetryOnResourceExhausted, gax.WithTimeout(cfg.GcpCallOpt.ListAssetsTimeout))...)
 		},
 	}
 

--- a/internal/resources/providers/gcplib/inventory/provider_test.go
+++ b/internal/resources/providers/gcplib/inventory/provider_test.go
@@ -543,14 +543,3 @@ func (s *ProviderTestSuite) TestListProjectsAncestorsPolicies() {
 	s.Equal("AssetName1", value[0].Policies[0].Name)
 	s.Equal("AssetName2", value[0].Policies[1].Name)
 }
-
-type fakeAssetServer struct {
-	assetpb.UnimplementedAssetServiceServer
-}
-
-func (*fakeAssetServer) ListAssets(ctx context.Context, req *assetpb.ListAssetsRequest) (*assetpb.ListAssetsResponse, error) {
-	return nil, nil
-}
-
-func TestAssetsInventoryWrapper(t *testing.T) {
-}

--- a/internal/resources/providers/gcplib/inventory/provider_test.go
+++ b/internal/resources/providers/gcplib/inventory/provider_test.go
@@ -543,3 +543,14 @@ func (s *ProviderTestSuite) TestListProjectsAncestorsPolicies() {
 	s.Equal("AssetName1", value[0].Policies[0].Name)
 	s.Equal("AssetName2", value[0].Policies[1].Name)
 }
+
+type fakeAssetServer struct {
+	assetpb.UnimplementedAssetServiceServer
+}
+
+func (*fakeAssetServer) ListAssets(ctx context.Context, req *assetpb.ListAssetsRequest) (*assetpb.ListAssetsResponse, error) {
+	return nil, nil
+}
+
+func TestAssetsInventoryWrapper(t *testing.T) {
+}

--- a/internal/resources/providers/gcplib/inventory/provider_test.go
+++ b/internal/resources/providers/gcplib/inventory/provider_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/elastic/cloudbeat/internal/config"
 	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/resources/fetching"
 	"github.com/elastic/cloudbeat/internal/resources/providers/gcplib/auth"
@@ -66,10 +67,11 @@ func (s *ProviderTestSuite) TestProviderInit() {
 		Parent:     "projects/1",
 		ClientOpts: []option.ClientOption{},
 	}
+	gcpCnf := config.GcpConfig{}
 
-	initMock.EXPECT().Init(mock.Anything, s.logger, gcpConfig).Return(&Provider{}, nil).Once()
+	initMock.EXPECT().Init(mock.Anything, s.logger, gcpConfig, gcpCnf).Return(&Provider{}, nil).Once()
 	t := s.T()
-	provider, err := initMock.Init(t.Context(), s.logger, gcpConfig)
+	provider, err := initMock.Init(t.Context(), s.logger, gcpConfig, gcpCnf)
 	s.Require().NoError(err)
 	s.NotNil(provider)
 }


### PR DESCRIPTION
### Summary of your changes
on gcp asset client:
  * Increased the default timeout on `ListAssets` to 4 minutes (configurable).
  * Increased the default page size to 200 (from 100) on `ListAssets` (configurable).
  * Added overwrite functionality using env vars `CLOUDBEAT_GCP_LIST_ASSETS_PAGE_SIZE` and `CLOUDBEAT_GCP_LIST_ASSETS_TIMEOUT`.
  * Created a wrapper on gax Retryer that logs on each retry. 

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
