### PR TITLE
fix: make version bump scripts idempotent on retrigger

### DIFF
--- a/.buildkite/scripts/release/bump-minor.sh
+++ b/.buildkite/scripts/release/bump-minor.sh
@@ -71,6 +71,11 @@ run_minor_bump() {
     update_arm_templates "${NEXT_CLOUDBEAT_VERSION}"
     update_mergify
 
+    if no_new_commits origin/main; then
+        echo "main is already at ${NEXT_CLOUDBEAT_VERSION} and mergify rule for ${BRANCH} already exists — nothing to bump."
+        return
+    fi
+
     local body
     body=$(render_template "${SCRIPT_DIR}/templates/pr-body-minor.md")
 

--- a/.buildkite/scripts/release/bump-patch.sh
+++ b/.buildkite/scripts/release/bump-patch.sh
@@ -43,6 +43,11 @@ run_patch_bump() {
 
     update_version_beat
 
+    if no_new_commits "origin/${BASE_BRANCH}"; then
+        echo "${BASE_BRANCH} is already at ${NEXT_CLOUDBEAT_VERSION} — nothing to bump."
+        return
+    fi
+
     local body
     body=$(render_template "${SCRIPT_DIR}/templates/pr-body-patch.md")
 

--- a/.buildkite/scripts/release/common.sh
+++ b/.buildkite/scripts/release/common.sh
@@ -52,6 +52,15 @@ update_arm_templates() {
     fi
 }
 
+# no_new_commits <base_ref>
+# Returns 0 (true) if HEAD has no changes relative to <base_ref>, i.e. the
+# preceding update_* calls found nothing to bump. Callers should skip
+# push/PR creation in that case — a branch identical to its base has no
+# commits for `gh pr create` to open a PR with.
+no_new_commits() {
+    git diff --quiet "$1" HEAD
+}
+
 # render_template <path>
 # Expands ${VAR} references in a template file using the caller's environment.
 render_template() {


### PR DESCRIPTION
## Summary

Raised by Julien in [#mission-control](https://elastic.slack.com/archives/C0JFN9HJL/p1783094800245129): retriggering the centralized version bump pipeline for an already-completed bump (9.4.4 / 9.3.8 / 8.19.19) failed instead of succeeding as a no-op.

**Root cause:** `pr_exists()` only checks for *open* PRs. Once the original bump PR merges, a retrigger sails past that guard, `update_version_beat` correctly finds no diff and skips the commit, but the script then unconditionally tries to push and `gh pr create` anyway. A branch identical to its base has nothing to open a PR with, so GitHub rejects it with "No commits between X and Y" and the script exits non-zero.

Confirmed against the real repo state (`9.4`/`9.3`/`8.19` are already at the reported versions, and their bump PRs are already merged) that this is exactly the failure condition.

- Add a shared `no_new_commits()` helper to `common.sh`
- Use it in `bump-patch.sh` and `bump-minor.sh` to skip push/PR creation cleanly (exit 0) when there's nothing to bump

## Test plan

- [x] Reproduced Julien's exact scenario for `9.4`→`9.4.4`, `9.3`→`9.3.8`, `8.19`→`8.19.19` against the real branches — all three now exit 0 with "already at X — nothing to bump" instead of failing
- [x] Verified a genuine new patch version (e.g. `9.4`→`9.4.5`) still produces a commit and PR as before

Made with [Cursor](https://cursor.com)