### PR TITLE
Attempt to fix update-beats.yml

### DIFF
--- a/.ci/updatecli/updatecli.d/update-beats.yml
+++ b/.ci/updatecli/updatecli.d/update-beats.yml
@@ -68,5 +68,4 @@ targets:
       command: .ci/updatecli/scripts/update-beats.sh
       environments:
         - name: PATH
-        - name: GOPATH
         - name: HOME


### PR DESCRIPTION
See https://github.com/elastic/cloudbeat/actions/runs/15368849301/job/43245213040

```
ERROR: environment variable "GOPATH" not found, skipping
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x29d1dfb]
```

In comparison, update-mods.yml does not export the `GOPATH` variable and still works: https://github.com/elastic/cloudbeat/blob/973858700dba3438417966d16ab7ead9b4875d73/.ci/updatecli/updatecli.d/update-mods.yml#L43-L44