### PR TITLE
Fix Asset Discover Integration Tests typo

### DIFF
--- a/tests/product/tests/test_aws_asset_inventory.py
+++ b/tests/product/tests/test_aws_asset_inventory.py
@@ -42,7 +42,7 @@ def test_aws_asset_inventory(
 register_params(
     test_aws_asset_inventory,
     Parameters(
-        ("type", "sub_type"),
+        ("type_", "sub_type"),
         [*aws_tc.test_cases.values()],
         ids=[*aws_tc.test_cases.keys()],
     ),

--- a/tests/product/tests/test_azure_asset_inventory.py
+++ b/tests/product/tests/test_azure_asset_inventory.py
@@ -43,7 +43,7 @@ def test_azure_asset_inventory(
 register_params(
     test_azure_asset_inventory,
     Parameters(
-        ("sub_type", "type"),
+        ("sub_type", "type_"),
         [*azure_tc.test_cases.values()],
         ids=[*azure_tc.test_cases.keys()],
     ),

--- a/tests/product/tests/test_gcp_asset_inventory.py
+++ b/tests/product/tests/test_gcp_asset_inventory.py
@@ -43,7 +43,7 @@ def test_gcp_asset_inventory(
 register_params(
     test_gcp_asset_inventory,
     Parameters(
-        ("type", "sub_type"),
+        ("type_", "sub_type"),
         [*gcp_tc.test_cases.values()],
         ids=[*gcp_tc.test_cases.keys()],
     ),


### PR DESCRIPTION

![Screenshot 2025-06-03 at 10 39 40](https://github.com/user-attachments/assets/dd82f7a5-d7dd-4aad-8f6d-99c05b80080d)

`type` -> `type_` 