### PR TITLE
Fix team label standardization across deployment configurations

### DIFF
--- a/.github/actions/cdr/action.yml
+++ b/.github/actions/cdr/action.yml
@@ -397,7 +397,7 @@ runs:
         # Only hyphens (-), underscores (_), lowercase characters, and numbers are allowed. International characters are allowed.
         # Convert github.actor to lowercase, replace disallowed characters
         gcp_label=$(echo "$ACTOR" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/_/g')
-        gcp_default_tag="division=engineering,org=security,team=cloud-security-posture,project=test-environments,owner=$gcp_label"
+        gcp_default_tag="division=engineering,org=security,team=contextual-security,project=test-environments,owner=$gcp_label"
         . ./set_env.sh && ./deploy.sh && gcloud compute instances update "${DEPLOYMENT_NAME}" --update-labels "${gcp_default_tag}" --zone="${GCP_ZONE}"
 
     - name: Upload CDR state

--- a/.github/actions/cis-agent-based/action.yml
+++ b/.github/actions/cis-agent-based/action.yml
@@ -179,7 +179,7 @@ runs:
         # Only hyphens (-), underscores (_), lowercase characters, and numbers are allowed. International characters are allowed.
         # Convert github.actor to lowercase, replace disallowed characters
         gcp_label=$(echo "$ACTOR" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/_/g')
-        gcp_default_tag="division=engineering,org=security,team=cloud-security-posture,project=test-environments,owner=$gcp_label"
+        gcp_default_tag="division=engineering,org=security,team=contextual-security,project=test-environments,owner=$gcp_label"
         . ./set_env.sh && ./deploy.sh && gcloud compute instances update "${DEPLOYMENT_NAME}" --update-labels "${gcp_default_tag}" --zone="${GCP_ZONE}"
 
     - name: Install CSPM Azure integration

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -148,9 +148,9 @@ env:
   AWS_REGION: "eu-west-1"
   WORKING_DIR: deploy/test-environments
   INTEGRATIONS_SETUP_DIR: tests/integrations_setup
-  AWS_DEFAULT_TAGS: "Key=division,Value=engineering Key=org,Value=security Key=team,Value=cloud-security-posture Key=project,Value=test-environments"
+  AWS_DEFAULT_TAGS: "Key=division,Value=engineering Key=org,Value=security Key=team,Value=contextual-security Key=project,Value=test-environments"
   GCP_ZONE: "us-central1-a"
-  AZURE_DEFAULT_TAGS: "division=engineering org=security team=cloud-security-posture project=test-environments owner=${{ github.actor }}"
+  AZURE_DEFAULT_TAGS: "division=engineering org=security team=contextual-security project=test-environments owner=${{ github.actor }}"
   TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
   TF_VAR_gcp_service_account_json: ${{ secrets.GCP_AGENT_CREDENTIALS }}
 

--- a/deploy/asset-inventory-cloudformation/gomain.go
+++ b/deploy/asset-inventory-cloudformation/gomain.go
@@ -112,7 +112,7 @@ func generateProdTemplate(prodTemplatePath string, devTemplatePath string) error
 } |
 .Resources.ElasticAgentEc2Instance.Properties.Tags += {
 	"Key": "team",
-	"Value": "cloud-security"
+	"Value": "contextual-security"
 } |
 .Resources.ElasticAgentEc2Instance.Properties.Tags += {
 	"Key": "project",

--- a/deploy/cloudformation/gomain.go
+++ b/deploy/cloudformation/gomain.go
@@ -120,7 +120,7 @@ func generateProdTemplate(prodTemplatePath string, devTemplatePath string) error
 } |
 .Resources.ElasticAgentEc2Instance.Properties.Tags += {
 	"Key": "team",
-	"Value": "cloud-security"
+	"Value": "contextual-security"
 } |
 .Resources.ElasticAgentEc2Instance.Properties.Tags += {
 	"Key": "project",

--- a/deploy/eks/simple-cluster.yml
+++ b/deploy/eks/simple-cluster.yml
@@ -9,7 +9,7 @@ metadata:
   tags:
     division: engineering
     org: security
-    team: cloud-security
+    team: contextual-security
     project: eks-simple-cluster # change this to reflect your project
 
 vpc:

--- a/deploy/test-environments/cdr/variables.tf
+++ b/deploy/test-environments/cdr/variables.tf
@@ -86,7 +86,7 @@ variable "org" {
 }
 
 variable "team" {
-  default     = "cloud-security-posture"
+  default     = "contextual-security"
   type        = string
   description = "Optional team resource tag"
 }

--- a/deploy/test-environments/cis/variables.tf
+++ b/deploy/test-environments/cis/variables.tf
@@ -46,7 +46,7 @@ variable "org" {
 }
 
 variable "team" {
-  default     = "cloud-security-posture"
+  default     = "contextual-security"
   type        = string
   description = "Optional team resource tag"
 }

--- a/deploy/test-environments/elk-stack/variables.tf
+++ b/deploy/test-environments/elk-stack/variables.tf
@@ -76,7 +76,7 @@ variable "org" {
 }
 
 variable "team" {
-  default     = "cloud-security-posture"
+  default     = "contextual-security"
   type        = string
   description = "Optional team resource tag"
 }

--- a/deploy/test-environments/modules/aws/cloudtrail/variables.tf
+++ b/deploy/test-environments/modules/aws/cloudtrail/variables.tf
@@ -25,7 +25,7 @@ variable "tags" {
   description = "Optional set of tags to use for all deployments"
   type        = map(string)
   default = {
-    "deployment"  = "cloud-security",
+    "deployment"  = "contextual-security",
     "environment" = "test-enviroments",
   }
 }
@@ -44,7 +44,7 @@ variable "org" {
 }
 
 variable "team" {
-  default     = "cloud-security-posture"
+  default     = "contextual-security"
   type        = string
   description = "Optional team resource tag"
 }

--- a/deploy/test-environments/modules/ec/variables.tf
+++ b/deploy/test-environments/modules/ec/variables.tf
@@ -23,13 +23,13 @@ variable "deployment_template" {
 variable "deployment_name_prefix" {
   description = "Prefix for the Elastic Cloud deployment name"
   type        = string
-  default     = "cloud-security"
+  default     = "contextual-security"
 }
 
 variable "tags" {
   type = map(string)
   default = {
-    "deployment"  = "cloud-security",
+    "deployment"  = "contextual-security",
     "environment" = "test-enviroment",
   }
   description = "Optional set of tags to use for all deployments"

--- a/tests/commonlib/kubernetes.py
+++ b/tests/commonlib/kubernetes.py
@@ -219,7 +219,7 @@ class KubernetesHelper:
         This function will delete all cloudbeat kubernetes resources.
         Currently, there is no ability to remove through utils due to the following:
         https://github.com/kubernetes-client/python/pull/1392
-        So below is cloud-security-posture own implementation.
+        So below is contextual-security own implementation.
         :return: V1Object - result
         """
         result_list = []

--- a/tests/integrations_setup/configuration_fleet.py
+++ b/tests/integrations_setup/configuration_fleet.py
@@ -25,7 +25,7 @@ from munch import Munch
 CNVM_TAGS = (
     "Key=division,Value=engineering "
     "Key=org,Value=security "
-    "Key=team,Value=cloud-security-posture "
+    "Key=team,Value=contextual-security "
     "Key=project,Value=test-environments"
 )
 


### PR DESCRIPTION
### Summary of your changes

Standardizes the team label value to `contextual-security` across all deployment configurations and infrastructure templates.

### Changes
- Updated Terraform variables for CDR, CIS, ELK stack, and CloudTrail test environments
- Added team label to CloudFormation templates (asset-inventory and standard)
- Updated GitHub Actions workflows and composite actions
- Fixed team label in test configuration files and EKS cluster template

