### PR TITLE
Fix EA workflow risk-score maintainer HTTP 500 by using sync run

### DIFF
--- a/.ci/scripts/install_entity_risk.sh
+++ b/.ci/scripts/install_entity_risk.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 #
 # Ensure Entity Store v2 is installed (public API), poll until running, init
-# maintainers, then POST risk-score maintainer run (internal API).
+# maintainers (idempotent), then POST risk-score maintainer sync run (internal API).
 #
 # Required: KIBANA_URL, ES_USER, ES_PASSWORD
 # Optional: ENTITY_STORE_STATUS_TIMEOUT_SEC (default 180), ENTITY_STORE_POLL_INTERVAL_SEC (default 5)
 #           RISK_SCORE_MAINTAINERS_MAX_ATTEMPTS (default 10), RISK_SCORE_MAINTAINERS_SLEEP_SEC (default 10)
+#           RISK_SCORE_MAINTAINER_SYNC_TIMEOUT_SEC (default 600) — curl max-time for sync run
 #
 # Requires: jq
 
@@ -24,10 +25,12 @@ readonly BASE="${KIBANA_URL%/}"
 readonly STATUS_URL="${BASE}/api/security/entity_store/status?apiVersion=2023-10-31"
 readonly INSTALL_URL="${BASE}/api/security/entity_store/install?apiVersion=2023-10-31"
 readonly INIT_URL="${BASE}/internal/security/entity_store/entity_maintainers/init?apiVersion=2"
-readonly RUN_URL="${BASE}/internal/security/entity_store/entity_maintainers/run/risk-score?apiVersion=2"
+readonly RUN_URL="${BASE}/internal/security/entity_store/entity_maintainers/run/risk-score?apiVersion=2&sync=true"
 
 readonly STATUS_FILE="${TMPDIR:-/tmp}/install_entity_risk_status.json"
 readonly CURL_COMMON=(--connect-timeout 10 --max-time 120 -sS)
+readonly SYNC_RUN_TIMEOUT_SEC="${RISK_SCORE_MAINTAINER_SYNC_TIMEOUT_SEC:-600}"
+readonly CURL_SYNC_RUN=(--connect-timeout 10 --max-time "${SYNC_RUN_TIMEOUT_SEC}" -sS)
 readonly POLL_TIMEOUT="${ENTITY_STORE_STATUS_TIMEOUT_SEC:-180}"
 readonly POLL_INTERVAL="${ENTITY_STORE_POLL_INTERVAL_SEC:-5}"
 
@@ -163,15 +166,17 @@ run_risk_score_maintainer() {
     local sleep_sec="${RISK_SCORE_MAINTAINERS_SLEEP_SEC:-10}"
     local attempt=1 http_code body_preview
 
+    # Sync run executes scoring inline (avoids Task Manager runSoon race after install).
+    # HTTP 500 is fail-fast: indicates a server/scoring error, not a transient TM conflict.
     while [[ "${attempt}" -le "${max_attempts}" ]]; do
-        echo "Risk-score maintainer run: attempt ${attempt}/${max_attempts} POST ${RUN_URL}"
+        echo "Risk-score maintainer sync run: attempt ${attempt}/${max_attempts} POST ${RUN_URL} (timeout ${SYNC_RUN_TIMEOUT_SEC}s)"
         http_code="$(
-            curl_auth -X POST "${INTERNAL_HEADERS[@]}" -d '{}' \
+            curl "${CURL_SYNC_RUN[@]}" -u "${ES_USER}:${ES_PASSWORD}" -X POST "${INTERNAL_HEADERS[@]}" -d '{}' \
                 -o "${run_out}" -w "%{http_code}" "${RUN_URL}" || echo "000"
         )"
 
         if [[ "${http_code}" == "200" || "${http_code}" == "201" || "${http_code}" == "204" ]]; then
-            echo "Risk-score maintainer run succeeded (HTTP ${http_code})"
+            echo "Risk-score maintainer sync run succeeded (HTTP ${http_code})"
             head -c 2000 "${run_out}" 2>/dev/null || true
             echo
             return 0
@@ -181,17 +186,17 @@ run_risk_score_maintainer() {
         echo "HTTP ${http_code} response preview: ${body_preview}"
 
         if [[ "${http_code}" == "502" || "${http_code}" == "503" || "${http_code}" == "504" || "${http_code}" == "000" ]]; then
-            echo "Transient error; sleeping ${sleep_sec}s before retry"
+            echo "Transient gateway/connection error; sleeping ${sleep_sec}s before retry"
             sleep "${sleep_sec}"
             attempt=$((attempt + 1))
             continue
         fi
 
-        echo "Risk-score maintainer run failed (non-retryable HTTP ${http_code})" >&2
+        echo "Risk-score maintainer sync run failed (non-retryable HTTP ${http_code})" >&2
         exit 1
     done
 
-    echo "Risk-score maintainer run failed after ${max_attempts} attempts" >&2
+    echo "Risk-score maintainer sync run failed after ${max_attempts} attempts" >&2
     exit 1
 }
 

--- a/.ci/scripts/install_entity_risk.sh
+++ b/.ci/scripts/install_entity_risk.sh
@@ -29,7 +29,13 @@ readonly RUN_URL="${BASE}/internal/security/entity_store/entity_maintainers/run/
 
 readonly STATUS_FILE="${TMPDIR:-/tmp}/install_entity_risk_status.json"
 readonly CURL_COMMON=(--connect-timeout 10 --max-time 120 -sS)
-readonly SYNC_RUN_TIMEOUT_SEC="${RISK_SCORE_MAINTAINER_SYNC_TIMEOUT_SEC:-600}"
+
+_sync_timeout_raw="${RISK_SCORE_MAINTAINER_SYNC_TIMEOUT_SEC:-600}"
+if [[ ! "${_sync_timeout_raw}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "install_entity_risk.sh: RISK_SCORE_MAINTAINER_SYNC_TIMEOUT_SEC must be a positive integer (got '${_sync_timeout_raw}')" >&2
+    exit 1
+fi
+readonly SYNC_RUN_TIMEOUT_SEC="${_sync_timeout_raw}"
 readonly CURL_SYNC_RUN=(--connect-timeout 10 --max-time "${SYNC_RUN_TIMEOUT_SEC}" -sS)
 readonly POLL_TIMEOUT="${ENTITY_STORE_STATUS_TIMEOUT_SEC:-180}"
 readonly POLL_INTERVAL="${ENTITY_STORE_POLL_INTERVAL_SEC:-5}"

--- a/.github/actions/elk-stack/action.yml
+++ b/.github/actions/elk-stack/action.yml
@@ -29,15 +29,10 @@ inputs:
     default: "latest"
     type: string
     required: false
-  kibana-security-solution-experimental:
-    description: "ESS only: Apply Entity Store v2 and Entity Analytics Feature flags (new home, watchlist, etc)"
+  kibana-enable-entity-analytics-settings:
+    description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents feature flag, Agent Builder experimental UI)"
     type: boolean
     default: true
-    required: false
-  kibana-enable-entity-analytics-settings:
-    description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents, Agent Builder, Entity Store v2 UI, experimental flags)"
-    type: boolean
-    default: false
     required: false
   elasticsearch-ml-enabled:
     description: "ESS only: Provision Elasticsearch ML nodes on the deployment"
@@ -99,7 +94,6 @@ runs:
         TF_VAR_ess_region: ${{ inputs.ess-region }}
         TF_VAR_ec_url: ${{ inputs.ec-url }}
         TF_VAR_pin_version: ${{ inputs.docker-image-version-override }}
-        TF_VAR_kibana_security_solution_experimental: ${{ inputs.kibana-security-solution-experimental }}
         TF_VAR_kibana_enable_entity_analytics_settings: ${{ inputs.kibana-enable-entity-analytics-settings }}
         TF_VAR_elasticsearch_ml_enabled: ${{ inputs.elasticsearch-ml-enabled }}
         TF_VAR_kibana_instance_size: ${{ inputs.kibana-instance-size }}

--- a/.github/workflows/cdr-infra.yml
+++ b/.github/workflows/cdr-infra.yml
@@ -33,8 +33,8 @@ on:
         description: "Number of days until environment expiration"
         required: false
         default: "5"
-      kibana_security_solution_experimental:
-        description: "ESS only: Apply Entity Store v2 and Entity Analytics Feature flags (new home, watchlist, etc)"
+      kibana_enable_entity_analytics_settings:
+        description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents feature flag, Agent Builder experimental UI)"
         type: boolean
         required: false
         default: true
@@ -75,5 +75,5 @@ jobs:
       serverless_mode: ${{ fromJSON(inputs.serverless_mode) }}
       infra-type: ${{ needs.init.outputs.infra-type }}
       expiration_days: ${{ inputs.expiration-days }}
-      kibana_security_solution_experimental: ${{ inputs.kibana_security_solution_experimental }}
+      kibana_enable_entity_analytics_settings: ${{ inputs.kibana_enable_entity_analytics_settings }}
       enable-entity-store-v2: ${{ fromJSON(inputs.enable-entity-store-v2) }}

--- a/.github/workflows/create-env-ea.yml
+++ b/.github/workflows/create-env-ea.yml
@@ -154,7 +154,6 @@ jobs:
           ess-region: ${{ env.ESS_REGION }}
           ec-api-key: ${{ env.TF_VAR_ec_api_key }}
           ec-url: ${{ env.EC_URL }}
-          kibana-security-solution-experimental: false
           kibana-enable-entity-analytics-settings: true
           kibana-instance-size: ${{ inputs.kibana_instance_size }}
           elasticsearch-ml-enabled: true

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -37,8 +37,8 @@ on:
         required: false
         description: "Provide the full Docker image path to override the default image (e.g. for testing BC/SNAPSHOT)"
         type: string
-      kibana_security_solution_experimental:
-        description: "ESS only: Apply Entity Store v2 and Entity Analytics Feature flags (new home, watchlist, etc)"
+      kibana_enable_entity_analytics_settings:
+        description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents feature flag, Agent Builder experimental UI)"
         type: boolean
         required: false
         default: true
@@ -89,8 +89,8 @@ on:
         required: false
         description: "Provide the full Docker image path to override the default image (e.g. for testing BC/SNAPSHOT)"
         type: string
-      kibana_security_solution_experimental:
-        description: "ESS only: Apply Entity Store v2 and Entity Analytics Feature flags (new home, watchlist, etc)"
+      kibana_enable_entity_analytics_settings:
+        description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents feature flag, Agent Builder experimental UI)"
         type: boolean
         required: false
         default: true
@@ -410,7 +410,7 @@ jobs:
           ec-api-key: ${{ env.TF_VAR_ec_api_key }}
           ec-url: ${{ env.EC_URL }}
           docker-image-version-override: ${{ env.TF_VAR_pin_version }}
-          kibana-security-solution-experimental: ${{ inputs.kibana_security_solution_experimental }}
+          kibana-enable-entity-analytics-settings: ${{ inputs.kibana_enable_entity_analytics_settings }}
           kibana-instance-size: "4g"
           env-s3-bucket: "${{ env.S3_BASE_BUCKET }}/${{ env.DEPLOYMENT_NAME }}_${{ env.TF_STATE_FOLDER }}"
           tag-project: ${{ github.actor }}

--- a/deploy/test-environments/elk-stack/main.tf
+++ b/deploy/test-environments/elk-stack/main.tf
@@ -68,7 +68,7 @@ module "ec_deployment" {
   }
 
   kibana_enable_entity_analytics_settings = var.kibana_enable_entity_analytics_settings
-  kibana_instance_size                         = var.kibana_instance_size
+  kibana_instance_size                    = var.kibana_instance_size
 }
 
 module "ec_project" {

--- a/deploy/test-environments/elk-stack/main.tf
+++ b/deploy/test-environments/elk-stack/main.tf
@@ -67,8 +67,7 @@ module "ec_deployment" {
     "apm"           = ""
   }
 
-  kibana_enable_security_solution_experimental = var.kibana_security_solution_experimental
-  kibana_enable_entity_analytics_settings      = var.kibana_enable_entity_analytics_settings
+  kibana_enable_entity_analytics_settings = var.kibana_enable_entity_analytics_settings
   kibana_instance_size                         = var.kibana_instance_size
 }
 

--- a/deploy/test-environments/elk-stack/variables.tf
+++ b/deploy/test-environments/elk-stack/variables.tf
@@ -34,15 +34,9 @@ variable "serverless_mode" {
   type        = bool
 }
 
-variable "kibana_security_solution_experimental" {
-  default     = true
-  description = "When true (ESS only), apply Kibana user_settings_yaml for Security Solution experimental flags"
-  type        = bool
-}
-
 variable "kibana_enable_entity_analytics_settings" {
-  default     = false
-  description = "When true (ESS only), apply Kibana user_settings_yaml for Entity Analytics (EA) feature flags and UI overrides"
+  default     = true
+  description = "When true (ESS only), apply Kibana user_settings_yaml for Entity Analytics (AI agents feature flag, Agent Builder experimental UI)"
   type        = bool
 }
 

--- a/deploy/test-environments/modules/ec/main.tf
+++ b/deploy/test-environments/modules/ec/main.tf
@@ -10,39 +10,20 @@ locals {
   apm_docker_image                 = lookup(var.docker_image, "apm", "")
   apm_docker_image_tag_override    = lookup(var.docker_image_tag_override, "apm", "")
 
-  security_solution_experimental_yaml = <<-EOT
-xpack.securitySolution.enableExperimental:
-  - entityAnalyticsEntityStoreV2
-  - entityAnalyticsWatchlistEnabled
-  - entityAnalyticsNewHomePageEnabled
-  - leadGenerationEnabled
-EOT
-
-  # Entity Analytics (EA): AI agents, Agent Builder, Entity Store v2 UI, expanded experimental flags.
+  # Entity Analytics: AI agents and Agent Builder experimental UI (ESS user_settings_yaml).
   entity_analytics_yaml = <<-EOT
 feature_flags.overrides:
   aiAssistant.aiAgents.enabled: true
 
 uiSettings.overrides:
   "agentBuilder:experimentalFeatures": true
-  "securitySolution:entityStoreEnableV2": true
-
-xpack.securitySolution.enableExperimental:
-  - entityAnalyticsNewHomePageEnabled
-  - entityAnalyticsWatchlistEnabled
-  - securitySolution:entityStoreEnableV2
-  - entityAnalyticsEntityStoreV2
-  - leadGenerationEnabled
 EOT
 
   kibana_docker_config = local.kibana_docker_image_tag_override != "" ? {
     docker_image = "${local.kibana_docker_image}:${local.kibana_docker_image_tag_override}"
   } : {}
 
-  # EA settings supersede the smaller experimental-only block when enabled.
-  kibana_user_settings_yaml = var.kibana_enable_entity_analytics_settings ? local.entity_analytics_yaml : (
-    var.kibana_enable_security_solution_experimental ? local.security_solution_experimental_yaml : ""
-  )
+  kibana_user_settings_yaml = var.kibana_enable_entity_analytics_settings ? local.entity_analytics_yaml : ""
 
   kibana_experimental_config = local.kibana_user_settings_yaml != "" ? {
     user_settings_yaml = local.kibana_user_settings_yaml

--- a/deploy/test-environments/modules/ec/variables.tf
+++ b/deploy/test-environments/modules/ec/variables.tf
@@ -91,16 +91,10 @@ variable "docker_image" {
   description = "Optional docker image overrides. The full map needs to be specified"
 }
 
-variable "kibana_enable_security_solution_experimental" {
-  type        = bool
-  default     = true
-  description = "When true, set Kibana user_settings_yaml with Security Solution experimental feature flags (ESS only)"
-}
-
 variable "kibana_enable_entity_analytics_settings" {
   type        = bool
-  default     = false
-  description = "When true (ESS only), set Kibana user_settings_yaml for Entity Analytics (feature flags, uiSettings, enableExperimental)"
+  default     = true
+  description = "When true (ESS only), set Kibana user_settings_yaml for Entity Analytics (AI agents feature flag, Agent Builder experimental UI)"
 }
 
 variable "kibana_instance_size" {

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -161,7 +161,7 @@ The workflow requires a subset of input parameters. All required inputs are desc
    - **`docker-image-override`**: optional docker image override for agent installs (mostly for BC/SNAPSHOT testing).
    - **`expiration-days`**: how long the environment should be kept before cleanup. Default is `5`.
    - **`cis-infra`**: optional. When `true`, also deploy CIS infrastructure (`infra_type=all`). When `false`, CDR only (`infra_type=cdr`).
-   - **`kibana_security_solution_experimental`** (ESS only): when `true`, applies Kibana `user_settings_yaml` with Entity Analytics feature flags and calls the internal Kibana settings API to enable and install Entity Store v2. Default is `true`.
+   - **`kibana_enable_entity_analytics_settings`** (ESS only): when `true`, applies Kibana `user_settings_yaml` with Entity Analytics settings (AI agents feature flag, Agent Builder experimental UI). Default is `true`. Entity Store install is separate — see **`enable-entity-store-v2`** (CDR) or the EA workflow's entity store script.
    - **`enable-entity-store-v2`**: when `true`, the workflow installs **Entity Store v2** (v2 installer script). When `false`, it installs **Entity Store v1 only**. Default is `true`.
 
 3. Click **Run workflow** and wait for completion.
@@ -173,7 +173,7 @@ The workflow requires a subset of input parameters. All required inputs are desc
 
 ## Create Environment (Entity Analytics)
 
-The [`create-env-ea`](https://github.com/elastic/cloudbeat/actions/workflows/create-env-ea.yml) workflow is a standalone manual dispatch that provisions an **ESS** stack in **production-cft**, applies **Entity Analytics (EA)** Kibana `user_settings_yaml` (AI Agents feature flag, Agent Builder experimental UI, Entity Store v2 UI settings, and expanded `xpack.securitySolution.enableExperimental` entries), then checks out [`elastic/security-documents-generator`](https://github.com/elastic/security-documents-generator) at **`main`**, and runs correlated organization data at **enterprise** size with **Google** productivity suite, **all** integrations, and **detection rules**. It does not install CIS or CDR cloud infrastructure.
+The [`create-env-ea`](https://github.com/elastic/cloudbeat/actions/workflows/create-env-ea.yml) workflow is a standalone manual dispatch that provisions an **ESS** stack in **production-cft**, applies **Entity Analytics (EA)** Kibana `user_settings_yaml` (AI agents feature flag and Agent Builder experimental UI), then checks out [`elastic/security-documents-generator`](https://github.com/elastic/security-documents-generator) at **`main`**, and runs correlated organization data at **enterprise** size with **Google** productivity suite, **all** integrations, and **detection rules**. It also installs Entity Store v2 and runs the risk-score maintainer via `install_entity_risk.sh`. It does not install CIS or CDR cloud infrastructure.
 
 ### Inputs (summary)
 


### PR DESCRIPTION
## Summary

Fixes the **Create EA Environment** workflow failure in the *Install entity store and run risk-score maintainer* step. The script now calls the risk-score maintainer with `sync=true`, matching Kibana FTR behavior, instead of the async `runSoon` path that races with Task Manager after entity store install.

## Problem

After entity store install and maintainer init succeed, the workflow failed on the first attempt to run the risk-score maintainer:

`Risk-score maintainer run failed (non-retryable HTTP 500)`


Entity store install already schedules maintainers with `autoStart: true` (Kibana #263732). The script then triggered an **async** run (`POST .../run/risk-score` without `sync=true`), which calls `taskManager.runSoon()` and can conflict with Task Manager's auto-run, producing a generic HTTP 500.

## Solution

- Use **synchronous** maintainer run: `.../run/risk-score?apiVersion=2&sync=true`
- Use a **600s** curl timeout for the sync run (Kibana allows up to 10 minutes); keep 120s for status/install/init
- Add optional env var `RISK_SCORE_MAINTAINER_SYNC_TIMEOUT_SEC` (default 600)
- Keep `POST init` as idempotent safety for the already-running (skip-install) path
- Retry only gateway/connection errors (502/503/504/000); fail fast on HTTP 500 (real scoring error with sync mode)

## Test plan

- [x] Re-run **Create EA Environment** (`create-env-ea.yml`) on `9.5.0-SNAPSHOT` (or the version that previously failed)
- [x] Confirm step logs show `sync=true` and `Risk-score maintainer sync run succeeded (HTTP 200)`
