### PR TITLE
chore: sync auto-approve-renovate-prs workflow to 9.3

### DIFF
--- a/.github/workflows/auto-approve-renovate-prs.yaml
+++ b/.github/workflows/auto-approve-renovate-prs.yaml
@@ -1,37 +1,36 @@
-# This workflow automatically approves Renovate PRs created by the Renovate bot.
-# It checks if the PR is created by the Renovate bot and has the 'renovate-auto-approve' label before approving it.
-# Its functionality is complimentary to the Renovate functionality in order to enable a 2-step PR based automerge.
+# This workflow automatically approves Renovate PRs created by the Renovate bot, for PRs which are set to perform PR-based automerge.
+# It checks that the PR is created by the Renovate bot and has the 'renovate-auto-approve' label, before it will auto-approve the changes.
+# Its functionality is complimentary to the Renovate functionality in order to enable PR-based automerge without needing a human to be in the loop.
 name: GitHub Actions Bot Auto-Approve Renovate PRs
+
 on:
   pull_request:
     branches:
       - main
-      - "9.7"
-      - "9.6"
-      - "9.5"
-      - "9.4"
-      - "9.3"
-      - "9.2"
-      - "9.1"
-      - "8.19"
-    # auto_merge_enabled is a custom event that is triggered when a PR is created.
-    # Auto-merge will be enabled by Renovate -if configured- and this will trigger the GitHub workflow.
-    types: [auto_merge_enabled]
+      - "9.*"
+      - "8.*"
+    # Auto-merge will be enabled by Renovate (if configured) and this will trigger the GitHub Actions workflow.
+    #  - 'auto_merge_enabled' is a custom event that is triggered when a PR is created.
+    #  - 'synchronize' will be triggered when a PR is synchronized (e.g. when a new commit is pushed to the PR).
+    #  - 'labeled' will be triggered when a label is added to a PR (handles cases where the label is applied after PR creation).
+    types: [auto_merge_enabled, synchronize, labeled]
+
 permissions:
   pull-requests: write
+
 jobs:
   approve:
     runs-on: ubuntu-latest
     # The condition checks if the PR is created by the Renovate bot and has the 'renovate-auto-approve' label
     if: (github.event.pull_request.user.login == 'elastic-renovate-prod[bot]') && contains(github.event.pull_request.labels.*.name, 'renovate-auto-approve')
     steps:
-    - name: Approve Renovate PR using GitHub Actions Bot
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const result = await github.rest.pulls.createReview({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            pull_number: context.issue.number,
-            event: "APPROVE"
-          })
+      - name: Approve Renovate PR using GitHub Actions Bot
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const result = await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              event: "APPROVE"
+            })


### PR DESCRIPTION
## Summary

- Syncs `.github/workflows/auto-approve-renovate-prs.yaml` from `main` to this branch
- Adds `labeled` and `synchronize` as additional trigger types alongside `auto_merge_enabled`

## Why

When Renovate creates many PRs in a batch, GitHub occasionally drops the `auto_merge_enabled` event for some PRs. The old workflow had no fallback, so those PRs were silently left without an auto-approval and stuck waiting for a human review.

The new trigger set means:
- **`labeled`** — fires when Renovate applies the `renovate-auto-approve` label (catches the case where `auto_merge_enabled` was dropped)
- **`synchronize`** — fires on every force-push/rebase (catches PRs that were force-pushed after the missed event)

PR [#5821](https://github.com/elastic/cloudbeat/pull/5821) is a concrete example: the `auto_merge_enabled` event was dropped during a batch of ~100 simultaneous PRs and the workflow never ran for it.