### PR TITLE
Revert "chore(deps): update terraform terraform-aws-modules/eks/aws to v21 (main)"

### DIFF
--- a/deploy/test-environments/modules/aws/eks/eks-cluster.tf
+++ b/deploy/test-environments/modules/aws/eks/eks-cluster.tf
@@ -1,6 +1,6 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "21.18.0"
+  version = "18.31.2"
 
   cluster_name    = local.cluster_name
   cluster_version = "1.32"


### PR DESCRIPTION
This reverts elastic/cloudbeat#5387 - the terraform-aws-modules/eks/aws upgrade that moved the CIS EKS stack from v18-compatible inputs to v21 without a full migration. That mismatch caused terraform validate/apply to fail (unsupported arguments such as cluster_name, cluster_version, eks_managed_node_group_defaults, and manage_aws_auth_configmap / aws_auth_roles), which broke the create/destroy environment workflow.