### PR TITLE
revert(deps): downgrade github.com/go-ini/ini to v1.67.0 (9.3)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -408,7 +408,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.8.0 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
-	github.com/go-ini/ini v1.67.1 // indirect
+	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-logr/logr v1.4.3
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect


### PR DESCRIPTION
Reverts the `github.com/go-ini/ini` bump from v1.67.1 back to v1.67.0 to fix the 9.3 packaging build.

v1.67.1 was the first release to ship a `go.mod` file declaring the module path as `gopkg.in/ini.v1`, causing a path mismatch error when `go mod download` is invoked during packaging.

Fixes: build failure in package-cloudbeat-linux/amd64-staging introduced by #5826.