### PR TITLE
Remove glog replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -573,6 +573,5 @@ require (
 replace (
 	github.com/apoydence/eachers => github.com/poy/eachers v0.0.0-20181020210610-23942921fe77 //indirect, see https://github.com/elastic/beats/pull/29780 for details.
 	github.com/dop251/goja => github.com/elastic/goja v0.0.0-20190128172624-dd2ac4456e20
-	github.com/golang/glog => github.com/golang/glog v1.2.4 // CVE https://github.com/advisories/GHSA-6wxm-mpqj-6jpf
 	github.com/google/gopacket => github.com/elastic/gopacket v1.1.20-0.20241002174017-e8c5fda595e6
 )

--- a/go.sum
+++ b/go.sum
@@ -1389,7 +1389,9 @@ github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w
 github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
-github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
+github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
### Summary of your changes
Continuation of https://github.com/elastic/cloudbeat/pull/3566

This was originally added to fix https://github.com/elastic/security/issues/6474.

I've checked and verified that 8.15 from the original issue actually compiles glog in the cloudbeat binary:
```shell
$ strings elastic-agent-8.15.0/data/elastic-agent-25075f/components/cloudbeat | grep glog | tail -n 5
github.com/golang/glog.Fatalf
github.com/golang/glog@v1.2.0/glog_file.go
github.com/golang/glog@v1.2.0/glog.go
dep	github.com/golang/glog	v1.2.0
=>	github.com/elastic/glog	v1.0.1-0.20210831205241-7d8b5c89dfc4	h1:ViJxdtOsHeO+SWVekzM82fYHH1xnvZ8CvGPXZj+G4YI=
```

However, our current version of cloudbeat does not use the dependency.

Furthermore, the replace is not necessary anymore as we don't pick the vulnerable version of the dependency.
With `replace`:
```shell
$ go list -m all | grep glog
github.com/golang/glog v1.2.5 => github.com/golang/glog v1.2.4
```
Without `replace`:
```shell
$ go list -m all | grep glog
github.com/golang/glog v1.2.5
```

The `go list -m all` command is listed in https://go.dev/ref/mod#minimal-version-selection as the way to check what dependency version is compiled in the final binary by Go's Minimal version selection (MVS) algorithm.

Removing the replace directive will help us avoid future vulnerabilities that might come up if we pin a static version in cloudbeat.

Regarding the outdated versions in go.sum see also relevant discussion in dependabot: https://github.com/dependabot/dependabot-core/issues/4740