### PR TITLE
Update to new release API endpoints

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Fetch active branches
         id: mk
         run: |
-          MATRIX_JSON="$(curl -s https://artifacts.elastic.co/releases/api/public/future-releases.json | jq -Mc '[ .releases[] | select(.active_release == true) | .branch | select(. != "main" and . != "7.17") ]')"
+          MATRIX_JSON="$(curl -s https://elastic-release-api.s3.us-west-2.amazonaws.com/public/future-releases.json | jq -Mc '[ .releases[] | select(.active_release == true) | .branch | select(. != "main" and . != "7.17") ]')"
           echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
 
   updatecli-backport:

--- a/llm/cve.md
+++ b/llm/cve.md
@@ -74,7 +74,7 @@ gh api repos/elastic/security/issues --jq '.[] | select(.title | contains("<CVE-
 To determine which versions need patches, check the future releases:
 ```bash
 # Fetch future releases to identify maintained versions
-curl -s https://artifacts.elastic.co/releases/api/public/future-releases.json | jq ".releases[].version"
+curl -s https://elastic-release-api.s3.us-west-2.amazonaws.com/public/future-releases.json | jq ".releases[].version"
 ```
 
 These are the versions that must receive patches when Cloudbeat is affected by a CVE.


### PR DESCRIPTION
Release API migration to new endpoints is now complete. 

Past Release Endpoint : https://elastic-release-api.s3.us-west-2.amazonaws.com/public/past-releases.json
Future Release Endpoint : https://elastic-release-api.s3.us-west-2.amazonaws.com/public/future-releases.json

This PR updates the old Release API endpoints to new one's

More Info:
https://groups.google.com/a/elastic.co/g/release-eng-team/c/qgXaCX-y29k/m/jzm2S8MeAwAJ