### PR TITLE
Install Chrome v145 in FTR action

### DIFF
--- a/.github/actions/kibana-ftr/README.md
+++ b/.github/actions/kibana-ftr/README.md
@@ -54,10 +54,13 @@ This action performs the following steps:
 3. **Setup Node**:
    - Uses the `actions/setup-node@v4` action to set up the Node.js environment based on the `package.json`.
 
-4. **Bootstrap Kibana**:
+4. **Setup Chrome**:
+   - Installs Chrome 145 via `browser-actions/setup-chrome` so FTR runs with a Chrome version that matches Kibana's ChromeDriver (the GitHub runner image may ship an older Chrome). The installed binary path is passed to FTR via `TEST_BROWSER_BINARY_PATH`.
+
+5. **Bootstrap Kibana**:
    - Runs the `yarn kbn bootstrap` command in the `kibana` directory to bootstrap the Kibana environment.
 
-5. **Run FTR**:
+6. **Run FTR**:
    - Runs the Functional Test Runner (FTR) using the `x-pack/test/cloud_security_posture_functional/config.cloud.ts` configuration and the necessary environment variables.
 
 ## Notes

--- a/.github/actions/kibana-ftr/action.yml
+++ b/.github/actions/kibana-ftr/action.yml
@@ -52,6 +52,12 @@ runs:
       with:
         node-version-file: ${{ steps.globals.outputs.KIBANA_DIR }}/package.json
 
+    - name: Setup Chrome
+      id: chrome
+      uses: browser-actions/setup-chrome@b94431e051d1c52dcbe9a7092a4f10f827795416 # v2.1.0
+      with:
+        chrome-version: 145
+
     - name: Bootstrap Kibana
       shell: bash
       working-directory: ${{ steps.globals.outputs.KIBANA_DIR }}
@@ -103,6 +109,7 @@ runs:
         TEST_BROWSER_HEADLESS: "1"
         TEST_CLOUD_HOST_NAME: "cloud.elastic.co"
         TEST_CONFIG: ${{ env.TEST_CONFIG }}
+        TEST_BROWSER_BINARY_PATH: ${{ steps.chrome.outputs.chrome-path }}
       run: |
         node scripts/functional_test_runner --config "$TEST_CONFIG" --es-version "$ES_VERSION"
 


### PR DESCRIPTION
### Summary of your changes

The ChromeDriver version in the Kibana repository has been updated to v145 (see:https://github.com/elastic/kibana/pull/252649).

Since the current [Docker image](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#browsers-and-drivers) does not include Chrome v145, this PR updates the FTR action to install the required version as part of the workflow.
