### PR TITLE
Add Entity Analytics experimental feature flags to ESS Kibana provision

### DIFF
--- a/.github/actions/elk-stack/action.yml
+++ b/.github/actions/elk-stack/action.yml
@@ -30,7 +30,7 @@ inputs:
     type: string
     required: false
   kibana-enable-entity-analytics-settings:
-    description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents feature flag, Agent Builder experimental UI)"
+    description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents, Agent Builder experimental UI, Security Solution experimental flags for risk score history / entity attachments / anomaly details, and Cases attachments)"
     type: boolean
     default: true
     required: false

--- a/.github/workflows/cdr-infra.yml
+++ b/.github/workflows/cdr-infra.yml
@@ -34,7 +34,7 @@ on:
         required: false
         default: "5"
       kibana_enable_entity_analytics_settings:
-        description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents feature flag, Agent Builder experimental UI)"
+        description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents, Agent Builder experimental UI, Security Solution experimental flags for risk score history / entity attachments / anomaly details, and Cases attachments)"
         type: boolean
         required: false
         default: true

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -38,7 +38,7 @@ on:
         description: "Provide the full Docker image path to override the default image (e.g. for testing BC/SNAPSHOT)"
         type: string
       kibana_enable_entity_analytics_settings:
-        description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents feature flag, Agent Builder experimental UI)"
+        description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents, Agent Builder experimental UI, Security Solution experimental flags for risk score history / entity attachments / anomaly details, and Cases attachments)"
         type: boolean
         required: false
         default: true
@@ -90,7 +90,7 @@ on:
         description: "Provide the full Docker image path to override the default image (e.g. for testing BC/SNAPSHOT)"
         type: string
       kibana_enable_entity_analytics_settings:
-        description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents feature flag, Agent Builder experimental UI)"
+        description: "ESS only: Apply Entity Analytics Kibana user_settings_yaml (AI agents, Agent Builder experimental UI, Security Solution experimental flags for risk score history / entity attachments / anomaly details, and Cases attachments)"
         type: boolean
         required: false
         default: true

--- a/deploy/test-environments/elk-stack/variables.tf
+++ b/deploy/test-environments/elk-stack/variables.tf
@@ -36,7 +36,7 @@ variable "serverless_mode" {
 
 variable "kibana_enable_entity_analytics_settings" {
   default     = true
-  description = "When true (ESS only), apply Kibana user_settings_yaml for Entity Analytics (AI agents feature flag, Agent Builder experimental UI)"
+  description = "When true (ESS only), apply Kibana user_settings_yaml for Entity Analytics (AI agents, Agent Builder experimental UI, Security Solution experimental flags for risk score history / entity attachments / anomaly details, and Cases attachments)"
   type        = bool
 }
 

--- a/deploy/test-environments/modules/ec/main.tf
+++ b/deploy/test-environments/modules/ec/main.tf
@@ -10,13 +10,20 @@ locals {
   apm_docker_image                 = lookup(var.docker_image, "apm", "")
   apm_docker_image_tag_override    = lookup(var.docker_image_tag_override, "apm", "")
 
-  # Entity Analytics: AI agents and Agent Builder experimental UI (ESS user_settings_yaml).
+  # Entity Analytics Kibana user_settings_yaml (ESS only).
   entity_analytics_yaml = <<-EOT
 feature_flags.overrides:
   aiAssistant.aiAgents.enabled: true
 
 uiSettings.overrides:
   "agentBuilder:experimentalFeatures": true
+
+xpack.securitySolution.enableExperimental:
+  - riskScoreHistoryEnabled
+  - entityAttachmentsEnabled
+  - entityAnalyticsAnomalyDetails
+
+xpack.cases.attachments.enabled: true
 EOT
 
   kibana_docker_config = local.kibana_docker_image_tag_override != "" ? {

--- a/deploy/test-environments/modules/ec/variables.tf
+++ b/deploy/test-environments/modules/ec/variables.tf
@@ -94,7 +94,7 @@ variable "docker_image" {
 variable "kibana_enable_entity_analytics_settings" {
   type        = bool
   default     = true
-  description = "When true (ESS only), set Kibana user_settings_yaml for Entity Analytics (AI agents feature flag, Agent Builder experimental UI)"
+  description = "When true (ESS only), set Kibana user_settings_yaml for Entity Analytics (AI agents, Agent Builder experimental UI, Security Solution experimental flags for risk score history / entity attachments / anomaly details, and Cases attachments)"
 }
 
 variable "kibana_instance_size" {

--- a/dev-docs/Cloud-Env-Testing.md
+++ b/dev-docs/Cloud-Env-Testing.md
@@ -161,7 +161,7 @@ The workflow requires a subset of input parameters. All required inputs are desc
    - **`docker-image-override`**: optional docker image override for agent installs (mostly for BC/SNAPSHOT testing).
    - **`expiration-days`**: how long the environment should be kept before cleanup. Default is `5`.
    - **`cis-infra`**: optional. When `true`, also deploy CIS infrastructure (`infra_type=all`). When `false`, CDR only (`infra_type=cdr`).
-   - **`kibana_enable_entity_analytics_settings`** (ESS only): when `true`, applies Kibana `user_settings_yaml` with Entity Analytics settings (AI agents feature flag, Agent Builder experimental UI). Default is `true`. Entity Store install is separate — see **`enable-entity-store-v2`** (CDR) or the EA workflow's entity store script.
+   - **`kibana_enable_entity_analytics_settings`** (ESS only): when `true`, applies Kibana `user_settings_yaml` with Entity Analytics settings (AI agents, Agent Builder experimental UI, Security Solution experimental flags for risk score history / entity attachments / anomaly details, and Cases attachments). Default is `true`. Entity Store install is separate — see **`enable-entity-store-v2`** (CDR) or the EA workflow's entity store script.
    - **`enable-entity-store-v2`**: when `true`, the workflow installs **Entity Store v2** (v2 installer script). When `false`, it installs **Entity Store v1 only**. Default is `true`.
 
 3. Click **Run workflow** and wait for completion.
@@ -173,7 +173,7 @@ The workflow requires a subset of input parameters. All required inputs are desc
 
 ## Create Environment (Entity Analytics)
 
-The [`create-env-ea`](https://github.com/elastic/cloudbeat/actions/workflows/create-env-ea.yml) workflow is a standalone manual dispatch that provisions an **ESS** stack in **production-cft**, applies **Entity Analytics (EA)** Kibana `user_settings_yaml` (AI agents feature flag and Agent Builder experimental UI), then checks out [`elastic/security-documents-generator`](https://github.com/elastic/security-documents-generator) at **`main`**, and runs correlated organization data at **enterprise** size with **Google** productivity suite, **all** integrations, and **detection rules**. It also installs Entity Store v2 and runs the risk-score maintainer via `install_entity_risk.sh`. It does not install CIS or CDR cloud infrastructure.
+The [`create-env-ea`](https://github.com/elastic/cloudbeat/actions/workflows/create-env-ea.yml) workflow is a standalone manual dispatch that provisions an **ESS** stack in **production-cft**, applies **Entity Analytics (EA)** Kibana `user_settings_yaml` (AI agents, Agent Builder experimental UI, Security Solution experimental flags for risk score history / entity attachments / anomaly details, and Cases attachments), then checks out [`elastic/security-documents-generator`](https://github.com/elastic/security-documents-generator) at **`main`**, and runs correlated organization data at **enterprise** size with **Google** productivity suite, **all** integrations, and **detection rules**. It also installs Entity Store v2 and runs the risk-score maintainer via `install_entity_risk.sh`. It does not install CIS or CDR cloud infrastructure.
 
 ### Inputs (summary)
 


### PR DESCRIPTION
## Summary

Extends the ESS Kibana `user_settings_yaml` applied by the EC Terraform module when `kibana_enable_entity_analytics_settings` is enabled (default: `true`).

Adds the following settings to support Entity Analytics testing:

- `xpack.securitySolution.enableExperimental`:
  - `riskScoreHistoryEnabled`
  - `entityAttachmentsEnabled`
  - `entityAnalyticsAnomalyDetails`
- `xpack.cases.attachments.enabled: true` (required for entity → cases attachments)

No new Terraform variable or workflow input was added — the new flags are included in the existing `entity_analytics_yaml` block and flow through existing workflows (`create-env-ea`, `test-environment`, `cdr-infra`).

## Changes

- **`deploy/test-environments/modules/ec/main.tf`** — append Security Solution experimental flags and Cases attachments setting to `entity_analytics_yaml`
- **`deploy/test-environments/modules/ec/variables.tf`** — update `kibana_enable_entity_analytics_settings` description
- **`deploy/test-environments/elk-stack/variables.tf`** — same description update
- **`.github/actions/elk-stack/action.yml`** — update input description
- **`.github/workflows/test-environment.yml`** — update workflow input descriptions (2 occurrences)
- **`.github/workflows/cdr-infra.yml`** — update workflow input description
- **`dev-docs/Cloud-Env-Testing.md`** — document new flags in CDR and EA workflow sections

## Test plan

- [x] `terraform validate` in `deploy/test-environments/elk-stack`
- [x] Provision an ESS environment via `create-env-ea` (or `test-environment` with `kibana_enable_entity_analytics_settings: true`)
- [x] Confirm Kibana user settings include:
  - `xpack.securitySolution.enableExperimental` with the three new flags
  - `xpack.cases.attachments.enabled: true`
- [x] Verify on a stack version that supports these experimental flags (e.g. `9.5.0-SNAPSHOT`)

## Notes

- ESS only — Serverless deployments are unaffected.