### PR TITLE
Fix Okta Fleet package policy for CDR Create Environment workflow

### DIFF
--- a/tests/integrations_setup/data/okta-pkg.json
+++ b/tests/integrations_setup/data/okta-pkg.json
@@ -9,6 +9,9 @@
   "name": "",
   "description": "",
   "namespace": "default",
+  "var_group_selections": {
+    "auth_method": "api_key"
+  },
   "inputs": {
     "okta-httpjson": {
       "enabled": true,
@@ -17,23 +20,17 @@
         "initial_interval": "24h",
         "url": "",
         "api_key": "",
-        "okta_scopes": [
-          "okta.logs.read"
+        "enable_request_tracer": false,
+        "tags": [
+          "forwarded",
+          "okta-system"
         ],
-        "enable_request_tracer": false
+        "preserve_original_event": false,
+        "disable_keep_alive": false
       },
       "streams": {
         "okta.system": {
-          "enabled": true,
-          "vars": {
-            "tags": [
-              "forwarded",
-              "okta-system"
-            ],
-            "preserve_original_event": false,
-            "disable_keep_alive": false,
-            "limit": 1000
-          }
+          "enabled": true
         }
       }
     }


### PR DESCRIPTION

**Changes in `tests/integrations_setup/data/okta-pkg.json`:**
- Add `var_group_selections.auth_method: "api_key"` (matches CDR API-key auth)
- Move `tags`, `preserve_original_event`, and `disable_keep_alive` to input-level vars
- Leave `okta.system` stream with `enabled: true` only
- Drop `limit` (hidden in default/agent deployment mode; manifest default applies)
- Drop `okta_scopes` (OAuth2/OIN only; not used for API-key auth)

No changes to `install_okta_integration.py` — it already patches `url` and `api_key` at the input level.

### Screenshot/Data

N/A

### Related Issues

N/A

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

### Test plan

- [ ] Re-run CDR workflow with `OKTA_LOGS_URL` and `OKTA_API_KEY` configured
- [ ] Confirm `install_okta_integration.py` completes and logs `Package policy '...' created successfully`
- [ ] Confirm `install_entityanalytics_okta_integration.py` still passes (unchanged)