### PR TITLE
chore: run Renovate daily on weekdays and increase PR concurrency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
     "8.19"
   ],
   "schedule": [
-    "after 1am on monday"
+    "* 1 * * 1-5"
   ],
   "labels": [
     "renovate",
@@ -27,7 +27,7 @@
     "gomodTidy"
   ],
   "separateMajorMinor": true,
-  "prConcurrentLimit": 20,
+  "prConcurrentLimit": 50,
   "automergeStrategy": "squash",
   "automergeType": "pr",
   "ignorePaths": [


### PR DESCRIPTION
Updates the Renovate configuration to run on weekdays at 1am instead of only Mondays, and raises the concurrent PR limit from 20 to 50 so dependency updates can be processed more frequently and in larger batches.