### PR TITLE
[AWS CIS] Change logging non blocking errors to warning

### DIFF
--- a/internal/infra/clog/clog.go
+++ b/internal/infra/clog/clog.go
@@ -33,7 +33,7 @@ type Logger struct {
 
 func (l *Logger) Errorf(template string, args ...any) {
 	// Downgrade context.Canceled errors to warning level
-	if hasErrorType(context.Canceled, args...) {
+	if hasErrorType(context.Canceled, append(args, template)...) {
 		l.Warnf(template, args...)
 		return
 	}

--- a/internal/infra/clog/clog_test.go
+++ b/internal/infra/clog/clog_test.go
@@ -20,11 +20,13 @@ package clog
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 )
 
@@ -46,31 +48,100 @@ func newObserverLogger(t *testing.T) (*Logger, *observer.ObservedLogs) {
 	return &Logger{Logger: testLogger.Named(t.Name())}, observed
 }
 
-func (s *LoggerTestSuite) TestErrorfWithContextCanceled() {
-	logger, obs := newObserverLogger(s.T())
+func (s *LoggerTestSuite) TestErrorf() {
+	tests := []struct {
+		name          string
+		logFunc       func(logger *Logger)
+		expectedLevel zapcore.Level
+	}{
+		{
+			name: "error arg",
+			logFunc: func(l *Logger) {
+				l.Errorf("failed: %v", context.Canceled)
+			},
+			expectedLevel: zap.WarnLevel,
+		},
+		{
+			name: "wrapped error arg",
+			logFunc: func(l *Logger) {
+				l.Errorf("failed: %v", fmt.Errorf("wrap: %w", context.Canceled))
+			},
+			expectedLevel: zap.WarnLevel,
+		},
+		{
+			name: "string arg",
+			logFunc: func(l *Logger) {
+				l.Errorf("failed: %s", context.Canceled.Error())
+			},
+			expectedLevel: zap.WarnLevel,
+		},
+		{
+			name: "generic error stays at ERROR",
+			logFunc: func(l *Logger) {
+				l.Errorf("failed: %v", errors.New("something went wrong"))
+			},
+			expectedLevel: zap.ErrorLevel,
+		},
+	}
 
-	err := context.Canceled
-	logger.Errorf("some error: %s", err)         // error with context.Canceled
-	logger.Errorf("some error: %s", err.Error()) // error string with context Canceled
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			logger, obs := newObserverLogger(s.T())
+			tt.logFunc(logger)
 
-	logs := obs.TakeAll()
-	if s.Len(logs, 2) {
-		s.Equal(zap.WarnLevel, logs[0].Level) // downgraded to warning
-		s.Equal("some error: context canceled", logs[0].Message)
-
-		s.Equal(zap.WarnLevel, logs[1].Level) // downgraded to warning
-		s.Equal("some error: context canceled", logs[1].Message)
+			logs := obs.TakeAll()
+			if s.Len(logs, 1) {
+				s.Equal(tt.expectedLevel, logs[0].Level, "expected %s but got %s", tt.expectedLevel, logs[0].Level)
+			}
+		})
 	}
 }
-func (s *LoggerTestSuite) TestLogErrorfWithoutContextCanceled() {
-	logger, obs := newObserverLogger(s.T())
 
-	err := errors.New("oops")
-	logger.Errorf("some error: %s", err)
+func (s *LoggerTestSuite) TestError() {
+	tests := []struct {
+		name          string
+		logFunc       func(logger *Logger)
+		expectedLevel zapcore.Level
+	}{
+		{
+			name: "error arg",
+			logFunc: func(l *Logger) {
+				l.Error(context.Canceled)
+			},
+			expectedLevel: zap.WarnLevel,
+		},
+		{
+			name: "wrapped error arg",
+			logFunc: func(l *Logger) {
+				l.Error(fmt.Errorf("wrap: %w", context.Canceled))
+			},
+			expectedLevel: zap.WarnLevel,
+		},
+		{
+			name: "string arg",
+			logFunc: func(l *Logger) {
+				l.Error(context.Canceled.Error())
+			},
+			expectedLevel: zap.WarnLevel,
+		},
+		{
+			name: "generic error stays at ERROR",
+			logFunc: func(l *Logger) {
+				l.Error(errors.New("something went wrong"))
+			},
+			expectedLevel: zap.ErrorLevel,
+		},
+	}
 
-	logs := obs.TakeAll()
-	if s.Len(logs, 1) {
-		s.Equal(zap.ErrorLevel, logs[0].Level)
-		s.Equal("some error: oops", logs[0].Message)
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			logger, obs := newObserverLogger(s.T())
+			tt.logFunc(logger)
+
+			logs := obs.TakeAll()
+			if s.Len(logs, 1) {
+				s.Equal(tt.expectedLevel, logs[0].Level, "expected %s but got %s", tt.expectedLevel, logs[0].Level)
+			}
+		})
 	}
 }

--- a/internal/resources/providers/aws_cis/logging/provider.go
+++ b/internal/resources/providers/aws_cis/logging/provider.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 
 	s3Client "github.com/aws/aws-sdk-go-v2/service/s3"
-	types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 
 	"github.com/elastic/cloudbeat/internal/resources/fetching"
 	"github.com/elastic/cloudbeat/internal/resources/providers/awslib"


### PR DESCRIPTION
The changed log lines are over alerting right now, it should be a warn instead of error