### PR TITLE
Bump elastic-github-actions

### DIFF
--- a/.github/actions/init-integration/action.yml
+++ b/.github/actions/init-integration/action.yml
@@ -17,7 +17,7 @@ runs:
       run: mage -v build
 
     - name: Run elasticsearch
-      uses: elastic/elastic-github-actions/elasticsearch@dc110609b1cb3024477ead739ca23ab547b8b9ff # master
+      uses: elastic/elastic-github-actions/elasticsearch@98431b45a60cbb6ace481778827bc8e11f12fd65 # master
       with:
         stack-version: ${{ inputs.elk-version }}
         security-enabled: false


### PR DESCRIPTION
### Summary of your changes

This PR bumps elastic-github-actions to fix the following error:
`Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44. Please upgrade your client to a newer version.`

[Here](https://github.com/elastic/cloudbeat/actions/runs/22038141130) is the successful run after the version bump.