### PR TITLE
Fix bump-workflow boolean inputs

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -50,13 +50,13 @@ jobs:
           git config --global user.name "Cloud Security Machine"
 
       - name: Bump Cloudbeat
-        if: ${{ github.event.inputs.bump_cloudbeat }}
+        if: ${{ inputs.bump_cloudbeat }}
         # bump_cloudbeat.sh will create multiple PRs with different HEAD branches
         env:
           GIT_BASE_BRANCH: ${{ github.ref_name }}
         run: scripts/bump_cloudbeat.sh
 
       - name: Bump Cloud Security Posture Integration
-        if: ${{ github.event.inputs.bump_integration }}
+        if: ${{ inputs.bump_integration }}
         # we need to run bump_integration.sh from the main branch
         run: git checkout origin/main && scripts/bump_integration.sh


### PR DESCRIPTION
### Summary of your changes
`inputs.` automatically handles boolean types, while `github.event.inputs.` treats everything as strings.

The `if` was in that form `if: ${{ github.event.inputs.bump_integration }}` so it resulted in running always, no matter the boolean value of the input.

https://docs.github.com/en/actions/reference/accessing-contextual-information-about-workflow-runs#inputs-context

`github.event.inputs.` = Raw webhook data (strings only)
`inputs.` = Processed, typed data (respects boolean, choice, etc.)

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
