### PR TITLE
Add expiration support to CDR wf

### DIFF
--- a/.github/workflows/cdr-infra.yml
+++ b/.github/workflows/cdr-infra.yml
@@ -29,6 +29,10 @@ on:
         required: false
         description: "Provide the full Docker image path to override the default image (e.g. for testing BC/SNAPSHOT)"
         type: string
+      expiration-days:
+        description: "Number of days until environment expiration"
+        required: false
+        default: "5"
 
 jobs:
   init:
@@ -61,3 +65,4 @@ jobs:
       elk-stack-version: ${{ inputs.elk-stack-version }}
       serverless_mode: ${{ fromJSON(inputs.serverless_mode) }}
       infra-type: ${{ needs.init.outputs.infra-type }}
+      expiration_days: ${{ inputs.expiration-days }}

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -45,7 +45,7 @@ on:
       expiration_days:
         description: "Number of days until environment expiration"
         required: false
-        default: 5
+        default: "5"
         type: string
       ec-api-key:
         type: string
@@ -92,7 +92,7 @@ on:
       expiration_days:
         description: "Number of days until environment expiration"
         required: false
-        default: 5
+        default: "5"
         type: string
       ec-api-key:
         type: string


### PR DESCRIPTION
### Summary of your changes

This PR exposes the expiration functionality, allowing the user to specify the number of days before the environment expires.

![Screenshot 2025-07-08 at 18 23 18](https://github.com/user-attachments/assets/52a9a4c0-5837-4426-9e44-abc9566c585c)

