### PR TITLE
fix: detect stale bump branches and fail clearly before pushing

### DIFF
--- a/.buildkite/scripts/release/bump-minor.sh
+++ b/.buildkite/scripts/release/bump-minor.sh
@@ -65,6 +65,8 @@ EOF
 run_minor_bump() {
     pr_exists && return
 
+    fail_if_stale_remote_branch "${BUMP_BRANCH}"
+
     git checkout -b "${BUMP_BRANCH}" origin/main
 
     update_version_beat

--- a/.buildkite/scripts/release/bump-patch.sh
+++ b/.buildkite/scripts/release/bump-patch.sh
@@ -39,6 +39,8 @@ setup_git_identity
 run_patch_bump() {
     pr_exists && return
 
+    fail_if_stale_remote_branch "${BUMP_BRANCH}"
+
     git checkout -b "${BUMP_BRANCH}" "origin/${BASE_BRANCH}"
 
     update_version_beat

--- a/.buildkite/scripts/release/common.sh
+++ b/.buildkite/scripts/release/common.sh
@@ -61,6 +61,42 @@ no_new_commits() {
     git diff --quiet "$1" HEAD
 }
 
+# fail_if_stale_remote_branch <branch>
+# Exits with an actionable error if <branch> exists on origin from a
+# closed-but-unmerged PR (or no PR at all). Only call this after pr_exists
+# has confirmed there's no *open* PR for <branch> — a leftover branch like
+# that is treated by GitHub as already having required checks, and blocks a
+# fresh push with the same branch name ("4 of N required status checks are
+# expected"), even though nothing is actually using it anymore.
+#
+# A branch whose PR was *merged* is not stale — it's evidence this exact
+# bump already shipped, and no_new_commits() further down will correctly
+# detect there's nothing left to do. Only flag the unmerged case here.
+#
+# We don't delete it automatically — that needs a human to confirm it's
+# safe first — so this just fails clearly instead of letting the push fail
+# further down with a more confusing error.
+fail_if_stale_remote_branch() {
+    local branch="$1"
+
+    if ! git ls-remote --exit-code --heads origin "${branch}" >/dev/null 2>&1; then
+        return
+    fi
+
+    local merged_pr
+    merged_pr=$(gh pr list --repo "${GH_REPO}" --head "${branch}" --state merged \
+        --json number --jq '.[0].number' 2>/dev/null || echo "")
+    if [[ -n "${merged_pr}" ]]; then
+        return
+    fi
+
+    echo "ERROR: ${branch} already exists on origin from a previous, closed (unmerged) run."
+    echo "GitHub treats it as a stale protected branch and will reject a fresh push to it."
+    echo "Delete it manually, then re-run this pipeline, e.g.:"
+    echo "  gh api -X DELETE repos/${GH_REPO}/git/refs/heads/${branch}"
+    exit 1
+}
+
 # next_minor_version <version>
 # Given "X.Y.Z", returns the next minor version "X.(Y+1).0".
 next_minor_version() {

--- a/.buildkite/scripts/release/post-minor-merge.sh
+++ b/.buildkite/scripts/release/post-minor-merge.sh
@@ -65,6 +65,8 @@ bump_main_to_next_minor() {
 
     pr_exists && return
 
+    fail_if_stale_remote_branch "${BUMP_BRANCH}"
+
     git checkout -b "${BUMP_BRANCH}" origin/main
 
     NEXT_CLOUDBEAT_VERSION="${NEXT_MAIN_VERSION}"


### PR DESCRIPTION
## Summary

Today's `9.5.0` minor FF ([build #35](https://buildkite.com/elastic/cloudbeat-version-bump/builds/35)) failed with:
```
remote: error: GH006: Protected branch update failed for refs/heads/bump-to-9.5.0.
remote: - Changes must be made through a pull request.
remote: - 4 of 4 required status checks are expected.
```

Root cause: `bump-to-9.5.0` already existed on origin from an old, closed-but-never-merged PR (#5607, from April). `pr_exists()` only guards against *open* PRs on that branch name — since #5607 is closed, the script proceeds to push anyway, and GitHub treats a once-used branch as protected, blocking the push.

We unblocked today's run by manually deleting `bump-to-9.5.0`, and proactively deleted `bump-to-9.6.0` too (same stale state, from #5608/#5609) since our new `bump_main_to_next_minor` step would have hit it later in the same run.

This PR adds a permanent safeguard — **detect and fail clearly, don't auto-delete**:
- New `fail_if_stale_remote_branch()` helper in `common.sh` — if the target `bump-to-*` branch still exists on origin, checks whether it belongs to a **merged** PR (harmless — that just means this exact bump already shipped, and `no_new_commits()` further down correctly turns it into a clean no-op) vs. a **closed-but-unmerged** PR or no PR at all (the actual stale-protected-branch problem). Only the latter exits with an actionable error pointing at the exact `gh api` delete command — no automatic mutation of the repo.
- Called right after the existing `pr_exists` check (and before checkout) in `bump-patch.sh`, `bump-minor.sh`, and `post-minor-merge.sh`'s `bump_main_to_next_minor` — the three places that create a disposable `bump-to-*` branch

## Test plan

- [x] Dry-run against a real **merged** stale-looking branch (`bump-to-9.4.4`, PR #7112 merged) — correctly treated as harmless, proceeds to the existing idempotency check, exits 0 with "nothing to bump"
- [x] Dry-run against a real **closed-unmerged** stale branch (`bump-to-9.3.5`, PR #5541 closed) — fails clearly with exit 1 and the exact delete command, branch left untouched
- [x] Shellcheck clean on all touched scripts

Made with [Cursor](https://cursor.com)