### PR TITLE
Update agent compatibility test workflow

### DIFF
--- a/.github/workflows/test-agent-compatibility.yml
+++ b/.github/workflows/test-agent-compatibility.yml
@@ -22,7 +22,7 @@ jobs:
         id: set-matrix
         # This script will generate the matrix of agents and packages
         # starting from the version 8.17 and up to the latest version.
-        run: python ./.ci/scripts/get_versions.py --after 8.17
+        run: python ./.ci/scripts/get_versions.py --after 8.16
 
   test-agents:
     name: Agent Compatibility Test


### PR DESCRIPTION
### Summary of your changes

This PR updates the initial stack version used to calculate the job matrix.
Since updates are only being received for version 8.16 and above, version 8.16 is now used as the starting point.

Evidence: This is a successful workflow [run](https://github.com/elastic/cloudbeat/actions/runs/15324337298/job/43114974950) after the update.

