### PR TITLE
cloud connectors aws cloudformation elastic role arn parameter

### DIFF
--- a/deploy/asset-inventory-cloudformation/cloud-connectors-remote-role-organization.yml
+++ b/deploy/asset-inventory-cloudformation/cloud-connectors-remote-role-organization.yml
@@ -29,7 +29,7 @@ Parameters:
     Type: String
 
   ElasticRoleARN:
-    Description: Elastic Role ARN
+    Description: Elastic's Role ARN that the cloud connector will trust upon (change it only if you need to perform test with Elastic's test environments).
     Type: String
     Default: arn:aws:iam::254766567737:role/cloud_connectors
 

--- a/deploy/asset-inventory-cloudformation/cloud-connectors-remote-role.yml
+++ b/deploy/asset-inventory-cloudformation/cloud-connectors-remote-role.yml
@@ -8,7 +8,7 @@ Parameters:
     Type: String
 
   ElasticRoleARN:
-    Description: Elastic Role ARN
+    Description: Elastic's Role ARN that the cloud connector will trust upon (change it only if you need to perform test with Elastic's test environments).
     Type: String
     Default: arn:aws:iam::254766567737:role/cloud_connectors
 

--- a/deploy/cloudformation/cloud-connectors-remote-role-organization.yml
+++ b/deploy/cloudformation/cloud-connectors-remote-role-organization.yml
@@ -29,7 +29,7 @@ Parameters:
     Type: String
 
   ElasticRoleARN:
-    Description: Elastic Role ARN
+    Description: Elastic's Role ARN that the cloud connector will trust upon (change it only if you need to perform test with Elastic's test environments).
     Type: String
     Default: arn:aws:iam::254766567737:role/cloud_connectors
 

--- a/deploy/cloudformation/cloud-connectors-remote-role.yml
+++ b/deploy/cloudformation/cloud-connectors-remote-role.yml
@@ -8,7 +8,7 @@ Parameters:
     Type: String
 
   ElasticRoleARN:
-    Description: Elastic Role ARN
+    Description: Elastic's Role ARN that the cloud connector will trust upon (change it only if you need to perform test with Elastic's test environments).
     Type: String
     Default: arn:aws:iam::254766567737:role/cloud_connectors
 


### PR DESCRIPTION
### Summary of your changes
Update aws cloudformations for cloud conenctors, make the elastic global role a parameter with default value, to be easier to change on QA.


### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->
<img width="1325" height="119" alt="Screenshot 2025-09-23 at 6 20 47 PM" src="https://github.com/user-attachments/assets/927c13cb-43de-4f68-9d80-3f08b613f652" />


### Related Issues
<!--
- Related: https://github.com/elastic/security-team/issues/
- Fixes: https://github.com/elastic/security-team/issues/
-->

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
