### PR TITLE
Fix destroy environment workflow failure due to missing variable

### DIFF
--- a/deploy/test-environments/manage_infrastructure.sh
+++ b/deploy/test-environments/manage_infrastructure.sh
@@ -4,9 +4,10 @@
 run_terraform() {
     local dir=$1
     local operation=$2
+    local terraform_rc
 
     echo "Running Terraform $operation in $dir..."
-    cd "$dir" || exit
+    cd "$dir" || exit 1
 
     case $operation in
     "apply")
@@ -33,12 +34,14 @@ run_terraform() {
         ../upload_state.sh "$dir"
         ;;
     *)
-        echo "Invalid operation. Use 'apply', 'destroy', 'output', or 'upload-state'."
-        cd - >/dev/null || exit 1
+        echo "Invalid operation. Use 'apply', 'destroy', 'output', or 'upload-state'." >&2
+        false
         ;;
     esac
 
-    cd - >/dev/null || exit
+    terraform_rc=$?
+    cd - >/dev/null || exit 1
+    return "$terraform_rc"
 }
 
 # Check for valid input
@@ -53,19 +56,23 @@ action=$2
 case $1 in
 elk-stack)
     run_terraform "elk-stack" "$action"
+    overall_rc=$?
     ;;
 cis)
-    run_terraform "elk-stack" "$action"
-    run_terraform "cis" "$action"
+    overall_rc=0
+    run_terraform "elk-stack" "$action" || overall_rc=1
+    run_terraform "cis" "$action" || overall_rc=1
     ;;
 cdr)
-    run_terraform "elk-stack" "$action"
-    run_terraform "cdr" "$action"
+    overall_rc=0
+    run_terraform "elk-stack" "$action" || overall_rc=1
+    run_terraform "cdr" "$action" || overall_rc=1
     ;;
 all)
-    run_terraform "elk-stack" "$action"
-    run_terraform "cdr" "$action"
-    run_terraform "cis" "$action"
+    overall_rc=0
+    run_terraform "elk-stack" "$action" || overall_rc=1
+    run_terraform "cdr" "$action" || overall_rc=1
+    run_terraform "cis" "$action" || overall_rc=1
     ;;
 *)
     echo "Usage: $0 {elk-stack|cis|cdr|all} {apply|destroy|output|upload-state}"
@@ -73,4 +80,9 @@ all)
     ;;
 esac
 
-echo "Terraform $action operation completed."
+if [ "$overall_rc" -eq 0 ]; then
+    echo "Terraform $action operation completed."
+else
+    echo "Terraform $action completed with errors (one or more stacks failed)." >&2
+fi
+exit "$overall_rc"

--- a/deploy/test-environments/manage_infrastructure.sh
+++ b/deploy/test-environments/manage_infrastructure.sh
@@ -20,6 +20,10 @@ run_terraform() {
             echo "Removing aws_auth resource from state in cis..."
             terraform state rm "$(terraform state list | grep "kubernetes_config_map_v1_data.aws_auth")"
         fi
+        # Destroy still evaluates module variable validation; CDR apply sets TF_VAR_* in CI, generic destroy does not.
+        if [ "$dir" == "cdr" ] && [ -z "${TF_VAR_windows_elastic_defend_winrm_ingress_cidr:-}" ]; then
+            export TF_VAR_windows_elastic_defend_winrm_ingress_cidr="127.0.0.1/32"
+        fi
         terraform destroy -auto-approve && rm terraform.tfstate
         ;;
     "output")


### PR DESCRIPTION
### Summary of your changes

The destroy environment workflow currently fails because a required variable is missing.
This PR adds the missing variable and sets it to the correct value to ensure the workflow runs successfully.
