### PR TITLE
Add Amazon Inspector permissions to the Federated Identity template

### DIFF
--- a/deploy/cloudformation/federated-identity-aws.yml
+++ b/deploy/cloudformation/federated-identity-aws.yml
@@ -48,6 +48,26 @@ Resources:
         # from the shipped cloud-connectors-guardduty template.
         - arn:aws:iam::aws:policy/AmazonGuardDutyReadOnlyAccess
 
+  # aws/inspector: finding reads for the Amazon Inspector data stream.
+  # The stream calls exactly one operation (POST /findings/list =
+  # inspector2:ListFindings); inspector2:ListCoverage from the
+  # elastic/integrations#20240 patch sets is never called and is omitted
+  # (see elastic/integrations#20439).
+  ElasticAwsInspector:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: ElasticAwsInspector
+      Roles:
+        - !Ref ElasticFederatedIdentityRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: ElasticAwsInspectorRead
+            Effect: Allow
+            Action:
+              - inspector2:ListFindings
+            Resource: '*'
+
 Outputs:
   RoleArn:
     Description: The ARN of the IAM Role. Paste this into Kibana.


### PR DESCRIPTION
## Summary

Adds the `ElasticAwsInspector` inline policy to the incremental Federated Identity template:

- `inspector2:ListFindings`

This is the single operation the Amazon Inspector data stream's HTTPJSON template calls (`POST /findings/list`), paired with elastic/integrations#20439 (the Inspector `auth.aws` migration + ungate). The IAM action maps 1:1 to the operation name.

**Deliberate omission:** the permission patch sets in elastic/integrations#20240 also list `inspector2:ListCoverage` — the stream never calls it, so it is left out (least privilege).

## Background

Part of https://github.com/elastic/ingest-dev/issues/8802.

**Stacked on #7422** (the incremental baseline); retargets to `main` automatically when it merges.

**Sibling PRs on the same baseline:** #7588 (aws_securityhub) and #7589 (aws Config) are the other per-integration additions. Whichever merges later rebases over a trivial same-region conflict.

## Test plan

- [x] `cfn-lint` and `rain` pass in pre-commit
- [ ] Deploy the stack in a test AWS account; verify the role carries `ElasticAwsInspector`
- [ ] Assume the role and call `ListFindings` to confirm the action authorizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)