### PR TITLE
Cloud connectors: add global role arn on remote role cloud formation

### DIFF
--- a/deploy/cloudformation/cloud-connectors-remote-role-organization.yml
+++ b/deploy/cloudformation/cloud-connectors-remote-role-organization.yml
@@ -43,9 +43,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-
-              # TODO: this is not a valid global super role, it will be replaced with the real one.
-              AWS: <TBD Elastic Global Super Role ARN>
+              AWS: arn:aws:iam::254766567737:role/cloud_connectors
             Action: sts:AssumeRole
             Condition:
               StringEquals:

--- a/deploy/cloudformation/cloud-connectors-remote-role.yml
+++ b/deploy/cloudformation/cloud-connectors-remote-role.yml
@@ -17,9 +17,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-
-              # TODO: this is not a valid global super role, it will be replaced with the real one.
-              AWS: <TBD Elastic Global Super Role ARN>
+              AWS: arn:aws:iam::254766567737:role/cloud_connectors
             Action: sts:AssumeRole
             Condition:
               StringEquals:


### PR DESCRIPTION
### Summary of your changes
Add elastic global cloud connectors role to remote role cloud formation
### Screenshot/Data



### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
