### PR TITLE
fix(ci): make hermit "Log cached paths" step non-fatal on cold cache

### DIFF
--- a/.github/actions/hermit/action.yml
+++ b/.github/actions/hermit/action.yml
@@ -106,7 +106,7 @@ runs:
     - name: Log cached paths
       shell: bash
       run: |
-        ls -lah ~/.cache/hermit/pkg
-        ls -lah ./.hermit
-        ls -lah ~/.cache/pypoetry
-        ls -lah ~/.cache/pre-commit
+        ls -lah ~/.cache/hermit/pkg || true
+        ls -lah ./.hermit || true
+        ls -lah ~/.cache/pypoetry || true
+        ls -lah ~/.cache/pre-commit || true


### PR DESCRIPTION
### Summary of your changes

The setup job of the E2E test-runner workflow fails on the "Hermit Environment" step whenever the Hermit cache is cold. The failure happens in the purely-diagnostic "Log cached paths" step, which runs ls -lah ./.hermit (and other cache dirs) under bash -eo pipefail. When the cache misses and the action is called with init-tools: false, those directories are never created, so ls exits with code 2 and fails the entire job.

This PR makes the diagnostic logging step non-fatal.

Related to [elastic/security-team#17923](https://github.com/elastic/security-team/issues/17923)