### PR TITLE
fix: prevent panic when MS Graph returns AgentIdentityBlueprintPrincipal in service principal list

### DIFF
--- a/internal/inventory/azurefetcher/fetcher_activedirectory.go
+++ b/internal/inventory/azurefetcher/fetcher_activedirectory.go
@@ -35,7 +35,7 @@ type activedirectoryFetcher struct {
 
 type (
 	activedirectoryProvider interface {
-		ListServicePrincipals(ctx context.Context) ([]*models.ServicePrincipal, error)
+		ListServicePrincipals(ctx context.Context) ([]models.ServicePrincipalable, error)
 		ListDirectoryRoles(context.Context) ([]*models.DirectoryRole, error)
 		ListGroups(context.Context) ([]*models.Group, error)
 		ListUsers(context.Context) ([]*models.User, error)

--- a/internal/inventory/azurefetcher/fetcher_activedirectory_mock.go
+++ b/internal/inventory/azurefetcher/fetcher_activedirectory_mock.go
@@ -232,8 +232,8 @@ func (_c *mockActivedirectoryProvider_ListServicePrincipals_Call) Run(run func(c
 	return _c
 }
 
-func (_c *mockActivedirectoryProvider_ListServicePrincipals_Call) Return(servicePrincipals []models.ServicePrincipalable, err error) *mockActivedirectoryProvider_ListServicePrincipals_Call {
-	_c.Call.Return(servicePrincipals, err)
+func (_c *mockActivedirectoryProvider_ListServicePrincipals_Call) Return(servicePrincipalables []models.ServicePrincipalable, err error) *mockActivedirectoryProvider_ListServicePrincipals_Call {
+	_c.Call.Return(servicePrincipalables, err)
 	return _c
 }
 

--- a/internal/inventory/azurefetcher/fetcher_activedirectory_mock.go
+++ b/internal/inventory/azurefetcher/fetcher_activedirectory_mock.go
@@ -181,23 +181,23 @@ func (_c *mockActivedirectoryProvider_ListGroups_Call) RunAndReturn(run func(con
 }
 
 // ListServicePrincipals provides a mock function for the type mockActivedirectoryProvider
-func (_mock *mockActivedirectoryProvider) ListServicePrincipals(ctx context.Context) ([]*models.ServicePrincipal, error) {
+func (_mock *mockActivedirectoryProvider) ListServicePrincipals(ctx context.Context) ([]models.ServicePrincipalable, error) {
 	ret := _mock.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListServicePrincipals")
 	}
 
-	var r0 []*models.ServicePrincipal
+	var r0 []models.ServicePrincipalable
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]*models.ServicePrincipal, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]models.ServicePrincipalable, error)); ok {
 		return returnFunc(ctx)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) []*models.ServicePrincipal); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []models.ServicePrincipalable); ok {
 		r0 = returnFunc(ctx)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*models.ServicePrincipal)
+			r0 = ret.Get(0).([]models.ServicePrincipalable)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
@@ -232,12 +232,12 @@ func (_c *mockActivedirectoryProvider_ListServicePrincipals_Call) Run(run func(c
 	return _c
 }
 
-func (_c *mockActivedirectoryProvider_ListServicePrincipals_Call) Return(servicePrincipals []*models.ServicePrincipal, err error) *mockActivedirectoryProvider_ListServicePrincipals_Call {
+func (_c *mockActivedirectoryProvider_ListServicePrincipals_Call) Return(servicePrincipals []models.ServicePrincipalable, err error) *mockActivedirectoryProvider_ListServicePrincipals_Call {
 	_c.Call.Return(servicePrincipals, err)
 	return _c
 }
 
-func (_c *mockActivedirectoryProvider_ListServicePrincipals_Call) RunAndReturn(run func(ctx context.Context) ([]*models.ServicePrincipal, error)) *mockActivedirectoryProvider_ListServicePrincipals_Call {
+func (_c *mockActivedirectoryProvider_ListServicePrincipals_Call) RunAndReturn(run func(ctx context.Context) ([]models.ServicePrincipalable, error)) *mockActivedirectoryProvider_ListServicePrincipals_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/inventory/azurefetcher/fetcher_activedirectory_test.go
+++ b/internal/inventory/azurefetcher/fetcher_activedirectory_test.go
@@ -141,7 +141,7 @@ func TestActiveDirectoryFetcher_Fetch(t *testing.T) {
 	provider := newMockActivedirectoryProvider(t)
 
 	provider.EXPECT().ListServicePrincipals(mock.Anything).Maybe().Return(
-		[]*models.ServicePrincipal{servicePrincipal}, nil,
+		[]models.ServicePrincipalable{servicePrincipal}, nil,
 	)
 	provider.EXPECT().ListDirectoryRoles(mock.Anything).Maybe().Return(
 		[]*models.DirectoryRole{role}, nil,
@@ -155,6 +155,53 @@ func TestActiveDirectoryFetcher_Fetch(t *testing.T) {
 
 	fetcher := newActiveDirectoryFetcher(logger, "id", provider)
 	// test & compare
+	testutil.CollectResourcesAndMatch(t, fetcher, expected)
+}
+
+// TestActiveDirectoryFetcher_Fetch_AgentIdentityBlueprintPrincipal verifies that the fetcher
+// correctly processes AgentIdentityBlueprintPrincipal objects (a ServicePrincipal subtype
+// provisioned automatically by Microsoft 365 Copilot/Agents) without panicking or dropping
+// the asset event.
+func TestActiveDirectoryFetcher_Fetch_AgentIdentityBlueprintPrincipal(t *testing.T) {
+	agentPrincipalID := "agent-principal-id"
+	appOwnerOrganizationId, _ := uuid.NewUUID()
+	values := map[string]any{
+		"id":                     &agentPrincipalID,
+		"displayName":            pointers.Ref("Copilot Agent"),
+		"appOwnerOrganizationId": &appOwnerOrganizationId,
+	}
+	bs := store.NewInMemoryBackingStore()
+	for k, v := range values {
+		_ = bs.Set(k, v)
+	}
+
+	agentPrincipal := models.NewAgentIdentityBlueprintPrincipal()
+	agentPrincipal.SetBackingStore(bs)
+
+	expected := []inventory.AssetEvent{
+		inventory.NewAssetEvent(
+			inventory.AssetClassificationAzureServicePrincipal,
+			agentPrincipalID,
+			"Copilot Agent",
+			inventory.WithRawAsset(values),
+			inventory.WithCloud(inventory.Cloud{
+				Provider:    inventory.AzureCloudProvider,
+				AccountID:   appOwnerOrganizationId.String(),
+				ServiceName: "Azure Entra",
+			}),
+		),
+	}
+
+	logger := testhelper.NewLogger(t)
+	provider := newMockActivedirectoryProvider(t)
+	provider.EXPECT().ListServicePrincipals(mock.Anything).Return(
+		[]models.ServicePrincipalable{agentPrincipal}, nil,
+	)
+	provider.EXPECT().ListDirectoryRoles(mock.Anything).Maybe().Return(nil, nil)
+	provider.EXPECT().ListGroups(mock.Anything).Maybe().Return(nil, nil)
+	provider.EXPECT().ListUsers(mock.Anything).Maybe().Return(nil, nil)
+
+	fetcher := newActiveDirectoryFetcher(logger, "tenant-id", provider)
 	testutil.CollectResourcesAndMatch(t, fetcher, expected)
 }
 
@@ -172,7 +219,7 @@ func TestActiveDirectoryFetcher_FetchError(t *testing.T) {
 
 	provider := newMockActivedirectoryProvider(t)
 	provider.EXPECT().ListServicePrincipals(mock.Anything).Return(
-		[]*models.ServicePrincipal{}, errors.New("! error listing service principals"),
+		[]models.ServicePrincipalable{}, errors.New("! error listing service principals"),
 	)
 	provider.EXPECT().ListDirectoryRoles(mock.Anything).Maybe().Return(
 		[]*models.DirectoryRole{}, nil,

--- a/internal/inventory/azurefetcher/fetcher_activedirectory_test.go
+++ b/internal/inventory/azurefetcher/fetcher_activedirectory_test.go
@@ -205,6 +205,64 @@ func TestActiveDirectoryFetcher_Fetch_AgentIdentityBlueprintPrincipal(t *testing
 	testutil.CollectResourcesAndMatch(t, fetcher, expected)
 }
 
+func TestActiveDirectoryFetcher_Fetch_MixedPrincipalTypes(t *testing.T) {
+	appOwnerOrganizationId, _ := uuid.NewUUID()
+	values := map[string]any{
+		"id":                     pointers.Ref("some-id"),
+		"displayName":            pointers.Ref("some-name"),
+		"appOwnerOrganizationId": &appOwnerOrganizationId,
+	}
+	bs := store.NewInMemoryBackingStore()
+	for k, v := range values {
+		_ = bs.Set(k, v)
+	}
+
+	// Both principals share the same backing store so each produces an identical event;
+	// the test verifies that both items are emitted regardless of their concrete type.
+	regularPrincipal := &models.ServicePrincipal{}
+	regularPrincipal.SetBackingStore(bs)
+	agentPrincipal := models.NewAgentIdentityBlueprintPrincipal()
+	agentPrincipal.SetBackingStore(bs)
+
+	expectedEvent := inventory.NewAssetEvent(
+		inventory.AssetClassificationAzureServicePrincipal,
+		"some-id",
+		"some-name",
+		inventory.WithRawAsset(values),
+		inventory.WithCloud(inventory.Cloud{
+			Provider:    inventory.AzureCloudProvider,
+			AccountID:   appOwnerOrganizationId.String(),
+			ServiceName: "Azure Entra",
+		}),
+	)
+
+	logger := testhelper.NewLogger(t)
+	provider := newMockActivedirectoryProvider(t)
+	provider.EXPECT().ListServicePrincipals(mock.Anything).Return(
+		[]models.ServicePrincipalable{regularPrincipal, agentPrincipal}, nil,
+	)
+	provider.EXPECT().ListDirectoryRoles(mock.Anything).Maybe().Return(nil, nil)
+	provider.EXPECT().ListGroups(mock.Anything).Maybe().Return(nil, nil)
+	provider.EXPECT().ListUsers(mock.Anything).Maybe().Return(nil, nil)
+
+	fetcher := newActiveDirectoryFetcher(logger, "tenant-id", provider)
+	testutil.CollectResourcesAndMatch(t, fetcher, []inventory.AssetEvent{expectedEvent, expectedEvent})
+}
+
+func TestActiveDirectoryFetcher_Fetch_EmptyServicePrincipalList(t *testing.T) {
+	logger := testhelper.NewLogger(t)
+	provider := newMockActivedirectoryProvider(t)
+	provider.EXPECT().ListServicePrincipals(mock.Anything).Return(
+		[]models.ServicePrincipalable{}, nil,
+	)
+	provider.EXPECT().ListDirectoryRoles(mock.Anything).Maybe().Return(nil, nil)
+	provider.EXPECT().ListGroups(mock.Anything).Maybe().Return(nil, nil)
+	provider.EXPECT().ListUsers(mock.Anything).Maybe().Return(nil, nil)
+
+	fetcher := newActiveDirectoryFetcher(logger, "tenant-id", provider)
+	testutil.CollectResourcesAndMatch(t, fetcher, []inventory.AssetEvent{})
+}
+
 func TestActiveDirectoryFetcher_FetchError(t *testing.T) {
 	// set up log capture
 	logCaptureBuf := &bytes.Buffer{}

--- a/internal/resources/providers/msgraph/provider.go
+++ b/internal/resources/providers/msgraph/provider.go
@@ -34,7 +34,7 @@ import (
 )
 
 type ProviderAPI interface {
-	ListServicePrincipals(context.Context) ([]*models.ServicePrincipal, error)
+	ListServicePrincipals(context.Context) ([]models.ServicePrincipalable, error)
 	ListDirectoryRoles(context.Context) ([]*models.DirectoryRole, error)
 	ListGroups(context.Context) ([]*models.Group, error)
 	ListUsers(context.Context) ([]*models.User, error)
@@ -71,7 +71,7 @@ func NewProvider(log *clog.Logger, azureConfig auth.AzureFactoryConfig) (Provide
 // - https://github.com/microsoftgraph/msgraph-sdk-go
 // - https://learn.microsoft.com/en-us/graph/api/serviceprincipal-list?view=graph-rest-beta&tabs=go
 // - https://learn.microsoft.com/en-us/graph/sdks/paging?tabs=go
-func (p *provider) ListServicePrincipals(ctx context.Context) ([]*models.ServicePrincipal, error) {
+func (p *provider) ListServicePrincipals(ctx context.Context) ([]models.ServicePrincipalable, error) {
 	requestConfig := &serviceprincipals.ServicePrincipalsRequestBuilderGetRequestConfiguration{}
 
 	response, err := p.client.ServicePrincipals().Get(ctx, requestConfig)
@@ -79,7 +79,7 @@ func (p *provider) ListServicePrincipals(ctx context.Context) ([]*models.Service
 		return nil, fmt.Errorf("error listing Azure Service Principals: %w", err)
 	}
 
-	pageIterator, err := graphcore.NewPageIterator[*models.ServicePrincipal](
+	pageIterator, err := graphcore.NewPageIterator[models.ServicePrincipalable](
 		response,
 		p.client.ServicePrincipals().RequestAdapter,
 		models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
@@ -88,8 +88,8 @@ func (p *provider) ListServicePrincipals(ctx context.Context) ([]*models.Service
 		return nil, fmt.Errorf("error paging Azure Service Principals: %w", err)
 	}
 
-	items := []*models.ServicePrincipal{}
-	err = pageIterator.Iterate(ctx, func(pageItem *models.ServicePrincipal) bool {
+	items := []models.ServicePrincipalable{}
+	err = pageIterator.Iterate(ctx, func(pageItem models.ServicePrincipalable) bool {
 		items = append(items, pageItem)
 		return true // to continue the iteration
 	})

--- a/internal/resources/providers/msgraph/provider_mock.go
+++ b/internal/resources/providers/msgraph/provider_mock.go
@@ -181,23 +181,23 @@ func (_c *MockProviderAPI_ListGroups_Call) RunAndReturn(run func(context1 contex
 }
 
 // ListServicePrincipals provides a mock function for the type MockProviderAPI
-func (_mock *MockProviderAPI) ListServicePrincipals(context1 context.Context) ([]*models.ServicePrincipal, error) {
+func (_mock *MockProviderAPI) ListServicePrincipals(context1 context.Context) ([]models.ServicePrincipalable, error) {
 	ret := _mock.Called(context1)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListServicePrincipals")
 	}
 
-	var r0 []*models.ServicePrincipal
+	var r0 []models.ServicePrincipalable
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]*models.ServicePrincipal, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context) ([]models.ServicePrincipalable, error)); ok {
 		return returnFunc(context1)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) []*models.ServicePrincipal); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context) []models.ServicePrincipalable); ok {
 		r0 = returnFunc(context1)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*models.ServicePrincipal)
+			r0 = ret.Get(0).([]models.ServicePrincipalable)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
@@ -232,12 +232,12 @@ func (_c *MockProviderAPI_ListServicePrincipals_Call) Run(run func(context1 cont
 	return _c
 }
 
-func (_c *MockProviderAPI_ListServicePrincipals_Call) Return(servicePrincipals []*models.ServicePrincipal, err error) *MockProviderAPI_ListServicePrincipals_Call {
+func (_c *MockProviderAPI_ListServicePrincipals_Call) Return(servicePrincipals []models.ServicePrincipalable, err error) *MockProviderAPI_ListServicePrincipals_Call {
 	_c.Call.Return(servicePrincipals, err)
 	return _c
 }
 
-func (_c *MockProviderAPI_ListServicePrincipals_Call) RunAndReturn(run func(context1 context.Context) ([]*models.ServicePrincipal, error)) *MockProviderAPI_ListServicePrincipals_Call {
+func (_c *MockProviderAPI_ListServicePrincipals_Call) RunAndReturn(run func(context1 context.Context) ([]models.ServicePrincipalable, error)) *MockProviderAPI_ListServicePrincipals_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/resources/providers/msgraph/provider_mock.go
+++ b/internal/resources/providers/msgraph/provider_mock.go
@@ -232,8 +232,8 @@ func (_c *MockProviderAPI_ListServicePrincipals_Call) Run(run func(context1 cont
 	return _c
 }
 
-func (_c *MockProviderAPI_ListServicePrincipals_Call) Return(servicePrincipals []models.ServicePrincipalable, err error) *MockProviderAPI_ListServicePrincipals_Call {
-	_c.Call.Return(servicePrincipals, err)
+func (_c *MockProviderAPI_ListServicePrincipals_Call) Return(servicePrincipalables []models.ServicePrincipalable, err error) *MockProviderAPI_ListServicePrincipals_Call {
+	_c.Call.Return(servicePrincipalables, err)
 	return _c
 }
 

--- a/internal/resources/providers/msgraph/provider_test.go
+++ b/internal/resources/providers/msgraph/provider_test.go
@@ -51,11 +51,19 @@ func newPage(items []models.ServicePrincipalable, nextLink *string) *models.Serv
 
 func ptr(s string) *string { return &s }
 
+// noopAdapter satisfies NewPageIterator's non-nil reqAdapter requirement for tests with no next
+// link; Send is never expected to be called in that case.
+func noopAdapter() *stubAdapter {
+	return &stubAdapter{sendFn: func() (absser.Parsable, error) {
+		panic("adapter should not be called when there is no next link")
+	}}
+}
+
 func TestPageIterator_EmptyResponse(t *testing.T) {
 	// nil value and an empty slice are both valid; both should yield zero items.
 	for _, items := range [][]models.ServicePrincipalable{nil, {}} {
 		pi, err := graphcore.NewPageIterator[models.ServicePrincipalable](
-			newPage(items, nil), nil,
+			newPage(items, nil), noopAdapter(),
 			models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
 		)
 		require.NoError(t, err)
@@ -72,7 +80,7 @@ func TestPageIterator_EmptyResponse(t *testing.T) {
 func TestPageIterator_RegularPrincipalOnly(t *testing.T) {
 	sp := models.NewServicePrincipal()
 	pi, err := graphcore.NewPageIterator[models.ServicePrincipalable](
-		newPage([]models.ServicePrincipalable{sp}, nil), nil,
+		newPage([]models.ServicePrincipalable{sp}, nil), noopAdapter(),
 		models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
 	)
 	require.NoError(t, err)
@@ -95,7 +103,7 @@ func TestPageIterator_RegularPrincipalOnly(t *testing.T) {
 func TestPageIterator_NoPanicWithSubtype(t *testing.T) {
 	agent := models.NewAgentIdentityBlueprintPrincipal()
 	pi, err := graphcore.NewPageIterator[models.ServicePrincipalable](
-		newPage([]models.ServicePrincipalable{agent}, nil), nil,
+		newPage([]models.ServicePrincipalable{agent}, nil), noopAdapter(),
 		models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
 	)
 	require.NoError(t, err)
@@ -115,7 +123,7 @@ func TestPageIterator_MixedTypes(t *testing.T) {
 	agent := models.NewAgentIdentityBlueprintPrincipal()
 	regular := models.NewServicePrincipal()
 	pi, err := graphcore.NewPageIterator[models.ServicePrincipalable](
-		newPage([]models.ServicePrincipalable{agent, regular}, nil), nil,
+		newPage([]models.ServicePrincipalable{agent, regular}, nil), noopAdapter(),
 		models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
 	)
 	require.NoError(t, err)

--- a/internal/resources/providers/msgraph/provider_test.go
+++ b/internal/resources/providers/msgraph/provider_test.go
@@ -19,47 +19,188 @@ package msgraph
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	abstractions "github.com/microsoft/kiota-abstractions-go"
+	absser "github.com/microsoft/kiota-abstractions-go/serialization"
 	graphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
 	"github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestPageIterator_ServicePrincipalable_NoPanicWithSubtype is the targeted regression test.
-// The MS Graph API returns AgentIdentityBlueprintPrincipal objects on tenants
-// with Microsoft 365 Copilot/Agents. The old PageIterator[*ServicePrincipal] panicked because
-// its internal convertToPage does value.Index(i).Interface().(*ServicePrincipal) — an unsafe
+// stubAdapter is a minimal RequestAdapter for pagination tests. It only implements Send;
+// all other methods are satisfied by the embedded interface (calling them would panic,
+// but pagination only requires Send).
+type stubAdapter struct {
+	abstractions.RequestAdapter
+	sendFn func() (absser.Parsable, error)
+}
+
+func (s *stubAdapter) Send(_ context.Context, _ *abstractions.RequestInformation, _ absser.ParsableFactory, _ abstractions.ErrorMappings) (absser.Parsable, error) {
+	return s.sendFn()
+}
+
+func newPage(items []models.ServicePrincipalable, nextLink *string) *models.ServicePrincipalCollectionResponse {
+	r := models.NewServicePrincipalCollectionResponse()
+	r.SetValue(items)
+	r.SetOdataNextLink(nextLink)
+	return r
+}
+
+func ptr(s string) *string { return &s }
+
+func TestPageIterator_EmptyResponse(t *testing.T) {
+	// nil value and an empty slice are both valid; both should yield zero items.
+	for _, items := range [][]models.ServicePrincipalable{nil, {}} {
+		pi, err := graphcore.NewPageIterator[models.ServicePrincipalable](
+			newPage(items, nil), nil,
+			models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
+		)
+		require.NoError(t, err)
+
+		var collected []models.ServicePrincipalable
+		require.NoError(t, pi.Iterate(context.Background(), func(item models.ServicePrincipalable) bool {
+			collected = append(collected, item)
+			return true
+		}))
+		assert.Empty(t, collected)
+	}
+}
+
+func TestPageIterator_RegularPrincipalOnly(t *testing.T) {
+	sp := models.NewServicePrincipal()
+	pi, err := graphcore.NewPageIterator[models.ServicePrincipalable](
+		newPage([]models.ServicePrincipalable{sp}, nil), nil,
+		models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
+	)
+	require.NoError(t, err)
+
+	var collected []models.ServicePrincipalable
+	require.NoError(t, pi.Iterate(context.Background(), func(item models.ServicePrincipalable) bool {
+		collected = append(collected, item)
+		return true
+	}))
+	require.Len(t, collected, 1)
+	assert.IsType(t, sp, collected[0])
+}
+
+// TestPageIterator_NoPanicWithSubtype is a regression test.
+// AgentIdentityBlueprintPrincipal is a ServicePrincipal subtype provisioned automatically
+// on tenants with Microsoft 365 Copilot/Agents. PageIterator[*ServicePrincipal] panicked on
+// these items because convertToPage does value.Index(i).Interface().(T) — an unsafe type
 // assertion that fails when the concrete type is *AgentIdentityBlueprintPrincipal.
-//
-// Using PageIterator[ServicePrincipalable] instead makes the assertion succeed for any type
-// that satisfies the interface, including all current and future ServicePrincipal subtypes.
-func TestPageIterator_ServicePrincipalable_NoPanicWithSubtype(t *testing.T) {
-	agentPrincipal := models.NewAgentIdentityBlueprintPrincipal()
-	regularPrincipal := models.NewServicePrincipal()
-
-	response := models.NewServicePrincipalCollectionResponse()
-	response.SetValue([]models.ServicePrincipalable{agentPrincipal, regularPrincipal})
-
-	// nil adapter is safe when there is no @odata.nextLink (single page).
-	pageIterator, err := graphcore.NewPageIterator[models.ServicePrincipalable](
-		response,
-		nil,
+// PageIterator[ServicePrincipalable] succeeds for any type that satisfies the interface.
+func TestPageIterator_NoPanicWithSubtype(t *testing.T) {
+	agent := models.NewAgentIdentityBlueprintPrincipal()
+	pi, err := graphcore.NewPageIterator[models.ServicePrincipalable](
+		newPage([]models.ServicePrincipalable{agent}, nil), nil,
 		models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
 	)
 	require.NoError(t, err)
 
 	var collected []models.ServicePrincipalable
 	require.NotPanics(t, func() {
-		iterErr := pageIterator.Iterate(context.Background(), func(item models.ServicePrincipalable) bool {
+		require.NoError(t, pi.Iterate(context.Background(), func(item models.ServicePrincipalable) bool {
 			collected = append(collected, item)
 			return true
-		})
-		require.NoError(t, iterErr)
+		}))
 	})
+	require.Len(t, collected, 1)
+	assert.IsType(t, agent, collected[0])
+}
 
+func TestPageIterator_MixedTypes(t *testing.T) {
+	agent := models.NewAgentIdentityBlueprintPrincipal()
+	regular := models.NewServicePrincipal()
+	pi, err := graphcore.NewPageIterator[models.ServicePrincipalable](
+		newPage([]models.ServicePrincipalable{agent, regular}, nil), nil,
+		models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
+	)
+	require.NoError(t, err)
+
+	var collected []models.ServicePrincipalable
+	require.NoError(t, pi.Iterate(context.Background(), func(item models.ServicePrincipalable) bool {
+		collected = append(collected, item)
+		return true
+	}))
 	require.Len(t, collected, 2)
-	assert.IsType(t, agentPrincipal, collected[0], "first item should be *AgentIdentityBlueprintPrincipal")
-	assert.IsType(t, regularPrincipal, collected[1], "second item should be *ServicePrincipal")
+	assert.IsType(t, agent, collected[0])
+	assert.IsType(t, regular, collected[1])
+}
+
+// TestPageIterator_Pagination_SubtypeOnSecondPage verifies the fix holds across page
+// boundaries. convertToPage is called for every fetched page, so a subtype on page 2
+// would also have triggered the original panic.
+func TestPageIterator_Pagination_SubtypeOnSecondPage(t *testing.T) {
+	sp := models.NewServicePrincipal()
+	agent := models.NewAgentIdentityBlueprintPrincipal()
+
+	adapter := &stubAdapter{sendFn: func() (absser.Parsable, error) {
+		return newPage([]models.ServicePrincipalable{agent}, nil), nil
+	}}
+	page1 := newPage([]models.ServicePrincipalable{sp}, ptr("https://graph.microsoft.com/v1.0/servicePrincipals?$skiptoken=X"))
+
+	pi, err := graphcore.NewPageIterator[models.ServicePrincipalable](
+		page1, adapter,
+		models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
+	)
+	require.NoError(t, err)
+
+	var collected []models.ServicePrincipalable
+	require.NoError(t, pi.Iterate(context.Background(), func(item models.ServicePrincipalable) bool {
+		collected = append(collected, item)
+		return true
+	}))
+	require.Len(t, collected, 2)
+	assert.IsType(t, sp, collected[0])
+	assert.IsType(t, agent, collected[1])
+}
+
+func TestPageIterator_Pagination_AdapterError(t *testing.T) {
+	sp := models.NewServicePrincipal()
+	adapter := &stubAdapter{sendFn: func() (absser.Parsable, error) {
+		return nil, errors.New("network error fetching page 2")
+	}}
+	page1 := newPage([]models.ServicePrincipalable{sp}, ptr("https://graph.microsoft.com/v1.0/servicePrincipals?$skiptoken=X"))
+
+	pi, err := graphcore.NewPageIterator[models.ServicePrincipalable](
+		page1, adapter,
+		models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
+	)
+	require.NoError(t, err)
+
+	var collected []models.ServicePrincipalable
+	err = pi.Iterate(context.Background(), func(item models.ServicePrincipalable) bool {
+		collected = append(collected, item)
+		return true
+	})
+	assert.ErrorContains(t, err, "network error fetching page 2")
+	assert.Len(t, collected, 1, "items from page 1 should have been collected before the error")
+}
+
+func TestPageIterator_EarlyStop(t *testing.T) {
+	sp1, sp2 := models.NewServicePrincipal(), models.NewServicePrincipal()
+	// A next link is present to confirm that early stop also prevents the adapter from being called.
+	adapterCalled := false
+	adapter := &stubAdapter{sendFn: func() (absser.Parsable, error) {
+		adapterCalled = true
+		return newPage(nil, nil), nil
+	}}
+	page1 := newPage([]models.ServicePrincipalable{sp1, sp2}, ptr("https://graph.microsoft.com/v1.0/servicePrincipals?$skiptoken=X"))
+
+	pi, err := graphcore.NewPageIterator[models.ServicePrincipalable](
+		page1, adapter,
+		models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
+	)
+	require.NoError(t, err)
+
+	var collected []models.ServicePrincipalable
+	require.NoError(t, pi.Iterate(context.Background(), func(item models.ServicePrincipalable) bool {
+		collected = append(collected, item)
+		return false // stop after the first item
+	}))
+	assert.Len(t, collected, 1)
+	assert.False(t, adapterCalled, "adapter should not be called when iteration is stopped early")
 }

--- a/internal/resources/providers/msgraph/provider_test.go
+++ b/internal/resources/providers/msgraph/provider_test.go
@@ -184,7 +184,7 @@ func TestPageIterator_Pagination_AdapterError(t *testing.T) {
 		collected = append(collected, item)
 		return true
 	})
-	assert.ErrorContains(t, err, "network error fetching page 2")
+	require.ErrorContains(t, err, "network error fetching page 2")
 	assert.Len(t, collected, 1, "items from page 1 should have been collected before the error")
 }
 

--- a/internal/resources/providers/msgraph/provider_test.go
+++ b/internal/resources/providers/msgraph/provider_test.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package msgraph
+
+import (
+	"context"
+	"testing"
+
+	graphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
+	"github.com/microsoftgraph/msgraph-sdk-go/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPageIterator_ServicePrincipalable_NoPanicWithSubtype is the targeted regression test.
+// The MS Graph API returns AgentIdentityBlueprintPrincipal objects on tenants
+// with Microsoft 365 Copilot/Agents. The old PageIterator[*ServicePrincipal] panicked because
+// its internal convertToPage does value.Index(i).Interface().(*ServicePrincipal) — an unsafe
+// assertion that fails when the concrete type is *AgentIdentityBlueprintPrincipal.
+//
+// Using PageIterator[ServicePrincipalable] instead makes the assertion succeed for any type
+// that satisfies the interface, including all current and future ServicePrincipal subtypes.
+func TestPageIterator_ServicePrincipalable_NoPanicWithSubtype(t *testing.T) {
+	agentPrincipal := models.NewAgentIdentityBlueprintPrincipal()
+	regularPrincipal := models.NewServicePrincipal()
+
+	response := models.NewServicePrincipalCollectionResponse()
+	response.SetValue([]models.ServicePrincipalable{agentPrincipal, regularPrincipal})
+
+	// nil adapter is safe when there is no @odata.nextLink (single page).
+	pageIterator, err := graphcore.NewPageIterator[models.ServicePrincipalable](
+		response,
+		nil,
+		models.CreateServicePrincipalCollectionResponseFromDiscriminatorValue,
+	)
+	require.NoError(t, err)
+
+	var collected []models.ServicePrincipalable
+	require.NotPanics(t, func() {
+		iterErr := pageIterator.Iterate(context.Background(), func(item models.ServicePrincipalable) bool {
+			collected = append(collected, item)
+			return true
+		})
+		require.NoError(t, iterErr)
+	})
+
+	require.Len(t, collected, 2)
+	assert.IsType(t, agentPrincipal, collected[0], "first item should be *AgentIdentityBlueprintPrincipal")
+	assert.IsType(t, regularPrincipal, collected[1], "second item should be *ServicePrincipal")
+}


### PR DESCRIPTION
### Summary of your changes

PageIterator[*models.ServicePrincipal] used an unsafe type assertion (value.Index(i).Interface().(T)) that panics when the API returns *AgentIdentityBlueprintPrincipal - a subtype automatically provisioned by Microsoft 365 Copilot/Agents.
Changed the type parameter to the ServicePrincipalable interface, which all subtypes satisfy.

### Screenshot/Data
<!--
If this PR adds a new feature, please add an example screenshot or data (findings json for example).
-->


### Related Issues

- Related: https://github.com/elastic/seceng/issues/13877

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

#### Introducing a new rule?

- [ ] Generate rule metadata using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rules-metadata)
- [ ] Add relevant unit tests
- [ ] Generate relevant rule templates using [this script](https://github.com/elastic/cloudbeat/tree/main/security-policies/dev#generate-rule-templates), and open a PR in [elastic/packages/cloud_security_posture](https://github.com/elastic/integrations/tree/main/packages/cloud_security_posture)
