### PR TITLE
[Cloud Security] Fix agentless configuration for Serverless CreateEnvironment GH Actions

### DIFF
--- a/.github/actions/cis-agentless/action.yml
+++ b/.github/actions/cis-agentless/action.yml
@@ -1,5 +1,5 @@
-name: 'CIS Agentless Integrations Installation'
-description: 'Deploy CIS Agentless Integrations to Elastic Cloud'
+name: "CIS Agentless Integrations Installation"
+description: "Deploy CIS Agentless Integrations to Elastic Cloud"
 inputs:
   cspm-azure-creds:
     description: "Azure credentials for CSPM agent deployment"
@@ -20,6 +20,10 @@ inputs:
     default: "default"
     required: false
     type: string
+  serverless-mode:
+    required: false
+    description: "Set to true if the environment is serverless"
+    default: "false"
 
 runs:
   using: composite
@@ -33,5 +37,6 @@ runs:
         ES_USER: ${{ inputs.es-user }}
         ES_PASSWORD: ${{ inputs.es-password }}
         KIBANA_URL: ${{ inputs.kibana-url }}
+        SERVERLESS_MODE: ${{ inputs.serverless-mode }}
       run: |
         poetry run python ./install_agentless_integrations.py

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -440,6 +440,7 @@ jobs:
           es-user: ${{ env.ES_USER }}
           es-password: ${{ env.ES_PASSWORD }}
           kibana-url: ${{ env.KIBANA_URL }}
+          serverless-mode: "${{ env.TF_VAR_serverless_mode }}"
 
       - name: Deploy CIS Agent Based Integrations
         id: cis-integrations

--- a/tests/integrations_setup/install_agentless_integrations.py
+++ b/tests/integrations_setup/install_agentless_integrations.py
@@ -8,6 +8,7 @@ The following steps are performed:
 """
 
 import json
+import os
 
 import configuration_fleet as cnfg
 from fleet_api.agent_policy_api import create_agent_policy
@@ -81,6 +82,8 @@ if __name__ == "__main__":
         generate_azure_integration_data(),
         generate_gcp_integration_data(),
     ]
+    serverless_mode = os.getenv("SERVERLESS_MODE", "false").lower() == "true"
+
     cspm_template = generate_policy_template(
         cfg=cnfg.elk_config,
         stream_prefix="cloud_security_posture",
@@ -90,7 +93,7 @@ if __name__ == "__main__":
         AGENTLESS_INPUT = {
             "name": f"Agentless policy for {INTEGRATION_NAME}",
             "supports_agentless": True,
-            "fleet_server_host_id": "fleet-default-fleet-server-host",
+            "fleet_server_host_id": "default-fleet-server" if serverless_mode else "fleet-default-fleet-server-host",
         }
 
         logger.info(f"Starting installation of agentless-agent {INTEGRATION_NAME} integration.")


### PR DESCRIPTION
### Summary of your changes
This pull request introduces support for a "serverless mode" configuration in the CIS Agentless Integrations setup. Key changes include updates to the action configuration, workflow files, and Python scripts to enable conditional behavior based on the serverless mode setting.

### Enhancements for serverless mode:

* [`.github/actions/cis-agentless/action.yml`](diffhunk://#diff-4e0c3e906c2958454508ddef8fc4ac83e0aa98279e4a5433f41c11e7d17855efR23-R26): Added a new input parameter `serverless-mode` with a default value of `"false"`. This parameter is passed to the environment during the action run. [[1]](diffhunk://#diff-4e0c3e906c2958454508ddef8fc4ac83e0aa98279e4a5433f41c11e7d17855efR23-R26) [[2]](diffhunk://#diff-4e0c3e906c2958454508ddef8fc4ac83e0aa98279e4a5433f41c11e7d17855efR40)
* [`.github/workflows/test-environment.yml`](diffhunk://#diff-e92acdebda21024508b591a7dae2cd202f1e96f7741c94ca643a88fbf9905666R443): Updated the workflow to include the `serverless-mode` parameter, sourcing its value from the environment variable `TF_VAR_serverless_mode`.
* [`tests/integrations_setup/install_agentless_integrations.py`](diffhunk://#diff-5555127c5b6addedc422370565e640fe1b60e399f8338cc1094f4ce8a4bf8796R85-R86): Introduced logic to read the `SERVERLESS_MODE` environment variable and conditionally set the `fleet_server_host_id` to `"default-fleet-server"` if serverless mode is enabled. [[1]](diffhunk://#diff-5555127c5b6addedc422370565e640fe1b60e399f8338cc1094f4ce8a4bf8796R85-R86) [[2]](diffhunk://#diff-5555127c5b6addedc422370565e640fe1b60e399f8338cc1094f4ce8a4bf8796L93-R96)

