### PR TITLE
[8.19] Align beats-bump automation config

### DIFF
--- a/.ci/updatecli/updatecli.d/update-beats.yml
+++ b/.ci/updatecli/updatecli.d/update-beats.yml
@@ -1,72 +1,56 @@
 ---
 name: Update Elastic Beats go.mod Version
-pipelineid: 'updatecli-beats-{{ requiredEnv "GIT_BRANCH" }}'
+pipelineid: 'updatecli-beats-{{ requiredEnv "BRANCH_NAME" }}'
 
-scms:
-  default:
-    kind: github
-    spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      owner: "{{ .github.owner }}"
-      repository: "{{ .github.repository }}"
-      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
-      branch: '{{ requiredEnv "GIT_BRANCH" }}'
-      email: 'cloudsecmachine@elastic.co'
-
-actions:
-  default:
-    title: '[updatecli] {{ requiredEnv "GIT_BRANCH" }} - Update to elastic/beats@{{ source "beats" }}'
-    kind: github/pullrequest
-    scmid: default
-    spec:
-      automerge: false
-      labels:
-        - automation
-        - backport-skip
-        - dependency
-        - go
-      description: |-
-        ### What
-        `elastic/beats` automatic sync
-
-        *Changeset*
-        * https://github.com/elastic/beats/commit/{{ source "beats" }}
-
-        Generated automatically with {{ requiredEnv "JOB_URL" }}
+# Note: This pipeline only edits files on disk. It is run with `--commit=false`
+# and the resulting Pull Request is created by the `bump-beats-version.yml`
+# workflow via peter-evans/create-pull-request, mirroring how elastic-agent does
+# it. updatecli does NOT push commits or open the PR itself.
 
 sources:
   beats:
     kind: json
     spec:
-      file: 'https://api.github.com/repos/elastic/beats/commits?sha={{ requiredEnv "GIT_BRANCH" }}&per_page=1'
+      file: 'https://api.github.com/repos/elastic/beats/commits?sha={{ requiredEnv "BRANCH_NAME" }}&per_page=1'
       key: '.[0].sha'
     transformers:
-      # substring 12 chars so it works for the condition
+      # substring 12 chars so it matches the go.mod pseudo-version suffix
       - findsubmatch:
           pattern: ^(.{12}).*
           captureindex: 1
+  gomod:
+    kind: golang/gomod
+    spec:
+      module: github.com/elastic/beats/v7
+    transformers:
+      # the commit hash is the last 12 chars of the pseudo-version
+      - findsubmatch:
+          pattern: .*(.{12})$
+          captureindex: 1
 
 conditions:
-  is:
+  is-already-updated:
     name: Is version 'github.com/elastic/beats@{{ source "beats" }}' not updated in 'go.mod'?
-    kind: file
+    kind: shell
     disablesourceinput: true
-    scmid: default
     spec:
-      file: go.mod
-      matchpattern: 'github\.com/elastic/beats.*-{{ source "beats" }}'
-    failwhen: true
+      command: '[ {{ source "beats" }} != {{ source "gomod" }} ]'
+    failwhen: false
 
 targets:
   beats:
     name: 'Update to elastic/beats@{{ source "beats" }}'
     sourceid: beats
-    scmid: default
     kind: shell
     spec:
       command: .ci/updatecli/scripts/update-beats.sh
       environments:
         - name: PATH
-        - name: GOPATH
         - name: HOME
+  export-versions:
+    name: "Export the previous and new beats version to /tmp/.beats-previous-version and /tmp/.beats-new-version files"
+    disablesourceinput: true
+    kind: shell
+    spec:
+      command: |
+        echo "{{ source "gomod" }}" > /tmp/.beats-previous-version && echo "{{ source "beats" }}" > /tmp/.beats-new-version

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -48,7 +48,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pipeline-name: [ beats, golang, hermit, mods ]
+        # beats is handled by the dedicated bump-beats-version.yml workflow.
+        pipeline-name: [ golang, hermit, mods ]
         git-branch: [ main, 8.x ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -81,7 +82,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pipeline-name: [ golang, beats ]
+        # beats is handled by the dedicated bump-beats-version.yml workflow.
+        pipeline-name: [ golang ]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Init Hermit


### PR DESCRIPTION
### What
Switch the updatecli beats config on `8.19` to the file-edit-only form used by the `bump-beats-version.yml` workflow, so the `update-beats (8.19)` job stops failing at config load.

### Why
The `update-beats` workflow (on `main`) checks out each active branch and runs `updatecli apply --config .ci/updatecli/updatecli.d/update-beats.yml`. That config is read from the **checked-out branch**, but `8.19` still had the old config (`requiredEnv "GIT_BRANCH"` + `scms`/`actions`), while the new workflow sets `BRANCH_NAME` and runs `--commit=false`:

```
template: cfg:3:32: executing "cfg" at <requiredEnv "GIT_BRANCH">: error calling requiredEnv: no value found for environment variable GIT_BRANCH
```

### How
- **`.ci/updatecli/updatecli.d/update-beats.yml`**: replace with the `BRANCH_NAME` / `--commit=false` config the new workflow expects.
- **`.github/workflows/updatecli.yml`**: remove `beats` from the matrices (now owned by the dedicated workflow).

### Scope note (deliberately config-only)
This PR does **not** include the `elastic/beats` version bump. Unlike `9.3`/`9.4`, bumping beats on `8.19` pulls `elastic-agent-libs` up to `v0.43.1`, which removes the global observer logging API (`logp.ToObserverOutput` / `logp.ObserverLogs()`) still used across ~22 sites in 6 test files on `8.19`. That requires backporting the `logptest.NewTestingLoggerWithObserver` migration (already done on `9.3`/`main`) and is best handled as a separate, deliberate change. With this config fix in place, the automation can run; the resulting bump PR will need that migration before it goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)