### PR TITLE
Install Chrome v148 in FTR action

### DIFF
--- a/.github/actions/kibana-ftr/action.yml
+++ b/.github/actions/kibana-ftr/action.yml
@@ -56,7 +56,7 @@ runs:
       id: chrome
       uses: browser-actions/setup-chrome@4f8e94349a351df0f048634f25fec36c3c91eded # v2.1.1
       with:
-        chrome-version: 146
+        chrome-version: 148
 
     - name: Bootstrap Kibana
       shell: bash


### PR DESCRIPTION
### Summary of your changes

Nightly Sanity UI tests are failing due to an incompatible Chrome version. This PR updates Chrome to v148.

```
 warn SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 148
      Current browser version is 146.0.7680.165 with binary path /opt/hostedtoolcache/setup-chrome/chrome/146.0.7680.165/x64/chrome
          at Object.throwDecodedError (/home/runner/work/cloudbeat/cloudbeat/kibana/node_modules/selenium-webdriver/lib/error.js:523:15)
          at parseHttpResponse (/home/runner/work/cloudbeat/cloudbeat/kibana/node_modules/selenium-webdriver/lib/http.js:526:13)
          at Executor.execute (/home/runner/work/cloudbeat/cloudbeat/kibana/node_modules/selenium-webdriver/lib/http.js:458:28)
          at processTicksAndRejections (node:internal/process/task_queues:104:5)
          at Executor.<anonymous> (prevent_parallel_calls.ts:49:14) ***
```
