### PR TITLE
GH actions: Improve caching

### DIFF
--- a/.ci/scripts/gh-cache.sh
+++ b/.ci/scripts/gh-cache.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euxo pipefail
-
-rm -rf /tmp/.buildx-cache
-mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/actions/hermit/action.yml
+++ b/.github/actions/hermit/action.yml
@@ -40,12 +40,15 @@ runs:
           ~/.cache/pypoetry
           ~/.cache/pre-commit
         key: ci-hermit-env-${{ runner.os }}-${{ steps.hermit-hash.outputs.hash }}
+        restore-keys: |
+          ci-hermit-env-${{ runner.os }}
 
     - id: cache-go-deps
       uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
       with:
         path: |
           ~/go/pkg/
+          ~/.cache/go-build
         key: ci-go-deps-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.mod', '**/go.sum') }}
 
     - name: Initialize hermit

--- a/.github/workflows/eks-ci.yml
+++ b/.github/workflows/eks-ci.yml
@@ -57,42 +57,19 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
-      # Disk cleanup
-      - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: true
-          swap-storage: true
-
       - name: Check out the repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: Setup GO (with caching)
-        uses: magnetikonline/action-golang-cache@fcca93e25c7fe3943de4d40c22d255d17f63e63b  # v5
+      - name: Hermit Environment
+        uses: ./.github/actions/hermit
         with:
-          go-version-file: .go-version
+          init-tools: 'false'
 
       - name: build cloudbeat binary
-        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b # v3
-        with:
-          version: latest
-          args: build
+        run: mage build
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
-
-      - name: Cache Build dependencies
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.workflow }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
 
       - name: Build cloudbeat-docker
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
@@ -101,8 +78,6 @@ jobs:
           file: ./deploy/Dockerfile
           push: false
           tags: cloudbeat:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
           outputs: type=docker,dest=/tmp/cloudbeat-${{ env.CONTAINER_SUFFIX }}.tar
 
       - name: Build elastic-agent
@@ -119,15 +94,7 @@ jobs:
           context: ./tests/.
           push: false
           tags: cloudbeat-test:latest
-          cache-from: type=local,mode=max,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
           outputs: type=docker,dest=/tmp/pytest-${{ env.CONTAINER_SUFFIX }}.tar
-
-      - name: Cache docker images
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
-        with:
-          path: /tmp/*.tar
-          key: ${{ runner.os }}-dockers-cache-${{ env.CONTAINER_SUFFIX }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2
@@ -146,11 +113,6 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           ./.ci/scripts/ecr-images.sh ${{ env.CONTAINER_SUFFIX }}  ${{ env.ECR_REGISTRY }} ${{ env.CI_ELASTIC_AGENT_DOCKER_TAG }}
-        shell: bash
-
-      - name: Move cache
-        run: |
-          ./.ci/scripts/gh-cache.sh
         shell: bash
 
   Test_Matrix:


### PR DESCRIPTION
### Summary of your changes
- Removes caching used in eks-ci. Since that action runs only on the main branch, it doesn't affect developers as much as using our cache for PRs.
- Re-add restore-keys for hermit environment. This was deleted because of https://github.com/elastic/cloudbeat/issues/2446. However, we are cleaning the local hermit cache on cache misses, which should avoid constantly increasing our cache size.
- Re-use our hermit setup action in eks-ci, remove old go caching