### PR TITLE
[GCP CSPM] Cache org display name

### DIFF
--- a/internal/resources/providers/gcplib/inventory/resource_manager.go
+++ b/internal/resources/providers/gcplib/inventory/resource_manager.go
@@ -70,6 +70,7 @@ func NewResourceManagerWrapper(ctx context.Context, log *clog.Logger, gcpConfig 
 				return orgName
 			}
 
+			// parent is the ID of the organization, and is the same for every call, so we cache it
 			org, err := crmService.Organizations.Get(parent).Context(ctx).Do()
 			if err != nil {
 				log.Errorf("error fetching GCP Org: %s, error: %s", parent, err)


### PR DESCRIPTION
fixes https://github.com/elastic/security-team/issues/13471

for each asset we grab the org display name and the project name. the already existing cache uses a key composed of the `projectId/orgId`. because of this, we ended up fetching the org name every time we had a new `projectId`, even though the org name doesn't change. this PR introduces an additional cache just for the org name so we don't get the display name of the same org multiple times.