### PR TITLE
Update naming convention for GCP deployments

### DIFF
--- a/.github/actions/cdr/action.yml
+++ b/.github/actions/cdr/action.yml
@@ -522,8 +522,8 @@ runs:
       shell: bash
       working-directory: deploy/deployment-manager
       env:
-        SERVICE_ACCOUNT_NAME: "${{ inputs.deployment-name }}-sa"
-        DEPLOYMENT_NAME: "${{ inputs.deployment-name }}-acc"
+        SERVICE_ACCOUNT_NAME: "${{ inputs.deployment-name }}-cdr-sa"
+        DEPLOYMENT_NAME: "${{ inputs.deployment-name }}-cdr-acc"
       run: |
           # Deploys a GCP Service Account
           ./deploy_service_account.sh
@@ -551,9 +551,9 @@ runs:
       working-directory: deploy/deployment-manager
       env:
         ACTOR: ${{ github.actor }}
-        DEPLOYMENT_NAME: "${{ inputs.deployment-name }}"
+        DEPLOYMENT_NAME: "${{ inputs.deployment-name }}-cdr"
         GCP_ZONE: "${{ inputs.gcp-zone }}"
-        SERVICE_ACCOUNT_NAME: "${{ inputs.deployment-name }}-sa"
+        SERVICE_ACCOUNT_NAME: "${{ inputs.deployment-name }}-cdr-sa"
       run: |
         # GCP labeling rules:
         # Only hyphens (-), underscores (_), lowercase characters, and numbers are allowed. International characters are allowed.

--- a/.github/actions/cdr/action.yml
+++ b/.github/actions/cdr/action.yml
@@ -541,6 +541,7 @@ runs:
         STACK_VERSION: ${{ inputs.elk-stack-version }}
         AGENT_VERSION: ${{ inputs.elk-stack-version }}
         SERVICE_ACCOUNT_JSON_PATH: "KEY_FILE.json"
+        DEPLOYMENT_NAME: "${{ inputs.deployment-name }}-cdr"
       run: |
         poetry run python ./install_gcp_asset_inventory_integration.py
 

--- a/.github/actions/cis-agent-based/action.yml
+++ b/.github/actions/cis-agent-based/action.yml
@@ -144,8 +144,8 @@ runs:
       shell: bash
       working-directory: deploy/deployment-manager
       env:
-        SERVICE_ACCOUNT_NAME: "${{ inputs.deployment-name }}-sa"
-        DEPLOYMENT_NAME: "${{ inputs.deployment-name }}-acc"
+        SERVICE_ACCOUNT_NAME: "${{ inputs.deployment-name }}-cis-sa"
+        DEPLOYMENT_NAME: "${{ inputs.deployment-name }}-cis-acc"
       run: |
           # Deploys a GCP Service Account
           ./deploy_service_account.sh
@@ -171,9 +171,9 @@ runs:
       working-directory: deploy/deployment-manager
       env:
         ACTOR: ${{ github.actor }}
-        DEPLOYMENT_NAME: "${{ inputs.deployment-name }}"
+        DEPLOYMENT_NAME: "${{ inputs.deployment-name }}-cis"
         GCP_ZONE: "${{ inputs.cspm-gcp-zone }}"
-        SERVICE_ACCOUNT_NAME: "${{ inputs.deployment-name }}-sa"
+        SERVICE_ACCOUNT_NAME: "${{ inputs.deployment-name }}-cis-sa"
       run: |
         # GCP labeling rules:
         # Only hyphens (-), underscores (_), lowercase characters, and numbers are allowed. International characters are allowed.

--- a/.github/actions/cis-agent-based/action.yml
+++ b/.github/actions/cis-agent-based/action.yml
@@ -161,6 +161,7 @@ runs:
         ES_PASSWORD: ${{ inputs.es-password }}
         KIBANA_URL: ${{ inputs.kibana-url }}
         SERVICE_ACCOUNT_JSON_PATH: "KEY_FILE.json"
+        DEPLOYMENT_NAME: "${{ inputs.deployment-name }}-cis"
       run: |
         poetry run python ./install_cspm_gcp_integration.py
 

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -171,6 +171,8 @@ The workflow requires a subset of input parameters. All required inputs are desc
 - **Infrastructure**: CDR VMs (AWS CloudTrail EC2, Azure activity logs VM, GCP audit logs VM, Wiz EC2, Asset Inventory EC2, Elastic Defend Linux + Windows, depending on the `deploy_*` Terraform vars defaults).
 - **Integrations / agents**: CloudTrail, Azure Activity Logs, GCP Audit Logs, Wiz, Okta (optional), Elastic Defend (Fleet), Asset Inventory (gated by stack version), and Entity Store (v1 or v2 based on the checkbox).
 
+**GCP naming (CDR vs CIS):** When workflows provision GCP via Deployment Manager, CDR uses a `-cdr` suffix and CIS agent-based uses a `-cis` suffix so both can run in the same project without colliding. For a `deployment-name` of `my-env`, expect service account ids `my-env-cdr-sa` / `my-env-cis-sa`, DM stacks `my-env-cdr-acc` / `my-env-cis-acc`, and compute instances `my-env-cdr` / `my-env-cis`. Keep `deployment-name` within the documented length limit (20 characters) so service account ids stay within GCP’s 30-character maximum.
+
 
 ## Install Integrations Worfklow
 
@@ -186,7 +188,9 @@ The [`Install Integrations`](https://github.com/elastic/cloudbeat/actions/workfl
   - **`all`** - Installs both `CIS` and `CDR` integrations.
   - **`cis`** - Installs `CSPM`, `KSPM`, and `CNVM` integrations.
   - **`cdr`** - Installs `Audit Logs`, `Asset Inventory`, and `Wiz` integrations.
-- **`docker-image-override`** - For build candidate versions, specifies a custom Docker image path for agent installations.
+- **`docker-image-override`** - For build candidate versions, specifies a custom docker image path for agent installations.
+
+When **`infra-type`** is **`all`**, GCP CSPM and GCP Asset Inventory each get their own Deployment Manager stacks and service accounts (see **GCP naming (CDR vs CIS)** above).
 
 ## Cleanup Procedure
 


### PR DESCRIPTION
### Summary of your changes
When deploying CDR and CIS integrations, the same name is currently used, which causes conflicts due to an existing account.
This PR updates the naming convention to ensure separate resource creation and avoid these conflicts.