### PR TITLE
fix: align renovate config with Elastic internal best practices

### DIFF
--- a/.github/workflows/auto-approve-renovate-prs.yaml
+++ b/.github/workflows/auto-approve-renovate-prs.yaml
@@ -12,7 +12,8 @@ on:
     # Auto-merge will be enabled by Renovate (if configured) and this will trigger the GitHub Actions workflow.
     #  - 'auto_merge_enabled' is a custom event that is triggered when a PR is created.
     #  - 'synchronize' will be triggered when a PR is synchronized (e.g. when a new commit is pushed to the PR).
-    types: [auto_merge_enabled, synchronize]
+    #  - 'labeled' will be triggered when a label is added to a PR (handles cases where the label is applied after PR creation).
+    types: [auto_merge_enabled, synchronize, labeled]
 
 permissions:
   pull-requests: write

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,6 +23,20 @@ defaults:
       labels:
         - "backport"
 pull_request_rules:
+  - name: auto-merge Renovate PRs
+    conditions:
+      - author=elastic-renovate-prod[bot]
+      - label=renovate-auto-approve
+      - "#approved-reviews-by>=1"
+      - check-success=Unit Test
+      - check-success=Lint
+      - check-success=Test Rego Policies
+      - check-success=Package Cloudbeat (docker)
+      - check-success=Package Cloudbeat (tar.gz)
+      - check-success=Manifest Tests
+    actions:
+      queue:
+        name: default
   - name: self-assign PRs
     conditions:
       - -merged

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,10 @@
     "8.19"
   ],
   "schedule": [
-    "* 1 * * 1-5"
+    "0 1 * * 1-5"
+  ],
+  "automergeSchedule": [
+    "at any time"
   ],
   "labels": [
     "renovate",
@@ -178,15 +181,18 @@
       "enabled": true
     },
     {
-      "description": "Auto-merge minor and patch updates for all packages",
+      "description": "Auto-merge minor, patch, digest, and pin updates for all packages",
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "digest",
+        "pin"
       ],
       "addLabels": [
         "renovate-auto-approve"
       ],
-      "automerge": true
+      "automerge": true,
+      "minimumReleaseAge": "2 days"
     },
     {
       "description": "Manual review for major updates",

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "local>elastic/renovate-config"
   ],
-  "baseBranches": [
+  "baseBranchPatterns": [
     "main",
     "9.4",
     "9.3",
@@ -11,7 +11,7 @@
     "8.19"
   ],
   "schedule": [
-    "0 1 * * 1-5"
+    "* 1 * * 1-5"
   ],
   "automergeSchedule": [
     "at any time"


### PR DESCRIPTION
## Summary

- Fix schedule cron from `* 1 * * 1-5` (every minute during hour 1) to `0 1 * * 1-5` (once at 01:00 Mon–Fri)
- Add `automergeSchedule: "at any time"` so automerge isn't gated by the PR-creation window
- Add `digest` and `pin` to the automerge rule's `matchUpdateTypes` (safest update types, should be automerged)
- Add `minimumReleaseAge: "2 days"` to prevent automerging packages that were just released
- Add `labeled` trigger to the auto-approve workflow so PRs where the `renovate-auto-approve` label is applied after creation still get approved
- Add Mergify queue rule for Renovate PRs so they merge correctly on branches with `strict:true` branch protection (`9.4`, `9.3`, `8.19`)

## Context

Based on a gap analysis against Elastic internal best practices for Renovate ([devflow-playground docs](https://docs.elastic.dev/r/devflow-playground/services/renovate/how-to/best-practices-for-administrating-renovate-configs-in-elastic)).

Non-main branches have `strict: true` in branch protection, which blocks GitHub's native auto-merge whenever a PR falls behind. Mergify was never wired up to handle Renovate PRs, so they stall indefinitely. The new Mergify rule queues Renovate PRs once CI passes and the bot approval is present — Mergify rebases atomically inside the queue.

## Test plan

- [ ] Verify `renovate-config-validator` passes on the updated `renovate.json`
- [ ] Confirm next scheduled Renovate run opens PRs at 01:00 (not every minute)
- [ ] Confirm Renovate PRs on `9.4`/`9.3`/`8.19` get queued and merged by Mergify without stalling

🤖 Generated with [Claude Code](https://claude.com/claude-code)