### PR TITLE
fix: make minor version bump fully idempotent on retrigger

### DIFF
--- a/.buildkite/scripts/release/bump-minor.sh
+++ b/.buildkite/scripts/release/bump-minor.sh
@@ -25,14 +25,24 @@ git fetch origin main
 git checkout main
 
 CURRENT_CLOUDBEAT_VERSION=$(grep defaultBeatVersion version/version.go | cut -f2 -d '"')
+POST_BUMP_MAIN_VERSION=$(next_minor_version "${NEW_VERSION}")
 
 echo "--- Minor bump parameters"
-echo "  REPO:            ${REPO}"
-echo "  BRANCH:          ${BRANCH}"
-echo "  CURRENT:         ${CURRENT_CLOUDBEAT_VERSION}"
-echo "  NEXT:            ${NEXT_CLOUDBEAT_VERSION}"
-echo "  BACKPORT_LABEL:  ${BACKPORT_LABEL}"
-echo "  DRY_RUN:         ${DRY_RUN}"
+echo "  REPO:                    ${REPO}"
+echo "  BRANCH:                  ${BRANCH}"
+echo "  CURRENT:                 ${CURRENT_CLOUDBEAT_VERSION}"
+echo "  NEXT:                    ${NEXT_CLOUDBEAT_VERSION}"
+echo "  POST_BUMP_MAIN_VERSION:  ${POST_BUMP_MAIN_VERSION}"
+echo "  BACKPORT_LABEL:          ${BACKPORT_LABEL}"
+echo "  DRY_RUN:                 ${DRY_RUN}"
+
+# Idempotent no-op: if main has already been advanced to the post-bump minor,
+# a previous run (or its post-minor-merge step) has completed this bump.
+# Re-running would regress version.go/ARM templates and open a downgrade PR.
+if [[ "${CURRENT_CLOUDBEAT_VERSION}" == "${POST_BUMP_MAIN_VERSION}" ]]; then
+    echo "main is already at ${POST_BUMP_MAIN_VERSION} — minor bump for ${NEW_VERSION} has already completed. Idempotent no-op."
+    exit 0
+fi
 
 setup_git_identity
 

--- a/.buildkite/scripts/release/common.sh
+++ b/.buildkite/scripts/release/common.sh
@@ -21,9 +21,32 @@ setup_git_identity() {
     git config --global user.name "Cloud Security Machine"
 }
 
+# is_downgrade <current> <target>
+# Returns 0 (true) if <target> is strictly older than <current>, using semver
+# ordering (via `sort -V`, which correctly handles multi-digit components).
+# Returns 1 (false) if target == current or target > current.
+is_downgrade() {
+    local current="$1"
+    local target="$2"
+    if [[ "${current}" == "${target}" ]]; then
+        return 1
+    fi
+    local highest
+    highest=$(printf '%s\n%s\n' "${current}" "${target}" | sort -V | tail -1)
+    [[ "${highest}" == "${current}" ]]
+}
+
 # update_version_beat
 # Updates defaultBeatVersion in version/version.go to NEXT_CLOUDBEAT_VERSION and stages the file.
+# Refuses to regress: if the current value is already >= NEXT_CLOUDBEAT_VERSION,
+# leaves the file untouched. Prevents a stale retrigger from opening a downgrade PR.
 update_version_beat() {
+    local current
+    current=$(grep defaultBeatVersion version/version.go | cut -f2 -d '"')
+    if is_downgrade "${current}" "${NEXT_CLOUDBEAT_VERSION}"; then
+        echo "Refusing to regress version/version.go: ${current} -> ${NEXT_CLOUDBEAT_VERSION} would be a downgrade."
+        return
+    fi
     sed -i'' -E "s/const defaultBeatVersion = .*/const defaultBeatVersion = \"${NEXT_CLOUDBEAT_VERSION}\"/g" version/version.go
     git add version/version.go
     if ! git diff --cached --quiet; then
@@ -33,8 +56,16 @@ update_version_beat() {
 
 # update_arm_templates <version>
 # Updates ElasticAgentVersion in both Azure ARM templates and regenerates dev variants.
+# Refuses to regress: if the current default is already >= <version>, leaves the
+# templates untouched.
 update_arm_templates() {
     local version="$1"
+    local current
+    current=$(jq -r '.parameters.ElasticAgentVersion.defaultValue' deploy/azure/ARM-for-single-account.json)
+    if is_downgrade "${current}" "${version}"; then
+        echo "Refusing to regress Azure ARM templates: ${current} -> ${version} would be a downgrade."
+        return
+    fi
     echo "--- Update ARM templates to ${version}"
     jq --indent 4 ".parameters.ElasticAgentVersion.defaultValue = \"${version}\"" \
         deploy/azure/ARM-for-single-account.json >tmp.json && mv tmp.json deploy/azure/ARM-for-single-account.json

--- a/.buildkite/scripts/release/post-minor-merge.sh
+++ b/.buildkite/scripts/release/post-minor-merge.sh
@@ -50,6 +50,22 @@ branch_out() {
         return
     fi
 
+    # Sanity check: main should still be at NEW_VERSION when we cut the release
+    # branch. If it has already been advanced (e.g. main == NEXT_MAIN_VERSION
+    # because a previous bump_main_to_next_minor merged but branch_out never
+    # ran), cutting the branch from current main would silently point ${BRANCH}
+    # at the wrong code. Refuse and require manual intervention rather than
+    # produce a wrong-content release branch.
+    local main_version
+    main_version=$(grep defaultBeatVersion version/version.go | cut -f2 -d '"')
+    if [[ "${main_version}" != "${NEW_VERSION}" ]]; then
+        echo "ERROR: main is at ${main_version}, expected ${NEW_VERSION}."
+        echo "Refusing to cut ${BRANCH} — the resulting branch would not represent ${NEW_VERSION}'s code."
+        echo "This means main advanced without ${BRANCH} being cut."
+        echo "To recover: create ${BRANCH} manually from the commit where main was at ${NEW_VERSION}, then re-run this pipeline."
+        exit 1
+    fi
+
     if [[ "${DRY_RUN}" == "true" ]]; then
         echo "Dry run: would create and push branch ${BRANCH}"
         return


### PR DESCRIPTION
## Summary

When Nina retriggered [unified-release-centralized-version-bump #35](https://buildkite.com/elastic/unified-release-centralized-version-bump/builds/35) yesterday after our `9.5.0` minor bump had already succeeded, [cloudbeat-version-bump #36](https://buildkite.com/elastic/cloudbeat-version-bump/builds/36) re-ran `bump-minor.sh` with the same env vars (`WORKFLOW=minor BRANCH=9.5 NEW_VERSION=9.5.0`). By then `main` was at `9.6.0` (from merged #7268), and the `sed` inside `update_version_beat` unconditionally rewrote `version.go` back to `9.5.0`, opening the now-closed **#7275** — a PR proposing to downgrade `main` (verified: `defaultBeatVersion` and 4 ARM `defaultValue` fields all flipped `9.6.0` -> `9.5.0`).

The existing `no_new_commits` guard couldn't tell the difference between "advance forward" and "regress backward" — it only asks "did anything change vs main?" — so the regression commits passed the check and got pushed.

This PR closes that gap and a related one in `post-minor-merge.sh`, with defense in depth so no future retrigger can produce a bad PR or a wrong-content release branch.

## Fix — three layers

### 1. Top-level guard in [`bump-minor.sh`](/Users/gsarantid/Elastic/cloudbeat/.buildkite/scripts/release/bump-minor.sh)

If `main` is already at `next_minor_version(NEW_VERSION)` (e.g. `main` = `9.6.0` while `NEW_VERSION` = `9.5.0`), the entire minor bump has completed. Exit `0` before touching any files.

### 2. Hardened shared helpers in [`common.sh`](/Users/gsarantid/Elastic/cloudbeat/.buildkite/scripts/release/common.sh)

New `is_downgrade()` helper using `sort -V` (so `9.10.0 > 9.9.0` sorts correctly). `update_version_beat` and `update_arm_templates` now call it before writing: if the current value is already `>=` the target, they refuse and log a clear message. Belt-and-suspenders — even if a future caller forgets the top-level guard, no downgrade can escape the shared helper.

### 3. Sanity check in [`post-minor-merge.sh`](/Users/gsarantid/Elastic/cloudbeat/.buildkite/scripts/release/post-minor-merge.sh)'s `branch_out()`

If `main` has drifted from `NEW_VERSION` at the moment we're about to cut the release branch, refuse and exit non-zero. Closes a related edge case (spotted during review): if `main` was advanced (e.g. via manual intervention or an out-of-order run) but the release branch was never cut, `branch_out()` previously would have silently cut `${BRANCH}` from current `main` — producing a `9.5` release branch pointing at `9.6.0` code. Same philosophy as `fail_if_stale_remote_branch` (from #7227): detect the anomaly, fail clearly, require a human to fix the underlying state.

## Related history

- #7184 — base `no_new_commits` idempotency (for retriggering completed **patch** bumps)
- #7227 — stale-branch detection (`fail_if_stale_remote_branch`)
- **This PR** — closes the retriggering-completed-**minor**-bump gap plus the release-branch-drift gap

## Explicit non-goals

- `bump-patch.sh` unchanged — patch bumps only advance forward, no regression risk.
- `bump_main_to_next_minor()` in `post-minor-merge.sh` unchanged — verified already idempotent (`no_new_commits` catches the "main already at target" case as a genuine sed no-op).

## Test plan

- [x] **`is_downgrade` unit tests** — 9 cases pass, including the multi-digit `9.9.0` -> `9.10.0` case that naive lexical comparison would get wrong.
- [x] **Retrigger simulation** on real `main` (=`9.6.0`) with `NEW_VERSION=9.5.0 DRY_RUN=true` — exits 0 immediately with `main is already at 9.6.0 — minor bump for 9.5.0 has already completed. Idempotent no-op.` No branch, no commits, no PR.
- [x] **Happy path** (main=`9.5.0`, `NEW_VERSION=9.7.0`) — guard doesn't fire, full flow proceeds through `update_version_beat` (`9.5.0` -> `9.7.0`), `update_arm_templates`, `update_mergify`, and would `gh pr create`.
- [x] **`update_version_beat` unit tests** — regression attempt (`9.6.0` -> `9.5.0`) prints refusal and doesn't commit; upgrade (`9.6.0` -> `9.7.0`) commits cleanly; no-op (`9.7.0` -> `9.7.0`) doesn't create duplicate commits.
- [x] **`branch_out()` sanity check** — three paths validated:
  - Branch missing + `main` drifted -> refuses with clear error, exits 1
  - Branch missing + `main` correct -> proceeds normally (dry-run)
  - Branch already exists -> existing "branch exists" short-circuit fires first (sanity check skipped)
- [x] `shellcheck` clean on `bump-minor.sh`, `common.sh`, and `post-minor-merge.sh`.
- [x] Fork smoke test: gsarantid/cloudbeat#5 — git plumbing verified end-to-end.

## After merge

[Cloudbeat-version-bump #36](https://buildkite.com/elastic/cloudbeat-version-bump/builds/36/) becomes safe to unblock at its `Wait for PR merge` gate — `post-minor-merge.sh` is already idempotent, so `branch_out()` short-circuits (branch exists), `bump_main_to_next_minor()` no-ops (main already at `9.6.0`), and the DRA-artifacts poll finds the already-published `9.5.0` artifacts.