### PR TITLE
Revert "chore(deps): update slackapi/slack-github-action action to v3 (main)"

### DIFF
--- a/.github/actions/slack-notification/action.yml
+++ b/.github/actions/slack-notification/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - name: Send Slack notification
       id: send-slack-notification
-      uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
+      uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
       env:
         SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
       with:


### PR DESCRIPTION
Reverts elastic/cloudbeat#5382 

There are breaking changes that prevent the latest version of the Slack action from working as expected. Therefore, migration from version 1.27 to 3.x requires the necessary adaptations.