### PR TITLE
[aws single account]: use aws account name if alias is not configured

### DIFF
--- a/internal/flavors/benchmark/aws_org.go
+++ b/internal/flavors/benchmark/aws_org.go
@@ -123,12 +123,12 @@ func (a *AWSOrg) initialize(ctx context.Context, log *clog.Logger, cfg *config.C
 
 // getAwsAccounts returns all the aws accounts of the org.
 // For each account it bundles together the cloud.Identity and the credentials for the cloudbeat-securityaudit role of that account.
-// It requires cloudbeat-root credentials (requires iam:ListAccountAliases and iam:GetRole).
+// It requires cloudbeat-root credentials (requires organizations:ListAccounts, organizations:ListParents, organizations:DescribeOrganizationalUnit and iam:GetRole).
 func (a *AWSOrg) getAwsAccounts(ctx context.Context, log *clog.Logger, cfgCloudbeatRoot awssdk.Config, rootIdentity *cloud.Identity) ([]preset.AwsAccount, error) {
 	stsClient := sts.NewFromConfig(cfgCloudbeatRoot)
 
 	// accountIdentities array contains all the Accounts and Organizational
-	// Units, even if they are nested. (requires iam:ListAccountAliases)
+	// Units, even if they are nested. (requires organizations:ListAccounts, organizations:ListParents, organizations:DescribeOrganizationalUnit)
 	accountIdentities, err := a.AccountProvider.ListAccounts(ctx, log, cfgCloudbeatRoot)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Summary of your changes
In AWS (both for CSPM and Asset Inventory) we have 2 ways to initialize the `cloud.Identity` (that contains the account number and account name). 

On the single-account we use `IdentityProvider.GetIdentity` that used to call aws `iam.ListAccountAliases` to fetch the configured **aliases** for the current aws account.

On the organization setup, we use `AccountProvider.ListAccounts` that calls aws `organizations.ListAccounts` to fetch all the org accounts with the **name** (not alias) of each one. 


In case we have single-account and **no alias configured** in the aws account, we don't resolve any name because we used to fetch only aliases in the `IdentityProvider.GetIdentity`.


In this PR:
  * Keep fetching aliases as first resolve attempt to keep backwords compatibility
  * If no alias is found, use aws `organizations.DescribeAccount` to fetch the account **name**.
  * AWS [SecurityAudit](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/SecurityAudit.html) already contains `"organizations:Describe*"`, so its safe to call the `organizations.DescribeAccount`.




### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->
Fixes: https://github.com/elastic/kibana/issues/226433


### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
