### PR TITLE
fix(cloudformation): use AWS::Partition for CSPM SecurityAudit ARN

### DIFF
--- a/deploy/cloudformation/elastic-agent-direct-access-key-cspm-organization.yml
+++ b/deploy/cloudformation/elastic-agent-direct-access-key-cspm-organization.yml
@@ -147,7 +147,7 @@ Resources:
                       - sts:AssumeRole
               Path: /
               ManagedPolicyArns:
-                - arn:aws:iam::aws:policy/SecurityAudit
+                - !Sub 'arn:${AWS::Partition}:iam::aws:policy/SecurityAudit'
 
   CloudbeatManagementAccountAuditRole:
     Type: AWS::IAM::Role
@@ -163,7 +163,7 @@ Resources:
               - sts:AssumeRole
       Path: /
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/SecurityAudit
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/SecurityAudit'
     Condition: ScanManagementAccountEnabled
 
   ElasticCSPMAccessKey:

--- a/deploy/cloudformation/elastic-agent-direct-access-key-cspm.yml
+++ b/deploy/cloudformation/elastic-agent-direct-access-key-cspm.yml
@@ -17,7 +17,7 @@ Resources:
               - /
               - !Ref AWS::StackId
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/SecurityAudit
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/SecurityAudit'
       Path: /
 
   ElasticCSPMAccessKey:

--- a/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml
@@ -228,7 +228,7 @@ Resources:
                       - sts:AssumeRole
               Path: /
               ManagedPolicyArns:
-                - arn:aws:iam::aws:policy/SecurityAudit
+                - !Sub 'arn:${AWS::Partition}:iam::aws:policy/SecurityAudit'
 
   CloudbeatManagementAccountAuditRole:
     Type: AWS::IAM::Role
@@ -244,7 +244,7 @@ Resources:
               - sts:AssumeRole
       Path: /
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/SecurityAudit
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/SecurityAudit'
     Condition: ScanManagementAccountEnabled
 
 Outputs:

--- a/deploy/cloudformation/elastic-agent-ec2-cspm.yml
+++ b/deploy/cloudformation/elastic-agent-ec2-cspm.yml
@@ -65,7 +65,7 @@ Resources:
               - sts:AssumeRole
       Path: /
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/SecurityAudit
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/SecurityAudit'
 
   # Instance profile to attach to EC2 instance
   ElasticAgentInstanceProfile:


### PR DESCRIPTION
### Summary of your changes

Replace hardcoded `arn:aws:` partition with the [`AWS::Partition`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html) pseudo-parameter in the four CSPM agent-based CloudFormation templates so they deploy successfully in both commercial AWS and AWS GovCloud (`aws-us-gov`) regions without requiring separate templates.

Each occurrence is swapped from:

```yaml
ManagedPolicyArns:
  - arn:aws:iam::aws:policy/SecurityAudit
```

to:

```yaml
ManagedPolicyArns:
  - !Sub 'arn:${AWS::Partition}:iam::aws:policy/SecurityAudit'
```

CloudFormation resolves `${AWS::Partition}` to `aws`, `aws-us-gov`, or `aws-cn` automatically based on the deployment region, so commercial deployments are unaffected.

**Affected templates** (6 line swaps total):
- `deploy/cloudformation/elastic-agent-ec2-cspm.yml`
- `deploy/cloudformation/elastic-agent-ec2-cspm-organization.yml`
- `deploy/cloudformation/elastic-agent-direct-access-key-cspm.yml`
- `deploy/cloudformation/elastic-agent-direct-access-key-cspm-organization.yml`

**Out of scope** (deliberately not touched):
- `cloud-connectors-*.yml` — agentless / identity-federation flow, excluded per the linked issue.
- `deploy/asset-inventory-cloudformation/*` — not CSPM.
- Kibana's "Launch CloudFormation" button still points at `console.aws.amazon.com`. GovCloud customers will need to manually open `console.amazonaws-us-gov.com` and paste the S3 template URL. The template fix unblocks them, but a one-click GovCloud UX is a separate follow-up.

### Static verification already performed

- `pre-commit run --files <the 4 templates>` — `cfn-python-lint` and `rain fmt` both pass; `rain fmt` made no formatting changes (the `!Sub '...'` form is already canonical).
- `aws cloudformation validate-template --template-body file://<path>` for each of the 4 files — all return valid Parameters/Capabilities, no errors.
- `git diff --stat` confirms exactly 6 insertions / 6 deletions, no collateral changes.

### Deployment verification

**Commercial AWS (regression) — completed for `elastic-agent-ec2-cspm.yml`:**

- Account: `elastic-security-cloud-security-dev` (`704479110758`), region `us-east-1`, branch HEAD
- Stack created via `aws cloudformation create-stack --template-body file://deploy/cloudformation/elastic-agent-ec2-cspm.yml ...` with parameters mirroring those Kibana's "Launch CloudFormation" deep-link pre-populates (fleet URL, enrollment token, agent version 9.4.2, default AMI / m6g.xlarge).
- [x] Stack reaches `CREATE_COMPLETE`
- [x] `ElasticAgentRole` resource created; `${AWS::Partition}` resolves to `aws` in `us-east-1`
- [x] `SecurityAudit` managed policy attaches with the resolved ARN, verified via `aws iam list-attached-role-policies`:

      PolicyArn:  arn:aws:iam::aws:policy/SecurityAudit
      PolicyName: SecurityAudit

  Byte-for-byte identical to the previous hardcoded form — zero regression in the standard partition.
- [x] EC2 launches, agent installs and enrolls into Fleet, and `cfn-signal --exit-code 0` fires within the `PT10M` `CreationPolicy.ResourceSignal` window

The other three modified templates (`elastic-agent-ec2-cspm-organization.yml`, `elastic-agent-direct-access-key-cspm.yml`, `elastic-agent-direct-access-key-cspm-organization.yml`) carry the identical single-line `!Sub 'arn:${AWS::Partition}:iam::aws:policy/SecurityAudit'` substitution with no other differences vs. their prior `arn:aws:...` form. Because the substitution is identical and CloudFormation's pseudo-parameter resolution is deterministic per region, the regression risk is bounded to the substitution itself.

**Still pending:**

- [ ] **AWS GovCloud (`aws-us-gov`) deployment** — blocked on GovCloud account access. This is the fix-verification half and is what actually exercises `${AWS::Partition}` producing a different value (`arn:aws-us-gov:...`). Will follow up once creds are available.

### Related Issues

- Fixes: https://github.com/elastic/security-team/issues/17710
- Related: https://github.com/elastic/integrations/issues/9187

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary README/documentation (if appropriate)

The "tests" box reflects the static checks above (`cfn-lint` + `aws cloudformation validate-template`); no new automated test was added because the change is a one-line per-file partition substitution with no runtime branching to cover. README is unchanged because the integration manifest and S3 keys are unchanged.
