### PR TITLE
Use testhelper.NewLogger for tests

### DIFF
--- a/internal/flavors/assetinventory/strategy_test.go
+++ b/internal/flavors/assetinventory/strategy_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/cloudbeat/internal/config"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
@@ -138,7 +137,7 @@ func TestStrategyPicks(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := strategy{
-				logger: clog.NewLogger("strategy_test"),
+				logger: testhelper.NewLogger(t),
 				cfg:    tc.cfg,
 			}
 			ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)

--- a/internal/flavors/benchmark/aws_org_test.go
+++ b/internal/flavors/benchmark/aws_org_test.go
@@ -173,7 +173,7 @@ func Test_getAwsAccounts(t *testing.T) {
 				IdentityProvider: nil,
 				AccountProvider:  tt.accountProvider,
 			}
-			log := clog.NewLogger("test")
+			log := testhelper.NewLogger(t)
 			got, err := a.getAwsAccounts(t.Context(), log, aws.Config{}, &tt.rootIdentity)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
@@ -262,7 +262,7 @@ func Test_pickManagementAccountRole(t *testing.T) {
 						zapcore.DebugLevel,
 					)
 				})
-				log = clog.NewLogger("test").WithOptions(replacement)
+				log = testhelper.NewLogger(t).WithOptions(replacement)
 			}
 
 			stsClient := &mockStsClient{}

--- a/internal/inventory/awsfetcher/fetcher_ec2_instance_test.go
+++ b/internal/inventory/awsfetcher/fetcher_ec2_instance_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/cloudbeat/internal/dataprovider/providers/cloud"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	ec2beat "github.com/elastic/cloudbeat/internal/resources/providers/awslib/ec2"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestEC2InstanceFetcher_Fetch(t *testing.T) {
@@ -138,7 +138,7 @@ func TestEC2InstanceFetcher_Fetch(t *testing.T) {
 		),
 	}
 
-	logger := clog.NewLogger("test_fetcher_ec2")
+	logger := testhelper.NewLogger(t)
 	provider := newMockEc2InstancesProvider(t)
 	provider.EXPECT().DescribeInstances(mock.Anything).Return(in, nil)
 

--- a/internal/inventory/awsfetcher/fetcher_elb_test.go
+++ b/internal/inventory/awsfetcher/fetcher_elb_test.go
@@ -26,13 +26,13 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/cloudbeat/internal/dataprovider/providers/cloud"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib/elb"
 	elbv2 "github.com/elastic/cloudbeat/internal/resources/providers/awslib/elb_v2"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestELBv1Fetcher_Fetch(t *testing.T) {
@@ -81,7 +81,7 @@ func TestELBv1Fetcher_Fetch(t *testing.T) {
 		),
 	}
 
-	logger := clog.NewLogger("test_fetcher_elb_v1")
+	logger := testhelper.NewLogger(t)
 	providerv1 := newMockV1Provider(t)
 	providerv1.EXPECT().DescribeAllLoadBalancers(mock.Anything).Return(in, nil)
 	providerv2 := newMockV2Provider(t)
@@ -127,7 +127,7 @@ func TestELBv2Fetcher_Fetch(t *testing.T) {
 		),
 	}
 
-	logger := clog.NewLogger("test_fetcher_elb_v2")
+	logger := testhelper.NewLogger(t)
 	providerv1 := newMockV1Provider(t)
 	providerv1.EXPECT().DescribeAllLoadBalancers(mock.Anything).Return(nil, nil)
 	providerv2 := newMockV2Provider(t)

--- a/internal/inventory/awsfetcher/fetcher_iam_policy_test.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_policy_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/cloudbeat/internal/dataprovider/providers/cloud"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib/iam"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestIAMPolicyFetcher_Fetch(t *testing.T) {
@@ -144,7 +144,7 @@ func TestIAMPolicyFetcher_Fetch(t *testing.T) {
 		),
 	}
 
-	logger := clog.NewLogger("test_fetcher_iam_role")
+	logger := testhelper.NewLogger(t)
 	provider := newMockIamPolicyProvider(t)
 	provider.EXPECT().GetPolicies(mock.Anything).Return(in, nil)
 

--- a/internal/inventory/awsfetcher/fetcher_iam_role_test.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_role_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/cloudbeat/internal/dataprovider/providers/cloud"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib/iam"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestIAMRoleFetcher_Fetch(t *testing.T) {
@@ -109,7 +109,7 @@ func TestIAMRoleFetcher_Fetch(t *testing.T) {
 		),
 	}
 
-	logger := clog.NewLogger("test_fetcher_iam_role")
+	logger := testhelper.NewLogger(t)
 	provider := newMockIamRoleProvider(t)
 	provider.EXPECT().ListRoles(mock.Anything).Return(in, nil)
 

--- a/internal/inventory/awsfetcher/fetcher_iam_user_test.go
+++ b/internal/inventory/awsfetcher/fetcher_iam_user_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/cloudbeat/internal/dataprovider/providers/cloud"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib/iam"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestIAMUserFetcher_Fetch(t *testing.T) {
@@ -123,7 +123,7 @@ func TestIAMUserFetcher_Fetch(t *testing.T) {
 		),
 	}
 
-	logger := clog.NewLogger("test_fetcher_iam_user")
+	logger := testhelper.NewLogger(t)
 	provider := newMockIamUserProvider(t)
 	provider.EXPECT().GetUsers(mock.Anything).Return(in, nil)
 

--- a/internal/inventory/awsfetcher/fetcher_lambda_test.go
+++ b/internal/inventory/awsfetcher/fetcher_lambda_test.go
@@ -24,12 +24,12 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/cloudbeat/internal/dataprovider/providers/cloud"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib/lambda"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestLambdaFunction_Fetch(t *testing.T) {
@@ -67,7 +67,7 @@ func TestLambdaFunction_Fetch(t *testing.T) {
 		),
 	}
 
-	logger := clog.NewLogger("test_fetcher_lambda")
+	logger := testhelper.NewLogger(t)
 	provider := newMockLambdaProvider(t)
 
 	provider.On("ListEventSourceMappings", mock.Anything, mock.Anything).Return([]awslib.AwsResource{}, nil)

--- a/internal/inventory/awsfetcher/fetcher_rds_test.go
+++ b/internal/inventory/awsfetcher/fetcher_rds_test.go
@@ -23,12 +23,12 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/cloudbeat/internal/dataprovider/providers/cloud"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib/rds"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestRDSInstanceFetcher_Fetch(t *testing.T) {
@@ -110,7 +110,7 @@ func TestRDSInstanceFetcher_Fetch(t *testing.T) {
 		),
 	}
 
-	logger := clog.NewLogger("test_fetcher_rds_instance")
+	logger := testhelper.NewLogger(t)
 	provider := newMockRdsProvider(t)
 	provider.EXPECT().DescribeDBInstances(mock.Anything).Return(in, nil)
 

--- a/internal/inventory/awsfetcher/fetcher_s3_bucket_test.go
+++ b/internal/inventory/awsfetcher/fetcher_s3_bucket_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/cloudbeat/internal/dataprovider/providers/cloud"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib/s3"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestS3BucketFetcher_Fetch(t *testing.T) {
@@ -130,7 +130,7 @@ func TestS3BucketFetcher_Fetch(t *testing.T) {
 		),
 	}
 
-	logger := clog.NewLogger("test_fetcher_s3_bucket")
+	logger := testhelper.NewLogger(t)
 	provider := newMockS3BucketProvider(t)
 	provider.EXPECT().DescribeBuckets(mock.Anything).Return(in, nil)
 

--- a/internal/inventory/awsfetcher/fetcher_sns_test.go
+++ b/internal/inventory/awsfetcher/fetcher_sns_test.go
@@ -24,12 +24,12 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/elastic/cloudbeat/internal/dataprovider/providers/cloud"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib/sns"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestSNSFetcher_Fetch(t *testing.T) {
@@ -57,7 +57,7 @@ func TestSNSFetcher_Fetch(t *testing.T) {
 		),
 	}
 
-	logger := clog.NewLogger("test_fetcher_sns_instance")
+	logger := testhelper.NewLogger(t)
 	provider := newMockSnsProvider(t)
 	provider.EXPECT().ListTopicsWithSubscriptions(mock.Anything).Return(in, nil)
 

--- a/internal/inventory/azurefetcher/fetcher_account_test.go
+++ b/internal/inventory/azurefetcher/fetcher_account_test.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	azurelib_inventory "github.com/elastic/cloudbeat/internal/resources/providers/azurelib/inventory"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestAccountFetcher_Fetch_Tenants(t *testing.T) {
@@ -55,7 +55,7 @@ func TestAccountFetcher_Fetch_Tenants(t *testing.T) {
 	}
 
 	// setup
-	logger := clog.NewLogger("azurefetcher_test")
+	logger := testhelper.NewLogger(t)
 	provider := newMockAccountProvider(t)
 	provider.EXPECT().ListTenants(mock.Anything).Return(azureAssets, nil)
 	provider.EXPECT().ListSubscriptions(mock.Anything).Return(nil, nil)
@@ -91,7 +91,7 @@ func TestAccountFetcher_Fetch_Subscriptions(t *testing.T) {
 	}
 
 	// setup
-	logger := clog.NewLogger("azurefetcher_test")
+	logger := testhelper.NewLogger(t)
 	provider := newMockAccountProvider(t)
 	provider.EXPECT().ListTenants(mock.Anything).Return(nil, nil)
 	provider.EXPECT().ListSubscriptions(mock.Anything).Return(azureAssets, nil)

--- a/internal/inventory/azurefetcher/fetcher_activedirectory_test.go
+++ b/internal/inventory/azurefetcher/fetcher_activedirectory_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestActiveDirectoryFetcher_Fetch(t *testing.T) {
@@ -137,7 +138,7 @@ func TestActiveDirectoryFetcher_Fetch(t *testing.T) {
 	}
 
 	// setup
-	logger := clog.NewLogger("azurefetcher_test")
+	logger := testhelper.NewLogger(t)
 	provider := newMockActivedirectoryProvider(t)
 
 	provider.EXPECT().ListServicePrincipals(mock.Anything).Maybe().Return(
@@ -170,7 +171,7 @@ func TestActiveDirectoryFetcher_FetchError(t *testing.T) {
 				zapcore.DebugLevel,
 			)
 		})
-		log = clog.NewLogger("test").WithOptions(replacement)
+		log = testhelper.NewLogger(t).WithOptions(replacement)
 	}
 
 	provider := newMockActivedirectoryProvider(t)

--- a/internal/inventory/azurefetcher/fetcher_resource_graph_test.go
+++ b/internal/inventory/azurefetcher/fetcher_resource_graph_test.go
@@ -25,10 +25,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	azurelib_inventory "github.com/elastic/cloudbeat/internal/resources/providers/azurelib/inventory"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestResourceGraphFetcher_Fetch(t *testing.T) {
@@ -104,7 +104,7 @@ func TestResourceGraphFetcher_Fetch(t *testing.T) {
 	}
 
 	// setup
-	logger := clog.NewLogger("azurefetcher_test")
+	logger := testhelper.NewLogger(t)
 	provider := newMockResourceGraphProvider(t)
 
 	provider.EXPECT().ListAllAssetTypesByName(

--- a/internal/inventory/azurefetcher/fetcher_storage_test.go
+++ b/internal/inventory/azurefetcher/fetcher_storage_test.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	azurelib_inventory "github.com/elastic/cloudbeat/internal/resources/providers/azurelib/inventory"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestStorageFetcher_Fetch(t *testing.T) {
@@ -169,7 +169,7 @@ func TestStorageFetcher_Fetch(t *testing.T) {
 	}
 
 	// setup
-	logger := clog.NewLogger("azurefetcher_test")
+	logger := testhelper.NewLogger(t)
 	provider := newMockStorageProvider(t)
 
 	provider.EXPECT().ListSubscriptions(

--- a/internal/inventory/gcpfetcher/fetcher_assets_test.go
+++ b/internal/inventory/gcpfetcher/fetcher_assets_test.go
@@ -26,15 +26,15 @@ import (
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	"github.com/elastic/cloudbeat/internal/resources/fetching"
 	gcpinventory "github.com/elastic/cloudbeat/internal/resources/providers/gcplib/inventory"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func TestAccountFetcher_Fetch_Assets(t *testing.T) {
-	logger := clog.NewLogger("gcpfetcher_test")
+	logger := testhelper.NewLogger(t)
 	createAsset := func(assetType string) *gcpinventory.ExtendedGcpAsset {
 		return &gcpinventory.ExtendedGcpAsset{
 			Asset: &assetpb.Asset{

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
 	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
@@ -141,7 +140,7 @@ func TestAssetInventory_Run(t *testing.T) {
 		)
 	})
 
-	logger := clog.NewLogger("test_run")
+	logger := testhelper.NewLogger(t)
 	inventory := AssetInventory{
 		logger:              logger,
 		fetchers:            []AssetFetcher{fetcher},
@@ -184,7 +183,7 @@ func TestAssetInventory_Period(t *testing.T) {
 		atomic.AddInt64(&cycleCounter, 1)
 	})
 
-	logger := clog.NewLogger("test_run")
+	logger := testhelper.NewLogger(t)
 	inventory := AssetInventory{
 		logger:              logger,
 		fetchers:            []AssetFetcher{fetcher},
@@ -227,7 +226,7 @@ func TestAssetInventory_RunAllFetchersOnce(t *testing.T) {
 		fetcherCounters = append(fetcherCounters, &counter)
 	}
 
-	logger := clog.NewLogger("test_run")
+	logger := testhelper.NewLogger(t)
 	inventory := AssetInventory{
 		logger:              logger,
 		fetchers:            fetchers,

--- a/internal/resources/providers/awslib/iam/password_policy_test.go
+++ b/internal/resources/providers/awslib/iam/password_policy_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 func Test_GetPasswordPolicy(t *testing.T) {
@@ -83,7 +83,7 @@ func Test_GetPasswordPolicy(t *testing.T) {
 	for _, tc := range tcs {
 		t.Run(tc.tcName, func(t *testing.T) {
 			ctx := t.Context()
-			log := clog.NewLogger("test")
+			log := testhelper.NewLogger(t)
 			client := &MockClient{}
 			provider := Provider{
 				log:                   log,

--- a/internal/resources/providers/awslib/sns/provider_test.go
+++ b/internal/resources/providers/awslib/sns/provider_test.go
@@ -28,9 +28,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 type (
@@ -40,7 +40,6 @@ type (
 
 var errMock = errors.New("mock error")
 var regions = []string{"us-east-1"}
-var logger = clog.NewLogger("TestSNSProvider")
 
 func TestProvider_ListTopics(t *testing.T) {
 	tests := []struct {
@@ -89,7 +88,7 @@ func TestProvider_ListTopics(t *testing.T) {
 				c.On(name, call[0]...).Return(call[1]...)
 			}
 			p := &Provider{
-				log:     logger,
+				log:     testhelper.NewLogger(t),
 				clients: createMockClients(c, regions),
 			}
 			got, err := p.ListTopics(t.Context())
@@ -140,7 +139,7 @@ func TestProvider_ListSubscriptionsByTopic(t *testing.T) {
 				c.On(name, call[0]...).Return(call[1]...)
 			}
 			p := &Provider{
-				log:     logger,
+				log:     testhelper.NewLogger(t),
 				clients: createMockClients(c, regions),
 			}
 			got, err := p.ListSubscriptionsByTopic(t.Context(), regions[0], tt.topic)
@@ -249,7 +248,7 @@ func TestProvider_ListTopicsWithSubscriptions(t *testing.T) {
 				c.On(name, call[0]...).Return(call[1]...)
 			}
 			p := &Provider{
-				log:     logger,
+				log:     testhelper.NewLogger(t),
 				clients: createMockClients(c, regions),
 			}
 			got, err := p.ListTopicsWithSubscriptions(t.Context())

--- a/internal/resources/providers/azurelib/inventory/mysql_provider_test.go
+++ b/internal/resources/providers/azurelib/inventory/mysql_provider_test.go
@@ -27,19 +27,19 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mysql/armmysqlflexibleservers"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 type flexibleConfigFn func(configName string) (armmysqlflexibleservers.ConfigurationsClientGetResponse, error)
 
-func mockAssetFlexibleConfigurationMysqlProvider(f flexibleConfigFn) MysqlProviderAPI {
+func mockAssetFlexibleConfigurationMysqlProvider(t *testing.T, f flexibleConfigFn) MysqlProviderAPI {
 	wrapper := mysqlAzureClientWrapper{
 		AssetFlexibleConfiguration: func(_ context.Context, _, _, _, configName string, _ *arm.ClientOptions, _ *armmysqlflexibleservers.ConfigurationsClientGetOptions) (armmysqlflexibleservers.ConfigurationsClientGetResponse, error) {
 			return f(configName)
 		},
 	}
 
-	return &mysqlProvider{client: wrapper, log: clog.NewLogger("mock_asset_flexible_config")}
+	return &mysqlProvider{client: wrapper, log: testhelper.NewLogger(t)}
 }
 
 func TestMysqlProvider_GetFlexibleTLSVersionConfiguration(t *testing.T) {
@@ -102,7 +102,7 @@ func TestMysqlProvider_GetFlexibleTLSVersionConfiguration(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			provider := mockAssetFlexibleConfigurationMysqlProvider(tc.configMock)
+			provider := mockAssetFlexibleConfigurationMysqlProvider(t, tc.configMock)
 
 			assets, err := provider.GetFlexibleTLSVersionConfiguration(t.Context(), "subscription", "resource", "server")
 

--- a/internal/resources/providers/azurelib/inventory/postgresql_provider_test.go
+++ b/internal/resources/providers/azurelib/inventory/postgresql_provider_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 type (
@@ -39,7 +39,7 @@ type (
 	assetFlexFirewallRuleFn   func() ([]armpostgresqlflexibleservers.FirewallRulesClientListByServerResponse, error)
 )
 
-func mockAssetSinglePSQLConfiguration(f assetSingleConfigFn) PostgresqlProviderAPI {
+func mockAssetSinglePSQLConfiguration(t *testing.T, f assetSingleConfigFn) PostgresqlProviderAPI {
 	cl := &psqlAzureClientWrapper{
 		AssetSingleServerConfigurations: func(_ context.Context, _, _, _ string, _ *arm.ClientOptions, _ *armpostgresql.ConfigurationsClientListByServerOptions) ([]armpostgresql.ConfigurationsClientListByServerResponse, error) {
 			return f()
@@ -47,12 +47,12 @@ func mockAssetSinglePSQLConfiguration(f assetSingleConfigFn) PostgresqlProviderA
 	}
 
 	return &psqlProvider{
-		log:    clog.NewLogger("mock_single_psql_config"),
+		log:    testhelper.NewLogger(t),
 		client: cl,
 	}
 }
 
-func mockAssetFlexPSQLConfiguration(f assetFlexConfigFn) PostgresqlProviderAPI {
+func mockAssetFlexPSQLConfiguration(t *testing.T, f assetFlexConfigFn) PostgresqlProviderAPI {
 	cl := &psqlAzureClientWrapper{
 		AssetFlexibleServerConfigurations: func(_ context.Context, _, _, _ string, _ *arm.ClientOptions, _ *armpostgresqlflexibleservers.ConfigurationsClientListByServerOptions) ([]armpostgresqlflexibleservers.ConfigurationsClientListByServerResponse, error) {
 			return f()
@@ -60,12 +60,12 @@ func mockAssetFlexPSQLConfiguration(f assetFlexConfigFn) PostgresqlProviderAPI {
 	}
 
 	return &psqlProvider{
-		log:    clog.NewLogger("mock_flex_psql_config"),
+		log:    testhelper.NewLogger(t),
 		client: cl,
 	}
 }
 
-func mockAssetSinglePSQLFirewallRule(f assetSingleFirewallRuleFn) PostgresqlProviderAPI {
+func mockAssetSinglePSQLFirewallRule(t *testing.T, f assetSingleFirewallRuleFn) PostgresqlProviderAPI {
 	cl := &psqlAzureClientWrapper{
 		AssetSingleServerFirewallRules: func(_ context.Context, _, _, _ string, _ *arm.ClientOptions, _ *armpostgresql.FirewallRulesClientListByServerOptions) ([]armpostgresql.FirewallRulesClientListByServerResponse, error) {
 			return f()
@@ -73,12 +73,12 @@ func mockAssetSinglePSQLFirewallRule(f assetSingleFirewallRuleFn) PostgresqlProv
 	}
 
 	return &psqlProvider{
-		log:    clog.NewLogger("mock_single_psql_firewall_rules"),
+		log:    testhelper.NewLogger(t),
 		client: cl,
 	}
 }
 
-func mockAssetFlexPSQLFirewallRule(f assetFlexFirewallRuleFn) PostgresqlProviderAPI {
+func mockAssetFlexPSQLFirewallRule(t *testing.T, f assetFlexFirewallRuleFn) PostgresqlProviderAPI {
 	cl := &psqlAzureClientWrapper{
 		AssetFlexibleServerFirewallRules: func(_ context.Context, _, _, _ string, _ *arm.ClientOptions, _ *armpostgresqlflexibleservers.FirewallRulesClientListByServerOptions) ([]armpostgresqlflexibleservers.FirewallRulesClientListByServerResponse, error) {
 			return f()
@@ -86,7 +86,7 @@ func mockAssetFlexPSQLFirewallRule(f assetFlexFirewallRuleFn) PostgresqlProvider
 	}
 
 	return &psqlProvider{
-		log:    clog.NewLogger("mock_flexs_psql_firewall_rules"),
+		log:    testhelper.NewLogger(t),
 		client: cl,
 	}
 }
@@ -149,7 +149,7 @@ func TestListSinglePostgresConfigurations(t *testing.T) {
 
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
-			p := mockAssetSinglePSQLConfiguration(tc.apiMockCall)
+			p := mockAssetSinglePSQLConfiguration(t, tc.apiMockCall)
 			got, err := p.ListSinglePostgresConfigurations(t.Context(), "subId", "resourceGroup", "psqlInstanceName")
 
 			if tc.expectError {
@@ -221,7 +221,7 @@ func TestListFlexiblePostgresConfigurations(t *testing.T) {
 
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
-			p := mockAssetFlexPSQLConfiguration(tc.apiMockCall)
+			p := mockAssetFlexPSQLConfiguration(t, tc.apiMockCall)
 			got, err := p.ListFlexiblePostgresConfigurations(t.Context(), "subId", "resourceGroup", "psqlInstanceName")
 
 			if tc.expectError {
@@ -280,7 +280,7 @@ func TestListSinglePostgresFirewallRules(t *testing.T) {
 
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
-			p := mockAssetSinglePSQLFirewallRule(tc.apiMockCall)
+			p := mockAssetSinglePSQLFirewallRule(t, tc.apiMockCall)
 			got, err := p.ListSinglePostgresFirewallRules(t.Context(), "subId", "resourceGroup", "psqlInstanceName")
 
 			if tc.expectError {
@@ -339,7 +339,7 @@ func TestFlexibleSinglePostgresFirewallRules(t *testing.T) {
 
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
-			p := mockAssetFlexPSQLFirewallRule(tc.apiMockCall)
+			p := mockAssetFlexPSQLFirewallRule(t, tc.apiMockCall)
 			got, err := p.ListFlexiblePostgresFirewallRules(t.Context(), "subId", "resourceGroup", "psqlInstanceName")
 
 			if tc.expectError {

--- a/internal/resources/providers/gcplib/auth/credentials_test.go
+++ b/internal/resources/providers/gcplib/auth/credentials_test.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/api/option"
 
 	"github.com/elastic/cloudbeat/internal/config"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
+	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 const (
@@ -289,7 +289,7 @@ func TestGetGcpClientConfig(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			for idx, cfg := range tt.cfg {
-				got, err := p.GetGcpClientConfig(t.Context(), cfg, clog.NewLogger("gcp credentials test"))
+				got, err := p.GetGcpClientConfig(t.Context(), cfg, testhelper.NewLogger(t))
 				if tt.wantErr {
 					require.Error(t, err)
 				} else {

--- a/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
+++ b/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
@@ -46,7 +46,7 @@ func TestInventoryRateLimiterTestSuite(t *testing.T) {
 }
 
 func (s *RateLimiterTestSuite) SetupTest() {
-	s.logger = clog.NewLogger("test")
+	s.logger = testhelper.NewLogger(s.T())
 	s.rateLimiter = NewAssetsInventoryRateLimiter(s.logger)
 }
 


### PR DESCRIPTION
### Summary of your changes
Simplifies test files by removing direct invocations of the clog package. Benefits:
1. Centralized invocation
2. No manual naming needed
3. Test-related logging configuration can be changed at once across all tests

Making a separate PR to help with https://github.com/elastic/cloudbeat/pull/3514