### PR TITLE
feat: add org-level IAM setup and use ORG_ID in GCP cloud connectors

### DIFF
--- a/deploy/infrastructure-manager/gcp-cloud-connectors/README.md
+++ b/deploy/infrastructure-manager/gcp-cloud-connectors/README.md
@@ -19,7 +19,7 @@ Deploy a target service account in your GCP environment for Elastic Cloud Connec
 export ELASTIC_RESOURCE_ID="<YOUR_DEPLOYMENT_ID>"  # Your Elastic deployment ID (must match AWS role session name)
 
 # Optional: For organization-level monitoring
-# export ORGANIZATION_ID="<YOUR_ORG_ID>"
+# export ORG_ID="<YOUR_ORG_ID>"
 
 # Optional: Override defaults
 # export DEPLOYMENT_NAME="elastic-agent-sa"                                    # Default: elastic-agent-sa
@@ -100,7 +100,7 @@ Customer's GCP Resources (monitored)
 
 **Organization Account**:
 - Monitors all projects in a GCP organization
-- Set `ORGANIZATION_ID` environment variable
+- Set `ORG_ID` environment variable
 - Requires organization-level permissions
 
 ### Security
@@ -144,16 +144,17 @@ The deployment service account needs these roles:
 - `roles/iam.workloadIdentityPoolAdmin` - Create Workload Identity Pool and Provider
 - `roles/resourcemanager.projectIamAdmin` - Manage IAM bindings
 - `roles/config.admin` - Infrastructure Manager operations
+- `roles/storage.admin` - Store Terraform state
 
-For organization-level deployments, you also need:
-- `roles/resourcemanager.organizationAdmin` - Manage organization IAM
+For organization-level deployments (when `ORG_ID` is set), you also need:
+- `roles/iam.securityAdmin` - Manage organization IAM bindings (granted at organization level)
 
 ### Troubleshooting
 
 **Common Issues:**
 
 1. **Permission denied on Workload Identity Pool creation**: Ensure you have `roles/iam.workloadIdentityPoolAdmin`
-2. **Permission denied on organization**: Ensure you have `roles/resourcemanager.organizationAdmin` for org-level deployments
+2. **Permission denied on organization**: Ensure you have `roles/iam.securityAdmin` at the organization level for org-level deployments
 3. **IAM binding failed**: Check that the service account has required permissions
 
 **Verify deployment:**

--- a/deploy/infrastructure-manager/gcp-cloud-connectors/deploy.sh
+++ b/deploy/infrastructure-manager/gcp-cloud-connectors/deploy.sh
@@ -9,7 +9,7 @@ PROJECT_ID=$(gcloud config get-value core/project)
 SERVICE_ACCOUNT="infra-manager-deployer"
 
 # Ensure prerequisites are configured
-"${SCRIPT_DIR}/setup.sh" "${PROJECT_ID}" "${SERVICE_ACCOUNT}"
+"${SCRIPT_DIR}/setup.sh" "${PROJECT_ID}" "${SERVICE_ACCOUNT}" "${ORG_ID}"
 
 # Required environment variables (no defaults - must be provided)
 # ELASTIC_RESOURCE_ID - Unique identifier for your Elastic deployment (must match AWS role session name)

--- a/deploy/infrastructure-manager/gcp-cloud-connectors/setup.sh
+++ b/deploy/infrastructure-manager/gcp-cloud-connectors/setup.sh
@@ -4,6 +4,7 @@ set -e
 # Accept parameters
 PROJECT_ID="$1"
 SERVICE_ACCOUNT="$2"
+ORG_ID="$3" # Optional: required for organization-scope deployments
 SERVICE_ACCOUNT_EMAIL="${SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com"
 
 REQUIRED_APIS=(
@@ -21,6 +22,10 @@ REQUIRED_ROLES=(
     roles/storage.admin
 )
 
+ORG_LEVEL_ROLES=(
+    roles/iam.securityAdmin
+)
+
 echo "Setting up GCP Infrastructure Manager prerequisites..."
 
 # Enable APIs
@@ -32,11 +37,21 @@ if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT_EMAIL}" >/dev/null 
         --display-name="Infra Manager Deployment Account" --quiet
 fi
 
-# Grant permissions
+# Grant project-level permissions
 for role in "${REQUIRED_ROLES[@]}"; do
     gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
         --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
         --role="${role}" --condition=None --quiet >/dev/null
 done
+
+# Grant organization-level permissions if ORG_ID is provided
+if [ -n "${ORG_ID}" ]; then
+    echo "Granting organization-level permissions for org ${ORG_ID}..."
+    for role in "${ORG_LEVEL_ROLES[@]}"; do
+        gcloud organizations add-iam-policy-binding "${ORG_ID}" \
+            --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
+            --role="${role}" --condition=None --quiet >/dev/null
+    done
+fi
 
 echo "✓ Setup complete"


### PR DESCRIPTION
Adds organization-level IAM setup to the GCP cloud connectors deployment and renames the organization scope environment variable from ORGANIZATION_ID to ORG_ID for consistency. When ORG_ID is set, setup.sh now grants the deployment service account the roles/iam.securityAdmin role at the organization level (instead of roles/resourcemanager.organizationAdmin), and the README is updated to document the storage.admin role for Terraform state and the new variable name. This enables customers to deploy Elastic Cloud Connectors with organization-level monitoring using the recommended, least-privilege securityAdmin role.