### PR TITLE
fix: prevent panic when RDS DB instance has a nil DBSubnetGroup

### DIFF
--- a/internal/resources/providers/awslib/rds/provider.go
+++ b/internal/resources/providers/awslib/rds/provider.go
@@ -87,6 +87,10 @@ func (p Provider) DescribeDBInstances(ctx context.Context) ([]awslib.AwsResource
 }
 
 func (p Provider) getDBInstanceSubnets(ctx context.Context, region string, dbInstance types.DBInstance) []Subnet {
+	if dbInstance.DBSubnetGroup == nil {
+		return []Subnet{}
+	}
+
 	results := make([]Subnet, 0, len(dbInstance.DBSubnetGroup.Subnets))
 	for _, subnet := range dbInstance.DBSubnetGroup.Subnets {
 		resultSubnet := Subnet{ID: *subnet.SubnetIdentifier, RouteTable: nil}

--- a/internal/resources/providers/awslib/rds/provider_test.go
+++ b/internal/resources/providers/awslib/rds/provider_test.go
@@ -135,6 +135,40 @@ func (s *ProviderTestSuite) TestProvider_DescribeDBInstances() {
 				},
 			},
 		},
+		{
+			// Regression test for https://github.com/elastic/seceng/issues/14066:
+			// AWS can return DB instances with a nil DBSubnetGroup (e.g. EC2-Classic
+			// instances or instances in certain transitional states), which used to
+			// cause a nil pointer dereference panic in getDBInstanceSubnets.
+			name: "Should not panic when a DB instance has no DBSubnetGroup",
+			rdsClientMockReturnVals: rdsClientMockReturnVals{
+				"DescribeDBInstances": {
+					awslib.DefaultRegion: {&rdsClient.DescribeDBInstancesOutput{
+						DBInstances: []types.DBInstance{
+							{
+								DBInstanceIdentifier:    &identifier,
+								DBInstanceArn:           &arn,
+								StorageEncrypted:        aws.Bool(false),
+								AutoMinorVersionUpgrade: aws.Bool(false),
+								PubliclyAccessible:      aws.Bool(false),
+								DBSubnetGroup:           nil,
+							},
+						},
+					}, nil},
+				},
+			},
+			expected: []awslib.AwsResource{
+				DBInstance{
+					Identifier:              identifier,
+					Arn:                     arn,
+					StorageEncrypted:        false,
+					AutoMinorVersionUpgrade: false,
+					PubliclyAccessible:      false,
+					Subnets:                 []Subnet{},
+					region:                  awslib.DefaultRegion,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary
- AWS can return `DescribeDBInstances` results with a nil `DBSubnetGroup` (e.g. for EC2-Classic instances or instances in certain transitional states). `getDBInstanceSubnets` unconditionally dereferenced `dbInstance.DBSubnetGroup.Subnets`, causing a nil pointer dereference panic that crashed cloudbeat's CSPM/asset-inventory AWS agent (observed as `likely-elastic-agent-integration-oom` alerts).
- Added a nil guard that returns an empty subnet list for instances without a `DBSubnetGroup`, matching existing behavior for instances with an empty subnet list.

Fixes elastic/seceng#14066

## Test plan
- [x] Added a regression test (`Should not panic when a DB instance has no DBSubnetGroup`) in `provider_test.go` covering a `DBInstance` with `DBSubnetGroup: nil`.
- [x] Verified the regression test reproduces the original panic when the fix is reverted (identical stack trace shape to the one in the issue).
- [x] `go test ./internal/resources/providers/awslib/...` passes.
- [x] `go build`, `go vet`, and `gofmt -l` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)