### PR TITLE
Add aws_securityhub permissions to the Federated Identity template

### DIFF
--- a/deploy/cloudformation/federated-identity-aws.yml
+++ b/deploy/cloudformation/federated-identity-aws.yml
@@ -48,6 +48,24 @@ Resources:
         # from the shipped cloud-connectors-guardduty template.
         - arn:aws:iam::aws:policy/AmazonGuardDutyReadOnlyAccess
 
+  # aws_securityhub: read access to Security Hub findings via the
+  # GetFindingsV2 API, which authorizes as securityhub:GetFindings.
+  # Mirrors the provider_permissions declared in elastic/integrations#20436.
+  ElasticAwsSecurityHub:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ElasticAwsSecurityHub
+      Roles:
+        - !Ref ElasticFederatedIdentityRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ElasticAwsSecurityHubRead
+            Effect: Allow
+            Action:
+              - securityhub:GetFindings
+            Resource: '*'
+
 Outputs:
   RoleArn:
     Description: The ARN of the IAM Role. Paste this into Kibana.


### PR DESCRIPTION
## Summary

Adds the `ElasticAwsSecurityHub` inline policy to the incremental Federated Identity template: `securityhub:GetFindings`, mirroring the `provider_permissions` declared by the `aws_securityhub` package in elastic/integrations#20436.

Note the IAM action: the package's CEL input calls the `GetFindingsV2` API (`POST /findingsv2`), but per the [AWS API reference](https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_GetFindingsV2.html), *"GetFindings and GetFindingsV2 both use securityhub:GetFindings in the Action element of an IAM policy statement."*

## Background

Part of https://github.com/elastic/ingest-dev/issues/8812.

**Stacked on #7422** (targets its branch; retargets to `main` automatically when it merges). This is the first per-integration addition under the incremental model: each integration that gains Federated Identity support lands its CFT permissions as a separate PR paired with the elastic/integrations PR that declares them.

**Sibling PRs on the same baseline:** #7422 (GuardDuty baseline) is the base; #7589 (aws Config) and #7590 (Amazon Inspector) are the sibling per-integration additions. Whichever merges second rebases over a trivial same-region conflict.

## Test plan

- [x] `cfn-lint` and `rain` pass in pre-commit
- [ ] Deploy the stack in a test AWS account and verify the role carries the `ElasticAwsSecurityHub` inline policy
- [ ] Assume the role and call `GetFindingsV2` to confirm the action authorizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


