### PR TITLE
github-actions: support backport labels after being merged

### DIFF
--- a/.github/workflows/backport-active.yml
+++ b/.github/workflows/backport-active.yml
@@ -2,7 +2,7 @@ name: Backport to active branches
 
 on:
   pull_request_target:
-    types: [closed]
+    types: [closed, labeled]
     branches:
       - main
 
@@ -13,9 +13,13 @@ permissions:
 jobs:
   backport:
     # Only run if the PR was merged (not just closed) and has one of the backport labels
+    # or has been added afterwards.
     if: |
       github.event.pull_request.merged == true &&
-      contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')
+      (
+        (github.event.action == 'closed' && contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')) ||
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport-active-'))
+      )
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### Summary of your changes

Support backports after a PR has been merged and labelled with `backport-active-*`.

Fixes a corner case when the PRs have been labeled after being merged with the supported list of active branches.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
