### PR TITLE
ci: fix auto-merge version bump PRs rule to use merge instead of queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -183,5 +183,5 @@ pull_request_rules:
       - check-success=Unit Test
       - check-success=Lint
     actions:
-      queue:
-        name: default
+      merge:
+        method: squash


### PR DESCRIPTION
## Summary

Replace Mergify's `queue` action with `merge` in the `auto-merge version bump PRs` rule. The `queue` action requires a `queue_rules` definition which is not present in this config, causing version bump PRs to be dequeued with a merge failure. Using `merge: method: squash` is consistent with the other auto-merge rules in this file (see https://github.com/elastic/cloudbeat/pull/5871/changes).

## Test plan

- [ ] Verify next bot-authored version bump PR is automatically merged without Mergify dequeue errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)