### PR TITLE
ci: declare workflow-level `contents: read` on 10 read-only workflows

### DIFF
--- a/.github/workflows/arm-template-lint.yml
+++ b/.github/workflows/arm-template-lint.yml
@@ -11,6 +11,9 @@ on:
     paths:
       - "deploy/azure/*.json"
 
+permissions:
+  contents: read
+
 jobs:
   lint-arm-ttk:
     name: Lint

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -22,6 +22,9 @@ env:
   SNYK_API_KEY: ${{ secrets.SNYK_API_KEY }}
   SNYK_INTEGRATION_ID: ${{ secrets.SNYK_INTEGRATION_ID }}
 
+permissions:
+  contents: read
+
 jobs:
   bump_version:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-pull_request.yml
+++ b/.github/workflows/ci-pull_request.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/cloudformation-ci.yml
+++ b/.github/workflows/cloudformation-ci.yml
@@ -22,6 +22,9 @@ env:
   INTEGRATIONS_SETUP_DIR: tests/integrations_setup
   TF_VAR_ec_api_key: ${{ secrets.EC_API_KEY }}
 
+permissions:
+  contents: read
+
 jobs:
   Deploy-CloudFormation:
     name: "Deploy CloudFormation"

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   package_beat:
     name: Package Cloudbeat

--- a/.github/workflows/sync-internal-cloudbeat-version.yml
+++ b/.github/workflows/sync-internal-cloudbeat-version.yml
@@ -7,6 +7,9 @@ on:
   #     - 'update-version-next-*'
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   synchronize-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-rule-templates.yml
+++ b/.github/workflows/sync-rule-templates.yml
@@ -10,6 +10,9 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.CLOUDSEC_MACHINE_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   Sync-Templates:
     name: Sync CIS Rule Templates

--- a/.github/workflows/test-opa-coverage.yml
+++ b/.github/workflows/test-opa-coverage.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-opa-policies.yml
+++ b/.github/workflows/test-opa-policies.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test-rego-policies:
     name: Test Rego Policies

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -21,6 +21,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   manifest_tests:


### PR DESCRIPTION
### Summary of your changes

Pins the default `GITHUB_TOKEN` to `contents: read` on the 10 workflows in `.github/workflows/` that don't actually use the default token for any write operation. Several look write-y from the filename, but the actual git push goes through a separate PAT (`CLOUDSEC_MACHINE_TOKEN`) not `GITHUB_TOKEN`:

- `arm-template-lint.yml`: ARM template lint, no GitHub API.
- `bump-version.yml`: workflow_dispatch; checkouts and pushes via `CLOUDSEC_MACHINE_TOKEN`. Default token unused.
- `ci-pull_request.yml`: standard PR CI. The only `secrets.GITHUB_TOKEN` reference is `COVERALLS_TOKEN` passed to goveralls, which uses the token to identify with Coveralls (token read for auth, not GitHub API write).
- `cloudformation-ci.yml`: only the `push` trigger is active; the `pull_request_target` block is commented out. No GitHub API.
- `packaging.yml`: build only.
- `sync-internal-cloudbeat-version.yml`: workflow_dispatch; all git ops use `CLOUDSEC_MACHINE_TOKEN`.
- `sync-rule-templates.yml`: same pattern; `CLOUDSEC_MACHINE_TOKEN` does the writes.
- `test-opa-coverage.yml`, `test-opa-policies.yml`, `unit-test.yml`: standard test workflows, no GitHub API.

`eks-ci.yml` is intentionally left out. It passes `GITHUB_TOKEN` to `andrcuns/allure-publish-action` which posts allure reports as PR comments, so it needs `pull-requests: write`. Better to leave that scope decision to a maintainer.

### Related Issues

None. This is a standalone CI hygiene PR.

### Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

### Checklist

- [x] YAML validated locally with `yaml.safe_load` on each touched file.
- [x] No functional change; only the scope of the implicit `GITHUB_TOKEN` is narrowed.
- [x] Workflows whose actual writes use `CLOUDSEC_MACHINE_TOKEN` are unaffected by this scope change.