### PR TITLE
fix: bump main to next minor after minor branch-out

### DIFF
--- a/.buildkite/scripts/release/common.sh
+++ b/.buildkite/scripts/release/common.sh
@@ -52,6 +52,16 @@ update_arm_templates() {
     fi
 }
 
+# next_minor_version <version>
+# Given "X.Y.Z", returns the next minor version "X.(Y+1).0".
+next_minor_version() {
+    local version="$1"
+    local major minor
+    major=$(echo "${version}" | cut -d. -f1)
+    minor=$(echo "${version}" | cut -d. -f2)
+    echo "${major}.$((minor + 1)).0"
+}
+
 # render_template <path>
 # Expands ${VAR} references in a template file using the caller's environment.
 render_template() {

--- a/.buildkite/scripts/release/post-minor-merge.sh
+++ b/.buildkite/scripts/release/post-minor-merge.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 # Runs after the minor version bump PR is merged into main.
-# Performs two operations:
+# Performs three operations:
 #   1. Branch-out: create and push the new X.Y release branch from main
-#   2. Hermit PR: sync CLOUDBEAT_VERSION in bin/hermit.hcl to match version.go
+#   2. Main bump: advance main's version to the next minor (e.g. 9.5.0 -> 9.6.0)
+#   3. Hermit PR: sync CLOUDBEAT_VERSION in bin/hermit.hcl to match version.go
 #
 # Required env vars:
 #   BRANCH      — new minor branch name (e.g. 9.3)
@@ -23,15 +24,18 @@ source "${SCRIPT_DIR}/common.sh"
 GH_REPO="elastic/${REPO}"
 DRY_RUN="${DRY_RUN:-false}"
 HERMIT_BRANCH="sync-cloudbeat-version-$(date +%s)"
+NEXT_MAIN_VERSION=$(next_minor_version "${NEW_VERSION}")
+BUMP_MAIN_BRANCH="bump-to-${NEXT_MAIN_VERSION}"
 
 git fetch origin main
 git checkout main
 
 echo "--- Post-minor-merge parameters"
-echo "  REPO:        ${REPO}"
-echo "  BRANCH:      ${BRANCH}"
-echo "  NEW_VERSION: ${NEW_VERSION}"
-echo "  DRY_RUN:     ${DRY_RUN}"
+echo "  REPO:              ${REPO}"
+echo "  BRANCH:            ${BRANCH}"
+echo "  NEW_VERSION:       ${NEW_VERSION}"
+echo "  NEXT_MAIN_VERSION: ${NEXT_MAIN_VERSION}"
+echo "  DRY_RUN:           ${DRY_RUN}"
 
 setup_git_identity
 
@@ -50,6 +54,58 @@ branch_out() {
 
     git checkout -b "${BRANCH}"
     git push origin "${BRANCH}"
+    git checkout main
+}
+
+bump_main_to_next_minor() {
+    echo "--- Bumping main to next minor version ${NEXT_MAIN_VERSION}"
+
+    local existing_pr
+    existing_pr=$(gh pr list --repo "${GH_REPO}" --head "${BUMP_MAIN_BRANCH}" --state open \
+        --json number --jq '.[0].number' 2>/dev/null || echo "")
+    if [[ -n "${existing_pr}" ]]; then
+        echo "PR #${existing_pr} already open for ${BUMP_MAIN_BRANCH} — skipping."
+        return
+    fi
+
+    git checkout -b "${BUMP_MAIN_BRANCH}" origin/main
+
+    NEXT_CLOUDBEAT_VERSION="${NEXT_MAIN_VERSION}"
+    echo "  NEXT_CLOUDBEAT_VERSION: ${NEXT_CLOUDBEAT_VERSION}"
+    update_version_beat
+    update_arm_templates "${NEXT_MAIN_VERSION}"
+
+    if git diff --quiet origin/main HEAD; then
+        echo "main is already at ${NEXT_MAIN_VERSION} — skipping."
+        git checkout main
+        return
+    fi
+
+    local body
+    body=$(render_template "${SCRIPT_DIR}/templates/pr-body-bump-main.md")
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        echo "--- Dry run: skipping push and PR creation"
+        gh pr create \
+            --repo "${GH_REPO}" \
+            --head "${BUMP_MAIN_BRANCH}" \
+            --base main \
+            --title "Bump cloudbeat version to ${NEXT_MAIN_VERSION}" \
+            --body "${body}" \
+            --label "backport-skip" \
+            --dry-run
+        git checkout main
+        return
+    fi
+
+    git push origin "${BUMP_MAIN_BRANCH}"
+    gh pr create \
+        --repo "${GH_REPO}" \
+        --head "${BUMP_MAIN_BRANCH}" \
+        --base main \
+        --title "Bump cloudbeat version to ${NEXT_MAIN_VERSION}" \
+        --body "${body}" \
+        --label "backport-skip"
     git checkout main
 }
 
@@ -93,4 +149,5 @@ hermit_pr() {
 }
 
 branch_out
+bump_main_to_next_minor
 hermit_pr

--- a/.buildkite/scripts/release/templates/pr-body-bump-main.md
+++ b/.buildkite/scripts/release/templates/pr-body-bump-main.md
@@ -1,0 +1,3 @@
+Bump cloudbeat version to `${NEXT_MAIN_VERSION}`
+
+Automated follow-up to the `${BRANCH}` branch-out: advances `main` to the next minor version.


### PR DESCRIPTION
## Summary

Prep for the Jul 07 minor FF ([context](https://elastic.slack.com/archives/C0JFN9HJL/p1780580577798249)): release-eng will trigger our pipeline with `WORKFLOW=minor BRANCH=9.5 NEW_VERSION=9.5.0` — `NEW_VERSION` is the version for the **new branch**, not for `main`, so each team owns bumping `main` to the next minor themselves.

`main` is already on `9.5.0`. Today's `post-minor-merge.sh` only branches out `9.5` and syncs `hermit.hcl` — nothing advances `main` afterward, so it would stay on `9.5.0` indefinitely. (Confirmed this isn't hypothetical: two ad-hoc "Bump to 9.6.0" PRs from the previous cycle, #5608/#5609, were closed unmerged.)

- Add `next_minor_version()` semver helper to `common.sh`
- Add `bump_main_to_next_minor` step to `post-minor-merge.sh`, run **after** branch-out (so `9.5` is cut while `main` is still `9.5.0`) and before the hermit sync — opens a `Bump cloudbeat version to 9.6.0` PR, same convention as prior manual bumps
- Add matching PR body template

## Test plan

- [x] Dry-run verified end-to-end against a scratch clone with `WORKFLOW=minor BRANCH=9.5 NEW_VERSION=9.5.0 DRY_RUN=true` — correct sequencing, semver math (`9.5.0` → `9.6.0`), commit messages, and PR body
- [x] Verified idempotent skip when a bump PR is already open / main already at target version
- [ ] Confirm `backport-v9.5.0` label is created in the repo before the FF (separate manual step, not covered here)
- [ ] Real run against a fork with `gh` to validate actual PR creation

Made with [Cursor](https://cursor.com)