### PR TITLE
Azure cloud connector credentials

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,7 +257,7 @@ const (
 	CloudConnectorsLocalRoleEnvVar  = "CLOUD_CONNECTORS_LOCAL_ROLE"
 	CloudConnectorsGlobalRoleEnvVar = "CLOUD_CONNECTORS_GLOBAL_ROLE"
 	CloudResourceIDEnvVar           = "CLOUD_RESOURCE_ID"
-	AzureClientAssertionPathEnvVar  = "AZURE_CLIENT_ASSERTION_PATH"
+	CloudConnectorsJWTPathEnvVar    = "CLOUD_CONNECTORS_JWT_PATH"
 )
 
 type CloudConnectorsConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,7 +117,6 @@ type AzureClientOpt struct {
 	ClientPassword            string `config:"client_password"`
 	ClientCertificatePath     string `config:"client_certificate_path"`
 	ClientCertificatePassword string `config:"client_certificate_password"`
-	ClientAssertionPath       string `config:"client_assertion_path"`
 }
 
 const (
@@ -258,6 +257,7 @@ const (
 	CloudConnectorsLocalRoleEnvVar  = "CLOUD_CONNECTORS_LOCAL_ROLE"
 	CloudConnectorsGlobalRoleEnvVar = "CLOUD_CONNECTORS_GLOBAL_ROLE"
 	CloudResourceIDEnvVar           = "CLOUD_RESOURCE_ID"
+	AzureClientAssertionPathEnvVar  = "AZURE_CLIENT_ASSERTION_PATH"
 )
 
 type CloudConnectorsConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,6 +117,7 @@ type AzureClientOpt struct {
 	ClientPassword            string `config:"client_password"`
 	ClientCertificatePath     string `config:"client_certificate_path"`
 	ClientCertificatePassword string `config:"client_certificate_password"`
+	ClientAssertionPath       string `config:"client_assertion_path"`
 }
 
 const (
@@ -125,6 +126,7 @@ const (
 	AzureClientCredentialsTypeManual          = "manual"
 	AzureClientCredentialsTypeSecret          = "service_principal_with_client_secret"
 	AzureClientCredentialsTypeCertificate     = "service_principal_with_client_certificate"
+	AzureClientCredentialsTypeCloudConnectors = "cloud_connectors"
 )
 
 const (

--- a/internal/resources/providers/azurelib/auth/auth_provider.go
+++ b/internal/resources/providers/azurelib/auth/auth_provider.go
@@ -69,9 +69,9 @@ func (a *AzureAuthProvider) FindCertificateCredential(tenantID string, clientID 
 
 // FindClientAssertionCredentials is a wrapper around azidentity.NewClientAssertionCredential that loads JWT from environment variable, similar to cloud connectors pattern
 func (a *AzureAuthProvider) FindClientAssertionCredentials(tenantID string, clientID string, options *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error) {
-	jwtFilePath := os.Getenv(config.AzureClientAssertionPathEnvVar)
+	jwtFilePath := os.Getenv(config.CloudConnectorsJWTPathEnvVar)
 	if jwtFilePath == "" {
-		return nil, fmt.Errorf("environment variable %s is required for client assertion credentials", config.AzureClientAssertionPathEnvVar)
+		return nil, fmt.Errorf("environment variable %s is required for client assertion credentials", config.CloudConnectorsJWTPathEnvVar)
 	}
 
 	getAssertion := func(ctx context.Context) (string, error) {

--- a/internal/resources/providers/azurelib/auth/auth_provider.go
+++ b/internal/resources/providers/azurelib/auth/auth_provider.go
@@ -18,8 +18,10 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 )
@@ -30,6 +32,7 @@ type AzureAuthProviderAPI interface {
 	FindDefaultCredentials(options *azidentity.DefaultAzureCredentialOptions) (*azidentity.DefaultAzureCredential, error)
 	FindClientSecretCredentials(tenantID string, clientID string, clientSecret string, options *azidentity.ClientSecretCredentialOptions) (*azidentity.ClientSecretCredential, error)
 	FindCertificateCredential(tenantID string, clientID string, certPath string, password string, options *azidentity.ClientCertificateCredentialOptions) (*azidentity.ClientCertificateCredential, error)
+	FindClientAssertionCredentials(tenantID string, clientID string, jwtFilePath string, options *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error)
 }
 
 // FindDefaultCredentials is a wrapper around azidentity.NewDefaultAzureCredential to make it easier to mock
@@ -60,4 +63,33 @@ func (a *AzureAuthProvider) FindCertificateCredential(tenantID string, clientID 
 	}
 
 	return azidentity.NewClientCertificateCredential(tenantID, clientID, certs, key, options)
+}
+
+// FindClientAssertionCredentials is a wrapper around azidentity.NewClientAssertionCredential that loads JWT from file, similar to FindCertificateCredential
+func (a *AzureAuthProvider) FindClientAssertionCredentials(tenantID string, clientID string, jwtFilePath string, options *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error) {
+	getAssertion := func(ctx context.Context) (string, error) {
+		return readJWTFromFile(jwtFilePath)
+	}
+
+	return azidentity.NewClientAssertionCredential(tenantID, clientID, getAssertion, options)
+}
+
+func readJWTFromFile(filePath string) (string, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("error trying to read JWT file %s: %s", filePath, err.Error())
+	}
+
+	jwt := strings.TrimSpace(string(data))
+	if jwt == "" {
+		return "", fmt.Errorf("JWT file %s is empty", filePath)
+	}
+
+	// Basic validation - JWT should have 3 parts separated by dots
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid JWT format in file %s: expected 3 parts separated by dots, got %d", filePath, len(parts))
+	}
+
+	return jwt, nil
 }

--- a/internal/resources/providers/azurelib/auth/credentials.go
+++ b/internal/resources/providers/azurelib/auth/credentials.go
@@ -101,7 +101,6 @@ func (p *ConfigProvider) getCloudConnectorsCredentialsConfig(cfg config.AzureCon
 	creds, err := p.AuthProvider.FindClientAssertionCredentials(
 		cfg.Credentials.TenantID,
 		cfg.Credentials.ClientID,
-		cfg.Credentials.ClientAssertionPath,
 		nil,
 	)
 	if err != nil {

--- a/internal/resources/providers/azurelib/auth/credentials.go
+++ b/internal/resources/providers/azurelib/auth/credentials.go
@@ -44,6 +44,8 @@ func (p *ConfigProvider) GetAzureClientConfig(cfg config.AzureConfig) (*AzureFac
 		return p.getSecretCredentialsConfig(cfg)
 	case config.AzureClientCredentialsTypeCertificate:
 		return p.getCertificateCredentialsConfig(cfg)
+	case config.AzureClientCredentialsTypeCloudConnectors:
+		return p.getCloudConnectorsCredentialsConfig(cfg)
 	case "", config.AzureClientCredentialsTypeManagedIdentity, config.AzureClientCredentialsTypeARMTemplate, config.AzureClientCredentialsTypeManual:
 		return p.getDefaultCredentialsConfig()
 	}
@@ -88,6 +90,22 @@ func (p *ConfigProvider) getCertificateCredentialsConfig(cfg config.AzureConfig)
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret credentials: %w", err)
+	}
+
+	return &AzureFactoryConfig{
+		Credentials: creds,
+	}, nil
+}
+
+func (p *ConfigProvider) getCloudConnectorsCredentialsConfig(cfg config.AzureConfig) (*AzureFactoryConfig, error) {
+	creds, err := p.AuthProvider.FindClientAssertionCredentials(
+		cfg.Credentials.TenantID,
+		cfg.Credentials.ClientID,
+		cfg.Credentials.ClientAssertionPath,
+		nil,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cloud connectors credentials: %w", err)
 	}
 
 	return &AzureFactoryConfig{

--- a/internal/resources/providers/azurelib/auth/credentials_test.go
+++ b/internal/resources/providers/azurelib/auth/credentials_test.go
@@ -142,12 +142,11 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 					ClientCredentialsType: config.AzureClientCredentialsTypeCloudConnectors,
 					TenantID:              "tenant_a",
 					ClientID:              "client_id",
-					ClientAssertionPath:   "/path/to/jwt.token",
 				},
 			},
 			authProviderInitFn: func(m *MockAzureAuthProviderAPI) {
 				m.EXPECT().
-					FindClientAssertionCredentials("tenant_a", "client_id", "/path/to/jwt.token", mock.Anything).
+					FindClientAssertionCredentials("tenant_a", "client_id", mock.Anything).
 					Return(&azidentity.ClientAssertionCredential{}, nil).
 					Once()
 			},
@@ -163,12 +162,11 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 					ClientCredentialsType: config.AzureClientCredentialsTypeCloudConnectors,
 					TenantID:              "tenant_a",
 					ClientID:              "client_id",
-					ClientAssertionPath:   "/path/to/jwt.token",
 				},
 			},
 			authProviderInitFn: func(m *MockAzureAuthProviderAPI) {
 				m.EXPECT().
-					FindClientAssertionCredentials("tenant_a", "client_id", "/path/to/jwt.token", mock.Anything).
+					FindClientAssertionCredentials("tenant_a", "client_id", mock.Anything).
 					Return(nil, errMockAzure).
 					Once()
 			},

--- a/internal/resources/providers/azurelib/auth/credentials_test.go
+++ b/internal/resources/providers/azurelib/auth/credentials_test.go
@@ -136,6 +136,46 @@ func TestConfigProvider_GetAzureClientConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Should return a ClientAssertionCredential for cloud_connectors",
+			config: config.AzureConfig{
+				Credentials: config.AzureClientOpt{
+					ClientCredentialsType: config.AzureClientCredentialsTypeCloudConnectors,
+					TenantID:              "tenant_a",
+					ClientID:              "client_id",
+					ClientAssertionPath:   "/path/to/jwt.token",
+				},
+			},
+			authProviderInitFn: func(m *MockAzureAuthProviderAPI) {
+				m.EXPECT().
+					FindClientAssertionCredentials("tenant_a", "client_id", "/path/to/jwt.token", mock.Anything).
+					Return(&azidentity.ClientAssertionCredential{}, nil).
+					Once()
+			},
+			want: &AzureFactoryConfig{
+				Credentials: &azidentity.ClientAssertionCredential{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should return an error on cloud_connectors credentials error",
+			config: config.AzureConfig{
+				Credentials: config.AzureClientOpt{
+					ClientCredentialsType: config.AzureClientCredentialsTypeCloudConnectors,
+					TenantID:              "tenant_a",
+					ClientID:              "client_id",
+					ClientAssertionPath:   "/path/to/jwt.token",
+				},
+			},
+			authProviderInitFn: func(m *MockAzureAuthProviderAPI) {
+				m.EXPECT().
+					FindClientAssertionCredentials("tenant_a", "client_id", "/path/to/jwt.token", mock.Anything).
+					Return(nil, errMockAzure).
+					Once()
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "Should return an error on credentials error",
 			config: config.AzureConfig{
 				Credentials: config.AzureClientOpt{

--- a/internal/resources/providers/azurelib/auth/mock_azure_auth_provider_api.go
+++ b/internal/resources/providers/azurelib/auth/mock_azure_auth_provider_api.go
@@ -99,9 +99,9 @@ func (_c *MockAzureAuthProviderAPI_FindCertificateCredential_Call) RunAndReturn(
 	return _c
 }
 
-// FindClientAssertionCredentials provides a mock function with given fields: tenantID, clientID, jwtFilePath, options
-func (_m *MockAzureAuthProviderAPI) FindClientAssertionCredentials(tenantID string, clientID string, jwtFilePath string, options *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error) {
-	ret := _m.Called(tenantID, clientID, jwtFilePath, options)
+// FindClientAssertionCredentials provides a mock function with given fields: tenantID, clientID, options
+func (_m *MockAzureAuthProviderAPI) FindClientAssertionCredentials(tenantID string, clientID string, options *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error) {
+	ret := _m.Called(tenantID, clientID, options)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FindClientAssertionCredentials")
@@ -109,19 +109,19 @@ func (_m *MockAzureAuthProviderAPI) FindClientAssertionCredentials(tenantID stri
 
 	var r0 *azidentity.ClientAssertionCredential
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string, string, *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error)); ok {
-		return rf(tenantID, clientID, jwtFilePath, options)
+	if rf, ok := ret.Get(0).(func(string, string, *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error)); ok {
+		return rf(tenantID, clientID, options)
 	}
-	if rf, ok := ret.Get(0).(func(string, string, string, *azidentity.ClientAssertionCredentialOptions) *azidentity.ClientAssertionCredential); ok {
-		r0 = rf(tenantID, clientID, jwtFilePath, options)
+	if rf, ok := ret.Get(0).(func(string, string, *azidentity.ClientAssertionCredentialOptions) *azidentity.ClientAssertionCredential); ok {
+		r0 = rf(tenantID, clientID, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*azidentity.ClientAssertionCredential)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string, string, *azidentity.ClientAssertionCredentialOptions) error); ok {
-		r1 = rf(tenantID, clientID, jwtFilePath, options)
+	if rf, ok := ret.Get(1).(func(string, string, *azidentity.ClientAssertionCredentialOptions) error); ok {
+		r1 = rf(tenantID, clientID, options)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -137,15 +137,14 @@ type MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call struct {
 // FindClientAssertionCredentials is a helper method to define mock.On call
 //   - tenantID string
 //   - clientID string
-//   - jwtFilePath string
 //   - options *azidentity.ClientAssertionCredentialOptions
-func (_e *MockAzureAuthProviderAPI_Expecter) FindClientAssertionCredentials(tenantID interface{}, clientID interface{}, jwtFilePath interface{}, options interface{}) *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call {
-	return &MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call{Call: _e.mock.On("FindClientAssertionCredentials", tenantID, clientID, jwtFilePath, options)}
+func (_e *MockAzureAuthProviderAPI_Expecter) FindClientAssertionCredentials(tenantID interface{}, clientID interface{}, options interface{}) *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call {
+	return &MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call{Call: _e.mock.On("FindClientAssertionCredentials", tenantID, clientID, options)}
 }
 
-func (_c *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call) Run(run func(tenantID string, clientID string, jwtFilePath string, options *azidentity.ClientAssertionCredentialOptions)) *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call {
+func (_c *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call) Run(run func(tenantID string, clientID string, options *azidentity.ClientAssertionCredentialOptions)) *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string), args[3].(*azidentity.ClientAssertionCredentialOptions))
+		run(args[0].(string), args[1].(string), args[2].(*azidentity.ClientAssertionCredentialOptions))
 	})
 	return _c
 }
@@ -155,7 +154,7 @@ func (_c *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call) Return(_
 	return _c
 }
 
-func (_c *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call) RunAndReturn(run func(string, string, string, *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error)) *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call {
+func (_c *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call) RunAndReturn(run func(string, string, *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error)) *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/resources/providers/azurelib/auth/mock_azure_auth_provider_api.go
+++ b/internal/resources/providers/azurelib/auth/mock_azure_auth_provider_api.go
@@ -99,6 +99,67 @@ func (_c *MockAzureAuthProviderAPI_FindCertificateCredential_Call) RunAndReturn(
 	return _c
 }
 
+// FindClientAssertionCredentials provides a mock function with given fields: tenantID, clientID, jwtFilePath, options
+func (_m *MockAzureAuthProviderAPI) FindClientAssertionCredentials(tenantID string, clientID string, jwtFilePath string, options *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error) {
+	ret := _m.Called(tenantID, clientID, jwtFilePath, options)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FindClientAssertionCredentials")
+	}
+
+	var r0 *azidentity.ClientAssertionCredential
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string, string, *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error)); ok {
+		return rf(tenantID, clientID, jwtFilePath, options)
+	}
+	if rf, ok := ret.Get(0).(func(string, string, string, *azidentity.ClientAssertionCredentialOptions) *azidentity.ClientAssertionCredential); ok {
+		r0 = rf(tenantID, clientID, jwtFilePath, options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*azidentity.ClientAssertionCredential)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string, string, *azidentity.ClientAssertionCredentialOptions) error); ok {
+		r1 = rf(tenantID, clientID, jwtFilePath, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindClientAssertionCredentials'
+type MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call struct {
+	*mock.Call
+}
+
+// FindClientAssertionCredentials is a helper method to define mock.On call
+//   - tenantID string
+//   - clientID string
+//   - jwtFilePath string
+//   - options *azidentity.ClientAssertionCredentialOptions
+func (_e *MockAzureAuthProviderAPI_Expecter) FindClientAssertionCredentials(tenantID interface{}, clientID interface{}, jwtFilePath interface{}, options interface{}) *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call {
+	return &MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call{Call: _e.mock.On("FindClientAssertionCredentials", tenantID, clientID, jwtFilePath, options)}
+}
+
+func (_c *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call) Run(run func(tenantID string, clientID string, jwtFilePath string, options *azidentity.ClientAssertionCredentialOptions)) *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string), args[2].(string), args[3].(*azidentity.ClientAssertionCredentialOptions))
+	})
+	return _c
+}
+
+func (_c *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call) Return(_a0 *azidentity.ClientAssertionCredential, _a1 error) *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call) RunAndReturn(run func(string, string, string, *azidentity.ClientAssertionCredentialOptions) (*azidentity.ClientAssertionCredential, error)) *MockAzureAuthProviderAPI_FindClientAssertionCredentials_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FindClientSecretCredentials provides a mock function with given fields: tenantID, clientID, clientSecret, options
 func (_m *MockAzureAuthProviderAPI) FindClientSecretCredentials(tenantID string, clientID string, clientSecret string, options *azidentity.ClientSecretCredentialOptions) (*azidentity.ClientSecretCredential, error) {
 	ret := _m.Called(tenantID, clientID, clientSecret, options)


### PR DESCRIPTION
### Summary of your changes
Introduce a new ClientCredentialsType for Azure named `AzureClientCredentialsTypeCloudConnectors`.
When providing the new credentials type, cloudbeat will get the jwt file and call `NewClientAssertionCredential` for valid azure credentials to be used.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
- https://github.com/elastic/security-team/issues/12605
