### PR TITLE
report existing resources

### DIFF
--- a/internal/inventory/awsfetcher/fetcher_ec2_instance.go
+++ b/internal/inventory/awsfetcher/fetcher_ec2_instance.go
@@ -59,7 +59,6 @@ func (e *ec2InstanceFetcher) Fetch(ctx context.Context, assetChannel chan<- inve
 	if err != nil {
 		e.logger.Errorf("Could not list ec2 instances: %v", err)
 		awslib.ReportMissingPermission(e.statusHandler, err)
-		return
 	}
 
 	for _, i := range instances {

--- a/internal/inventory/awsfetcher/fetcher_elb.go
+++ b/internal/inventory/awsfetcher/fetcher_elb.go
@@ -78,7 +78,6 @@ func (f *elbFetcher) fetch(ctx context.Context, resourceName string, function el
 	if err != nil {
 		awslib.ReportMissingPermission(f.statusHandler, err)
 		f.logger.Errorf("Could not fetch %s: %v", resourceName, err)
-		return
 	}
 
 	for _, item := range awsResources {

--- a/internal/inventory/awsfetcher/fetcher_lambda.go
+++ b/internal/inventory/awsfetcher/fetcher_lambda.go
@@ -78,7 +78,6 @@ func (s *lambdaFetcher) fetch(ctx context.Context, resourceName string, function
 	if err != nil {
 		awslib.ReportMissingPermission(s.statusHandler, err)
 		s.logger.Errorf("Could not fetch %s: %v", resourceName, err)
-		return
 	}
 
 	for _, item := range awsResources {

--- a/internal/inventory/awsfetcher/fetcher_networking.go
+++ b/internal/inventory/awsfetcher/fetcher_networking.go
@@ -93,7 +93,6 @@ func (s *networkingFetcher) fetch(ctx context.Context, resourceName string, func
 	if err != nil {
 		awslib.ReportMissingPermission(s.statusHandler, err)
 		s.logger.Errorf("Could not fetch %s: %v", resourceName, err)
-		return
 	}
 
 	for _, item := range awsResources {

--- a/internal/inventory/awsfetcher/fetcher_sns.go
+++ b/internal/inventory/awsfetcher/fetcher_sns.go
@@ -57,7 +57,6 @@ func (s *snsFetcher) Fetch(ctx context.Context, assetChannel chan<- inventory.As
 	if err != nil {
 		s.logger.Errorf("Could not fetch SNS Topics: %v", err)
 		awslib.ReportMissingPermission(s.statusHandler, err)
-		return
 	}
 
 	for _, item := range awsResources {


### PR DESCRIPTION
### Summary of your changes

some aws asset discovery fetchers are not sending data due to an early return 

any usage of the underlining multi region selector that returns early when it has an error, should instead check the results length, which we do in some cases: 
https://github.com/elastic/cloudbeat/blob/0d86b968927fd05a886ff71dc9b9c0f98cb9a7b0/internal/inventory/awsfetcher/fetcher_iam_policy.go#L58-L65

but this is the same as just removing the `return`, which is what this PR does for the rest of the fetchers


### Related Issues

- TODO
