### PR TITLE
refactor(tests): Remove logger objects from test structs

### DIFF
--- a/internal/evaluator/opa_test.go
+++ b/internal/evaluator/opa_test.go
@@ -31,7 +31,6 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/elastic/cloudbeat/internal/config"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/resources/fetching"
 	"github.com/elastic/cloudbeat/internal/resources/fetching/cycle"
 	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
@@ -57,14 +56,12 @@ func (d *DummyResource) GetElasticCommonData() (map[string]any, error) {
 
 type OpaTestSuite struct {
 	suite.Suite
-	log *clog.Logger
 }
 
 func TestOpaTestSuite(t *testing.T) {
 	testhelper.SkipLong(t)
 
 	s := new(OpaTestSuite)
-	s.log = testhelper.NewLogger(t)
 
 	suite.Run(t, s)
 }
@@ -134,7 +131,7 @@ func (s *OpaTestSuite) TestOpaEvaluatorWithDecisionLogs() {
 	for _, tt := range tests {
 		s.Run(fmt.Sprintf("TestEvaluationsDecisionLogs %+v", tt), func() {
 			cfg := s.getTestConfig()
-			e, err := NewOpaEvaluator(ctx, s.log, cfg)
+			e, err := NewOpaEvaluator(ctx, testhelper.NewLogger(s.T()), cfg)
 			s.Require().NoError(err)
 
 			for i := 0; i < tt.evals; i++ {

--- a/internal/flavors/benchmark/aws_org_test.go
+++ b/internal/flavors/benchmark/aws_org_test.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/elastic/cloudbeat/internal/config"
 	"github.com/elastic/cloudbeat/internal/dataprovider/providers/cloud"
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/resources/fetching"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib/iam"
@@ -252,18 +251,15 @@ func Test_pickManagementAccountRole(t *testing.T) {
 			}
 
 			// set up log capture
-			var log *clog.Logger
 			logCaptureBuf := &bytes.Buffer{}
-			{
-				replacement := zap.WrapCore(func(zapcore.Core) zapcore.Core {
-					return zapcore.NewCore(
-						zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
-						zapcore.AddSync(logCaptureBuf),
-						zapcore.DebugLevel,
-					)
-				})
-				log = testhelper.NewLogger(t).WithOptions(replacement)
-			}
+			replacement := zap.WrapCore(func(zapcore.Core) zapcore.Core {
+				return zapcore.NewCore(
+					zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+					zapcore.AddSync(logCaptureBuf),
+					zapcore.DebugLevel,
+				)
+			})
+			log := testhelper.NewLogger(t).WithOptions(replacement)
 
 			stsClient := &mockStsClient{}
 			rootCfg := assumeRole(stsClient, aws.Config{}, "cloudbeat-root")

--- a/internal/inventory/azurefetcher/fetcher_activedirectory_test.go
+++ b/internal/inventory/azurefetcher/fetcher_activedirectory_test.go
@@ -32,7 +32,6 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/inventory"
 	"github.com/elastic/cloudbeat/internal/inventory/testutil"
 	"github.com/elastic/cloudbeat/internal/resources/utils/pointers"
@@ -161,18 +160,15 @@ func TestActiveDirectoryFetcher_Fetch(t *testing.T) {
 
 func TestActiveDirectoryFetcher_FetchError(t *testing.T) {
 	// set up log capture
-	var log *clog.Logger
 	logCaptureBuf := &bytes.Buffer{}
-	{
-		replacement := zap.WrapCore(func(zapcore.Core) zapcore.Core {
-			return zapcore.NewCore(
-				zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
-				zapcore.AddSync(logCaptureBuf),
-				zapcore.DebugLevel,
-			)
-		})
-		log = testhelper.NewLogger(t).WithOptions(replacement)
-	}
+	replacement := zap.WrapCore(func(zapcore.Core) zapcore.Core {
+		return zapcore.NewCore(
+			zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+			zapcore.AddSync(logCaptureBuf),
+			zapcore.DebugLevel,
+		)
+	})
+	log := testhelper.NewLogger(t).WithOptions(replacement)
 
 	provider := newMockActivedirectoryProvider(t)
 	provider.EXPECT().ListServicePrincipals(mock.Anything).Return(

--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/goleak"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
@@ -128,7 +127,6 @@ func (v *validatorMock) Validate(cfg *config.C) error {
 type LauncherTestSuite struct {
 	suite.Suite
 
-	log  *clog.Logger
 	opts goleak.Option
 }
 
@@ -141,7 +139,6 @@ func TestLauncherTestSuite(t *testing.T) {
 	testhelper.SkipLong(t)
 
 	s := new(LauncherTestSuite)
-	s.log = testhelper.NewLogger(t)
 
 	s.opts = goleak.IgnoreCurrent()
 	suite.Run(t, s)
@@ -510,7 +507,7 @@ func (s *LauncherTestSuite) initMocks() *launcherMocks {
 }
 
 func (s *LauncherTestSuite) newLauncher(mocks *launcherMocks, creator beat.Creator) *launcher {
-	sut, ok := New(s.log, "DummyBeat", mocks.reloader, mocks.validator, creator, config.NewConfig()).(*launcher)
+	sut, ok := New(testhelper.NewLogger(s.T()), "DummyBeat", mocks.reloader, mocks.validator, creator, config.NewConfig()).(*launcher)
 	s.Require().True(ok)
 	return sut
 }

--- a/internal/resources/providers/awslib/multi_region_test.go
+++ b/internal/resources/providers/awslib/multi_region_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
@@ -48,7 +47,6 @@ func TestMultiRegionWrapper_NewMultiRegionClients(t *testing.T) {
 	type args struct {
 		selector func() RegionsSelector
 		cfg      aws.Config
-		log      *clog.Logger
 	}
 	tests := []struct {
 		name string
@@ -66,7 +64,6 @@ func TestMultiRegionWrapper_NewMultiRegionClients(t *testing.T) {
 				cfg: aws.Config{
 					Region: afRegion,
 				},
-				log: testhelper.NewLogger(t),
 			},
 			want: map[string]string{afRegion: afRegion},
 		},
@@ -79,7 +76,6 @@ func TestMultiRegionWrapper_NewMultiRegionClients(t *testing.T) {
 					return m
 				},
 				cfg: aws.Config{},
-				log: testhelper.NewLogger(t),
 			},
 			want: map[string]string{DefaultRegion: DefaultRegion, euRegion: euRegion},
 		},
@@ -92,7 +88,7 @@ func TestMultiRegionWrapper_NewMultiRegionClients(t *testing.T) {
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
-			multiRegionClients := wrapper.NewMultiRegionClients(t.Context(), tt.args.selector(), tt.args.cfg, factory, tt.args.log)
+			multiRegionClients := wrapper.NewMultiRegionClients(t.Context(), tt.args.selector(), tt.args.cfg, factory, testhelper.NewLogger(t))
 			clients := multiRegionClients.GetMultiRegionsClientMap()
 			if !reflect.DeepEqual(clients, tt.want) {
 				t.Errorf("GetRegions() got = %v, want %v", clients, tt.want)

--- a/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
+++ b/internal/resources/providers/gcplib/inventory/grpc_rate_limiter_test.go
@@ -31,13 +31,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/elastic/cloudbeat/internal/infra/clog"
 	"github.com/elastic/cloudbeat/internal/resources/utils/testhelper"
 )
 
 type RateLimiterTestSuite struct {
 	suite.Suite
-	logger      *clog.Logger
 	rateLimiter *AssetsInventoryRateLimiter
 }
 
@@ -46,8 +44,8 @@ func TestInventoryRateLimiterTestSuite(t *testing.T) {
 }
 
 func (s *RateLimiterTestSuite) SetupTest() {
-	s.logger = testhelper.NewLogger(s.T())
-	s.rateLimiter = NewAssetsInventoryRateLimiter(s.logger)
+	logger := testhelper.NewLogger(s.T())
+	s.rateLimiter = NewAssetsInventoryRateLimiter(logger)
 }
 
 func (s *RateLimiterTestSuite) TestRateLimiterWait() {

--- a/internal/vulnerability/events_creator_test.go
+++ b/internal/vulnerability/events_creator_test.go
@@ -123,7 +123,7 @@ type EventsCreatorTestSuite struct {
 	suite.Suite
 	cdp     *MockEnricher
 	bdp     *dataprovider.MockCommonDataProvider
-	creator EventsCreator
+	creator *EventsCreator
 }
 
 func TestSuite(t *testing.T) {
@@ -135,7 +135,7 @@ func (s *EventsCreatorTestSuite) SetupTest() {
 	s.cdp = &MockEnricher{}
 	s.bdp = &dataprovider.MockCommonDataProvider{}
 
-	s.creator = EventsCreator{
+	s.creator = &EventsCreator{
 		log:                testhelper.NewLogger(s.T()),
 		cloudDataProvider:  s.bdp,
 		commonDataProvider: s.cdp,
@@ -184,7 +184,6 @@ func (s *EventsCreatorTestSuite) TestCreateEvents_Cancel() {
 	s.bdp.EXPECT().EnrichEvent(mock.Anything, mock.Anything).Return(nil).Times(10)
 	s.cdp.EXPECT().EnrichEvent(mock.Anything).Return(nil).Times(10)
 
-	creator := s.creator
 	t := s.T()
 	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
@@ -196,10 +195,10 @@ func (s *EventsCreatorTestSuite) TestCreateEvents_Cancel() {
 		}
 	}()
 
-	ch := creator.GetChan()
+	ch := s.creator.GetChan()
 	s.NotNil(ch)
 
-	creator.CreateEvents(ctx, scanCh)
+	s.creator.CreateEvents(ctx, scanCh)
 
 	_, ok := <-ch
 	s.False(ok)
@@ -229,7 +228,7 @@ func (s *EventsCreatorTestSuite) TestGetCVSSVersion() {
 	}
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			e := EventsCreator{log: testhelper.NewLogger(s.T())}
+			e := &EventsCreator{log: testhelper.NewLogger(s.T())}
 			got := e.getCVSSVersion(tt.vul)
 			s.Equal(tt.want, got)
 		})
@@ -260,7 +259,7 @@ func (s *EventsCreatorTestSuite) TestGetCVSSVector() {
 	}
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			e := EventsCreator{log: testhelper.NewLogger(s.T())}
+			e := &EventsCreator{log: testhelper.NewLogger(s.T())}
 			got := e.getCVSSVector(tt.vul)
 			s.Equal(tt.want, got)
 		})
@@ -301,7 +300,7 @@ func (s *EventsCreatorTestSuite) TestGetCVSSScore() {
 	}
 	for _, tt := range tests {
 		s.Run(tt.name, func() {
-			e := EventsCreator{log: testhelper.NewLogger(s.T())}
+			e := &EventsCreator{log: testhelper.NewLogger(s.T())}
 			got := e.getCVSSScore(tt.vul)
 			s.InEpsilon(tt.want, got, 0.001)
 			s.InDelta(tt.want, got, 0.001)

--- a/internal/vulnerability/verifier_test.go
+++ b/internal/vulnerability/verifier_test.go
@@ -51,7 +51,6 @@ func (s *VerifierTestSuite) TearDownTest() {
 }
 
 func (s *VerifierTestSuite) TestVulnerabilityVerifier_VerifySnapshot_Cancel() {
-	logger := testhelper.NewLogger(s.T())
 	provider := &mockSnapshotDescriber{}
 	provider.EXPECT().DescribeSnapshots(mock.Anything, mock.Anything).Return([]ec2.EBSSnapshot{
 		{
@@ -73,7 +72,7 @@ func (s *VerifierTestSuite) TestVulnerabilityVerifier_VerifySnapshot_Cancel() {
 			},
 		},
 	}, nil)
-	verifier := NewVulnerabilityVerifier(logger, provider)
+	verifier := NewVulnerabilityVerifier(testhelper.NewLogger(s.T()), provider)
 	verifier.interval = 100 * time.Millisecond
 
 	t := s.T()
@@ -99,7 +98,6 @@ func (s *VerifierTestSuite) TestVulnerabilityVerifier_VerifySnapshot_Cancel() {
 }
 
 func (s *VerifierTestSuite) TestVulnerabilityVerifier_verify() {
-	logger := testhelper.NewLogger(s.T())
 	provider := &mockSnapshotDescriber{}
 	expectedSnapshots := []ec2.EBSSnapshot{
 		{
@@ -116,7 +114,7 @@ func (s *VerifierTestSuite) TestVulnerabilityVerifier_verify() {
 		},
 	}
 	provider.EXPECT().DescribeSnapshots(mock.Anything, mock.Anything).Return(expectedSnapshots, nil)
-	verifier := NewVulnerabilityVerifier(logger, provider)
+	verifier := NewVulnerabilityVerifier(testhelper.NewLogger(s.T()), provider)
 
 	t := s.T()
 	ctx, cancel := context.WithCancel(t.Context())


### PR DESCRIPTION
### Summary of your changes
This commit refactors multiple test files to remove logger objects that were previously embedded within test suite structs. Instead, loggers are now created directly within the test functions where they are needed, using `testhelper.NewLogger()`.

This change improves code quality by making dependencies more explicit and reducing the state carried by test structs.