### PR TITLE
ci: remove Mergify auto-merge for version bump PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -174,17 +174,6 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
-  - name: auto-merge version bump PRs
-    conditions:
-      - author=elastic-vault-github-plugin-prod[bot]
-      - title~=^Bump cloudbeat version
-      - label=backport-skip
-      - "#approved-reviews-by>=1"
-      - check-success=Unit Test
-      - check-success=Lint
-    actions:
-      merge:
-        method: squash
   - name: backport patches to 9.5 branch
     conditions:
       - merged


### PR DESCRIPTION
## Summary

Removes the `auto-merge version bump PRs` Mergify rule from `.mergify.yml` so GitHub's native merge queue owns merging into `main`.

## Rationale

GitHub's native merge queue is enforced on `main`. Mergify's `merge:` action performs a **direct merge**, which bypasses the queue — GitHub then rejects it with "GitHub refused to merge the pull request". This is the second time this pattern has bitten:

- #5871 migrated most Mergify rules from `queue:` to `merge:` when moving to GitHub's native queue.
- #6678 (`b035bd1f`) did the same for the version-bump rule after it started dequeuing with `"Repository rule violations found: Changes must be made through the merge queue"` — the same error we're seeing now on #7225.

The `merge:` action was a stopgap that worked only until the ruleset actually enforced the queue. Now that it does, Mergify shouldn't be attempting the merge at all — GitHub's native auto-merge (`gh pr merge --auto --squash` or the UI checkbox) and "Merge when ready" flow already handle queued merges cleanly, so this rule is redundant *and* actively harmful.

## Scope

Narrow — only removes the `auto-merge version bump PRs` rule. The `auto-merge Renovate PRs` (line 16) and mergify-housekeeping (line 93) rules use the same `merge:` action pattern and are latent versions of the same bug — they'll be handled in follow-ups once they actually surface, to keep this PR focused.

## Test plan

- [x] `.mergify.yml` still parses as valid YAML
- [x] Structural schema check: 14 remaining rules, all with valid `name`/`conditions`/`actions`, only known Mergify actions used (`assign`, `backport`, `close`, `comment`, `label`, `merge`, `review`)
- [x] Fork-based smoke test: gsarantid/cloudbeat#4 — git plumbing verified end-to-end. Note: Mergify is not installed on the fork, so behavioral verification against Mergify's service was not possible without an interactive OAuth install; the change is a self-contained YAML block removal with no cross-references so behavioral risk is minimal.
- [x] No cross-references — Mergify rules don't reference each other by name, so removing this rule cannot affect any other rule.

Made with [Cursor](https://cursor.com)