### PR TITLE
Add aws Config permissions to the Federated Identity template

### DIFF
--- a/deploy/cloudformation/federated-identity-aws.yml
+++ b/deploy/cloudformation/federated-identity-aws.yml
@@ -48,6 +48,26 @@ Resources:
         # from the shipped cloud-connectors-guardduty template.
         - arn:aws:iam::aws:policy/AmazonGuardDutyReadOnlyAccess
 
+  # aws/config: rule listing and per-rule compliance reads for the AWS
+  # Config data stream. Mirrors the permission set from the patch files in
+  # elastic/integrations#20240, minus config:DescribeComplianceByConfigRule,
+  # which the CEL program never calls (see elastic/integrations#20437).
+  ElasticAwsConfig:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ElasticAwsConfig
+      Roles:
+        - !Ref ElasticFederatedIdentityRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ElasticAwsConfigRead
+            Effect: Allow
+            Action:
+              - config:DescribeConfigRules
+              - config:GetComplianceDetailsByConfigRule
+            Resource: '*'
+
 Outputs:
   RoleArn:
     Description: The ARN of the IAM Role. Paste this into Kibana.


### PR DESCRIPTION
## Summary

Adds the `ElasticAwsConfig` inline policy to the incremental Federated Identity template:

- `config:DescribeConfigRules`
- `config:GetComplianceDetailsByConfigRule`

These are the two operations the AWS Config data stream's CEL program calls, paired with elastic/integrations#20437 (the Config `auth.aws` migration + ungate). Both IAM actions map 1:1 to their API operation names.

**Deliberate omission:** the permission patch sets in elastic/integrations#20240 also list `config:DescribeComplianceByConfigRule` — the program never calls it, so it is left out (least privilege; likely stale in #20240 since the service-linked-rules fix reshaped the collection flow).

## Background

Part of https://github.com/elastic/ingest-dev/issues/8802.

**Stacked on #7422** (the incremental baseline); retargets to `main` automatically when it merges. One CFT PR per federated integration, each paired with the elastic/integrations PR that defines the stream's actual API surface.

**Sibling PRs on the same baseline:** #7422 (GuardDuty baseline) is the base; #7588 (aws_securityhub) and #7590 (Amazon Inspector) are the sibling per-integration additions. Whichever merges second rebases over a trivial same-region conflict.

## Test plan

- [x] `cfn-lint` and `rain` pass in pre-commit
- [ ] Deploy the stack in a test AWS account; verify the role carries `ElasticAwsConfig`
- [ ] Assume the role and call `DescribeConfigRules` + `GetComplianceDetailsByConfigRule` to confirm both authorize

🤖 Generated with [Claude Code](https://claude.com/claude-code)


