### PR TITLE
chore(renovate): disable non-dependency updates on release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -225,6 +225,12 @@
       "description": "Group Go toolchain and golangci-lint version updates together",
       "groupName": "go-version",
       "matchDepNames": ["go", "golangci-lint"]
+    },
+    {
+      "description": "Disable CI/infrastructure/test-environment updates on release branches",
+      "matchBaseBranches": ["9.4", "9.3", "9.2", "8.19"],
+      "matchPaths": [".github/workflows/**", ".buildkite/**", "**/pyproject.toml", "deploy/test-environments/**"],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
Adds a `packageRule` to skip Renovate PRs for CI workflows, Buildkite pipelines, Python pyproject files, and test-environment Terraform on release branches (`9.4`, `9.3`, `9.2`, `8.19`). Only Go module updates will be created on those branches.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)