### PR TITLE
Automate elastic/beats bump like elastic-agent

### DIFF
--- a/.ci/updatecli/updatecli.d/update-beats.yml
+++ b/.ci/updatecli/updatecli.d/update-beats.yml
@@ -1,71 +1,56 @@
 ---
 name: Update Elastic Beats go.mod Version
-pipelineid: 'updatecli-beats-{{ requiredEnv "GIT_BRANCH" }}'
+pipelineid: 'updatecli-beats-{{ requiredEnv "BRANCH_NAME" }}'
 
-scms:
-  default:
-    kind: github
-    spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      owner: "{{ .github.owner }}"
-      repository: "{{ .github.repository }}"
-      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
-      branch: '{{ requiredEnv "GIT_BRANCH" }}'
-      email: 'cloudsecmachine@elastic.co'
-
-actions:
-  default:
-    title: '[updatecli] {{ requiredEnv "GIT_BRANCH" }} - Update to elastic/beats@{{ source "beats" }}'
-    kind: github/pullrequest
-    scmid: default
-    spec:
-      automerge: false
-      labels:
-        - automation
-        - backport-skip
-        - dependency
-        - go
-      description: |-
-        ### What
-        `elastic/beats` automatic sync
-
-        *Changeset*
-        * https://github.com/elastic/beats/commit/{{ source "beats" }}
-
-        Generated automatically with {{ requiredEnv "JOB_URL" }}
+# Note: This pipeline only edits files on disk. It is run with `--commit=false`
+# and the resulting Pull Request is created by the `bump-beats-version.yml`
+# workflow via peter-evans/create-pull-request, mirroring how elastic-agent does
+# it. updatecli does NOT push commits or open the PR itself.
 
 sources:
   beats:
     kind: json
     spec:
-      file: 'https://api.github.com/repos/elastic/beats/commits?sha={{ requiredEnv "GIT_BRANCH" }}&per_page=1'
+      file: 'https://api.github.com/repos/elastic/beats/commits?sha={{ requiredEnv "BRANCH_NAME" }}&per_page=1'
       key: '.[0].sha'
     transformers:
-      # substring 12 chars so it works for the condition
+      # substring 12 chars so it matches the go.mod pseudo-version suffix
       - findsubmatch:
           pattern: ^(.{12}).*
           captureindex: 1
+  gomod:
+    kind: golang/gomod
+    spec:
+      module: github.com/elastic/beats/v7
+    transformers:
+      # the commit hash is the last 12 chars of the pseudo-version
+      - findsubmatch:
+          pattern: .*(.{12})$
+          captureindex: 1
 
 conditions:
-  is:
+  is-already-updated:
     name: Is version 'github.com/elastic/beats@{{ source "beats" }}' not updated in 'go.mod'?
-    kind: file
+    kind: shell
     disablesourceinput: true
-    scmid: default
     spec:
-      file: go.mod
-      matchpattern: 'github\.com/elastic/beats.*-{{ source "beats" }}'
-    failwhen: true
+      command: '[ {{ source "beats" }} != {{ source "gomod" }} ]'
+    failwhen: false
 
 targets:
   beats:
     name: 'Update to elastic/beats@{{ source "beats" }}'
     sourceid: beats
-    scmid: default
     kind: shell
     spec:
       command: .ci/updatecli/scripts/update-beats.sh
       environments:
         - name: PATH
         - name: HOME
+  export-versions:
+    name: "Export the previous and new beats version to /tmp/.beats-previous-version and /tmp/.beats-new-version files"
+    disablesourceinput: true
+    kind: shell
+    spec:
+      command: |
+        echo "{{ source "gomod" }}" > /tmp/.beats-previous-version && echo "{{ source "beats" }}" > /tmp/.beats-new-version

--- a/.github/workflows/bump-beats-version.yml
+++ b/.github/workflows/bump-beats-version.yml
@@ -1,0 +1,92 @@
+---
+name: update-beats
+
+# Bumps the github.com/elastic/beats/v7 go.mod dependency to the latest commit
+# on each active branch and opens a Pull Request per branch.
+#
+# Modeled on elastic/elastic-agent's bump-beats-version.yml: updatecli only edits
+# files (`--commit=false`) and the PR is opened by peter-evans/create-pull-request.
+# This avoids letting updatecli push/authenticate to GitHub itself.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every weekday at 00:00 UTC.
+    - cron: "0 0 * * 1-5"
+
+permissions:
+  contents: read
+
+jobs:
+  filter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.generator.outputs.matrix }}
+    permissions:
+      contents: read
+    steps:
+      - id: generator
+        uses: elastic/oblt-actions/elastic/active-branches@v1
+        with:
+          filter-branches: true
+
+  update-beats:
+    permissions:
+      contents: write
+      pull-requests: write
+    needs:
+      - filter
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.filter.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Hermit Environment
+        uses: ./.github/actions/hermit
+        with:
+          init-tools: "true"
+          free-disk: "true"
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@2c3221bc5f4499a99fec2c87d9de4a83cb30e990 # v3.1.3
+
+      # We can't let updatecli create the PR because it pushes/authenticates to
+      # GitHub itself; we run it in apply mode without committing and let
+      # create-pull-request handle the git side.
+      - name: Run Updatecli in Apply mode
+        run: updatecli apply --config .ci/updatecli/updatecli.d/update-beats.yml --commit=false
+        env:
+          BRANCH_NAME: ${{ matrix.branch }}
+
+      - name: Export beats versions to environment variables
+        run: |
+          if [[ -f /tmp/.beats-new-version ]]; then
+            echo "BEATS_PREVIOUS_VERSION=$(cat /tmp/.beats-previous-version)" >> "$GITHUB_ENV"
+            echo "BEATS_NEW_VERSION=$(cat /tmp/.beats-new-version)" >> "$GITHUB_ENV"
+          fi
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "[${{ matrix.branch }}][Automation] Update elastic/beats to ${{ env.BEATS_NEW_VERSION }}"
+          title: "[${{ matrix.branch }}][Automation] Update elastic/beats to ${{ env.BEATS_NEW_VERSION }}"
+          body: |
+            ### What
+            Update `elastic/beats` to the latest version on branch `${{ matrix.branch }}`.
+
+            *Changeset*
+            * https://github.com/elastic/beats/compare/${{ env.BEATS_PREVIOUS_VERSION }}...${{ env.BEATS_NEW_VERSION }}
+          branch: update-beats-${{ matrix.branch }}
+          base: ${{ matrix.branch }}
+          delete-branch: true
+          labels: |
+            automation
+            backport-skip
+            dependency
+            go

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -48,7 +48,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pipeline-name: [beats, golang, hermit, mods]
+        # beats is handled by the dedicated bump-beats-version.yml workflow.
+        pipeline-name: [golang, hermit, mods]
         git-branch: [main]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -85,7 +86,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pipeline-name: [golang, beats]
+        # beats is handled by the dedicated bump-beats-version.yml workflow.
+        pipeline-name: [golang]
         git-branch: ${{ fromJSON(needs.active-branches.outputs.matrix) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
### What
Automate bumping the `github.com/elastic/beats/v7` go.mod dependency, modeled on elastic-agent's beats-bump (elastic/elastic-agent#14565), and make it work across active branches.

### Why
cloudbeat already had a beats bump driven by updatecli, but it has been **failing on every scheduled run** (main and every backport branch). updatecli pushed commits and opened the PR itself using `CLOUDSEC_MACHINE_TOKEN`, which now returns `401 Bad credentials`:

```
ERROR: pushing commits failed ...
unable to query GitHub API rate limit ... 401 Unauthorized body: "Bad credentials"
```

elastic-agent avoids this entirely by keeping git/PR work out of updatecli and using the built-in `GITHUB_TOKEN`.

### How (aligned with elastic-agent)
- **New `.github/workflows/bump-beats-version.yml`**: an `elastic/oblt-actions/elastic/active-branches` matrix opens one PR per active branch. updatecli runs in `apply --commit=false` mode (file edits only); `peter-evans/create-pull-request` opens the PR using the built-in `secrets.GITHUB_TOKEN` plus job-level `contents: write` / `pull-requests: write`. **No machine token / PAT.** Go and mage come from the existing Hermit action.
- **`.ci/updatecli/updatecli.d/update-beats.yml`** rewritten to file-edit-only (`beats` + `gomod` sources, `is-already-updated` condition, `beats` + `export-versions` targets); dropped the `scms`/`actions` blocks so updatecli no longer authenticates to GitHub.
- **`.github/workflows/updatecli.yml`**: removed `beats` from the main and backport matrices so the dedicated workflow owns it.

### Prerequisites to enable
- Settings → Actions → General → **"Allow GitHub Actions to create and approve pull requests"** must be enabled (required for `create-pull-request` to work with `GITHUB_TOKEN`, same as elastic-agent).
- Note: PRs opened by `GITHUB_TOKEN` do not auto-trigger CI (GitHub anti-recursion rule) — this matches elastic-agent's behavior.

### Test
`gh workflow run bump-beats-version.yml` (or wait for the weekday schedule) should open a PR per active branch titled `[<branch>][Automation] Update elastic/beats to <hash>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)