### PR TITLE
OTel: Align span names

### DIFF
--- a/internal/flavors/benchmark/aws_org.go
+++ b/internal/flavors/benchmark/aws_org.go
@@ -98,7 +98,7 @@ func (a *AWSOrg) initialize(ctx context.Context, log *clog.Logger, cfg *config.C
 	cache := make(map[string]registry.FetchersMap)
 	reg := registry.NewRegistry(log, registry.WithUpdater(
 		func(ctx context.Context) (registry.FetchersMap, error) {
-			ctx, span := observability.StartSpan(ctx, scopeName, "Update AWS accounts")
+			ctx, span := observability.StartSpan(ctx, scopeName, "benchmark.AWSOrg.initialize")
 			defer span.End()
 			spannedLog := log.WithSpanContext(span.SpanContext())
 

--- a/internal/resources/fetching/manager/manager.go
+++ b/internal/resources/fetching/manager/manager.go
@@ -104,7 +104,7 @@ func (m *Manager) fetchIteration(ctx context.Context) {
 	ctx, span := observability.StartSpan(
 		ctx,
 		scopeName,
-		"Fetch Iteration",
+		"manager.Manager.fetchIteration",
 		trace.WithAttributes(attribute.String("transaction.type", "request")),
 	)
 	defer span.End()


### PR DESCRIPTION
### Summary of your changes

Span naming convention: `<package>.<receiver>.<method>`

According to https://github.com/elastic/security-team/issues/13322