### PR TITLE
chore: add 9.5 to renovate baseBranches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
   ],
   "baseBranches": [
     "main",
+    "9.5",
     "9.4",
     "9.3",
     "8.19"
@@ -239,6 +240,7 @@
     {
       "description": "Disable CI/infrastructure/test-environment updates on release branches",
       "matchBaseBranches": [
+        "9.5",
         "9.4",
         "9.3",
         "8.19"


### PR DESCRIPTION
## Summary

- Adds `9.5` to `baseBranches` so Renovate opens dependency update PRs targeting the 9.5 release branch
- Adds `9.5` to the `matchBaseBranches` rule that disables CI/infrastructure file updates on release branches, keeping it consistent with 9.4, 9.3, and 8.19

## Test plan

- [ ] Verify Renovate creates `chore(deps)` PRs against `9.5` after the next scheduled run (weekdays at 1 AM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)