### PR TITLE
fix: include hidden files in docker-images artifact upload

### DIFF
--- a/.github/actions/docker-images/action.yml
+++ b/.github/actions/docker-images/action.yml
@@ -131,6 +131,7 @@ runs:
         if-no-files-found: error
         retention-days: 2
         overwrite: true
+        include-hidden-files: true
 
     - if: ${{ inputs.build-docker-images == 'false' }}
       name: Download docker images


### PR DESCRIPTION
`upload-artifact` v4.4.0 added `include-hidden-files` defaulting to `false`. The artifact path `/tmp/.docker-images` starts with a dot, so the uploader silently excluded the entire directory. This was masked while hermit was failing (the job was skipped); now that hermit passes, the upload step fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)