### PR TITLE
Add `entity.source` to asset discovery

### DIFF
--- a/internal/inventory/asset.go
+++ b/internal/inventory/asset.go
@@ -176,9 +176,10 @@ type URL struct {
 
 // Entity contains the identifiers of the asset
 type Entity struct {
-	Id   string `json:"id"`
-	Name string `json:"name"`
-	Raw  *any   `json:"raw"`
+	Id     string  `json:"id"`
+	Name   string  `json:"name"`
+	Source *string `json:"source"`
+	Raw    *any    `json:"raw"`
 	AssetClassification
 
 	// non exported fields
@@ -318,6 +319,7 @@ func WithNetwork(network Network) AssetEnricher {
 func WithCloud(cloud Cloud) AssetEnricher {
 	return func(a *AssetEvent) {
 		a.Cloud = &cloud
+		a.Entity.Source = &cloud.Provider
 	}
 }
 

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/cloudbeat/internal/infra/clog"
+	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
 	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
@@ -43,8 +44,9 @@ func TestAssetInventory_Run(t *testing.T) {
 			Timestamp: now(),
 			Fields: mapstr.M{
 				"entity": Entity{
-					Id:   "arn:aws:ec2:us-east::ec2/234567890",
-					Name: "test-server",
+					Id:     "arn:aws:ec2:us-east::ec2/234567890",
+					Name:   "test-server",
+					Source: pointers.Ref(AwsCloudProvider),
 					AssetClassification: AssetClassification{
 						Category: CategoryInfrastructure,
 						Type:     "Virtual Machine",


### PR DESCRIPTION
Add `entity.source` ([ECS field](https://github.com/elastic/ecs/blob/main/rfcs/text/0049/entity.yml#L30))

- Related to https://github.com/elastic/security-team/issues/12550
- Complimentary of https://github.com/elastic/integrations/pull/14087
