### PR TITLE
fix: prevent orphan empty-timestamp S3 env folders

### DIFF
--- a/.github/workflows/create-env-ea.yml
+++ b/.github/workflows/create-env-ea.yml
@@ -67,6 +67,14 @@ jobs:
             exit 1
           fi
 
+      # Resolve S3 prefix before auth so always() uploads never write to DEPLOYMENT_NAME_/
+      - name: Set S3 state folder
+        run: |
+          TF_STATE_FOLDER=$(date +'%Y-%m-%d_%H-%M-%S')
+          S3_BUCKET_PATH="${S3_BASE_BUCKET}/${DEPLOYMENT_NAME}_${TF_STATE_FOLDER}"
+          echo "TF_STATE_FOLDER=$TF_STATE_FOLDER" >> "$GITHUB_ENV"
+          echo "S3_BUCKET_PATH=$S3_BUCKET_PATH" >> "$GITHUB_ENV"
+
       - name: Process Stack Version
         id: remove-commit-hash
         run: |
@@ -140,10 +148,6 @@ jobs:
           aws-secret-access-key: ${{ env.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Update Vars
-        run: |
-          echo "TF_STATE_FOLDER=$(date +'%Y-%m-%d_%H-%M-%S')" >> "$GITHUB_ENV"
-
       - name: Deploy ELK Cloud Stack
         id: elk-stack
         uses: ./.github/actions/elk-stack
@@ -157,15 +161,15 @@ jobs:
           kibana-enable-entity-analytics-settings: true
           kibana-instance-size: ${{ inputs.kibana_instance_size }}
           elasticsearch-ml-enabled: true
-          env-s3-bucket: "${{ env.S3_BASE_BUCKET }}/${{ env.DEPLOYMENT_NAME }}_${{ env.TF_STATE_FOLDER }}"
+          env-s3-bucket: ${{ env.S3_BUCKET_PATH }}
           tag-project: ${{ github.actor }}
           tag-owner: ${{ github.actor }}
 
       - name: Upload environment info
         id: upload-state
-        if: always()
+        if: always() && env.S3_BUCKET_PATH != ''
         env:
-          S3_BUCKET: "${{ env.S3_BASE_BUCKET }}/${{ env.DEPLOYMENT_NAME }}_${{ env.TF_STATE_FOLDER }}"
+          S3_BUCKET: ${{ env.S3_BUCKET_PATH }}
           EXPIRATION_DAYS: ${{ inputs.expiration_days }}
           ESS_REGION: production-cft
           ESS_REGION_MAPPED: ${{ env.ESS_REGION }}

--- a/.github/workflows/test-e2e-flow.yml
+++ b/.github/workflows/test-e2e-flow.yml
@@ -77,6 +77,6 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
-    if: success()
+    if: always() && needs.setup.result == 'success' && needs.deploy.result != 'skipped'
     with:
       prefix: ${{ needs.setup.outputs.deployment_name }}

--- a/.github/workflows/test-environment.yml
+++ b/.github/workflows/test-environment.yml
@@ -223,6 +223,14 @@ jobs:
             exit 1
           fi
 
+      # Resolve S3 prefix before auth so always() uploads never write to DEPLOYMENT_NAME_/
+      - name: Set S3 state folder
+        run: |
+          TF_STATE_FOLDER=$(date +'%Y-%m-%d_%H-%M-%S')
+          S3_BUCKET_PATH="${S3_BASE_BUCKET}/${DEPLOYMENT_NAME}_${TF_STATE_FOLDER}"
+          echo "TF_STATE_FOLDER=$TF_STATE_FOLDER" >> "$GITHUB_ENV"
+          echo "S3_BUCKET_PATH=$S3_BUCKET_PATH" >> "$GITHUB_ENV"
+
       - name: Mask Sensitive Data
         if: inputs.ec-api-key != ''
         run: |
@@ -396,7 +404,6 @@ jobs:
       - name: Update Vars
         run: |
           echo "TF_VAR_gcp_project_id=$GCP_PROJECT" >> $GITHUB_ENV
-          echo "TF_STATE_FOLDER=$(date +'%Y-%m-%d_%H-%M-%S')" >> $GITHUB_ENV
 
       - name: Deploy ELK Cloud Stack
         id: elk-stack
@@ -412,15 +419,15 @@ jobs:
           docker-image-version-override: ${{ env.TF_VAR_pin_version }}
           kibana-enable-entity-analytics-settings: ${{ inputs.kibana_enable_entity_analytics_settings }}
           kibana-instance-size: "4g"
-          env-s3-bucket: "${{ env.S3_BASE_BUCKET }}/${{ env.DEPLOYMENT_NAME }}_${{ env.TF_STATE_FOLDER }}"
+          env-s3-bucket: ${{ env.S3_BUCKET_PATH }}
           tag-project: ${{ github.actor }}
           tag-owner: ${{ github.actor }}
 
       - name: Upload environment info
         id: upload-state
-        if: always()
+        if: always() && env.S3_BUCKET_PATH != ''
         env:
-          S3_BUCKET: "${{ env.S3_BASE_BUCKET }}/${{ env.DEPLOYMENT_NAME }}_${{ env.TF_STATE_FOLDER }}"
+          S3_BUCKET: ${{ env.S3_BUCKET_PATH }}
           EXPIRATION_DAYS: ${{ inputs.expiration_days }}
           ESS_REGION: ${{ inputs.ess-region || 'production-cft' }}
           ESS_REGION_MAPPED: ${{ env.ESS_REGION }}
@@ -499,7 +506,7 @@ jobs:
           okta-logs-url: ${{ secrets.OKTA_LOGS_URL }}
           okta-api-key: ${{ secrets.OKTA_API_KEY }}
           okta-entity-analytics-domain: ${{ secrets.OKTA_ENTITY_ANALYTICS_DOMAIN }}
-          env-s3-bucket: "${{ env.S3_BASE_BUCKET }}/${{ env.DEPLOYMENT_NAME }}_${{ env.TF_STATE_FOLDER }}"
+          env-s3-bucket: ${{ env.S3_BUCKET_PATH }}
           es-user: ${{ env.ES_USER }}
           es-password: ${{ env.ES_PASSWORD }}
           kibana-url: ${{ env.KIBANA_URL }}
@@ -534,7 +541,7 @@ jobs:
           cspm-azure-creds: ${{ secrets.AZURE_CREDENTIALS }}
           cspm-azure-tags: ${{ env.AZURE_DEFAULT_TAGS }}
           stack-enrollment-token: ${{ env.ENROLLMENT_TOKEN }}
-          env-s3-bucket: "${{ env.S3_BASE_BUCKET }}/${{ env.DEPLOYMENT_NAME }}_${{ env.TF_STATE_FOLDER }}"
+          env-s3-bucket: ${{ env.S3_BUCKET_PATH }}
           es-user: ${{ env.ES_USER }}
           es-password: ${{ env.ES_PASSWORD }}
           kibana-url: ${{ env.KIBANA_URL }}


### PR DESCRIPTION
## Summary
- Resolve `TF_STATE_FOLDER` / `S3_BUCKET_PATH` early in Create Environment (and EA) so uploads never write to `DEPLOYMENT_NAME_/` when the timestamp is unset.
- Gate `Upload environment info` (`if: always()`) on `S3_BUCKET_PATH` being set; reuse the resolved path for elk/CDR/CIS uploads.
- Run Test E2E Flow destroy when setup succeeded and deploy was not skipped, so failed UI/sanity runs still clean up S3 state folders.

## Test plan
- [ ] Workflow YAML review: early `Set S3 state folder` precedes vault/auth; no remaining `${S3_BASE_BUCKET}/${DEPLOYMENT_NAME}_${TF_STATE_FOLDER}` upload paths in create-env workflows
- [ ] Next Test Runner / manual Create Environment: expect a single `name_YYYY-MM-DD_HH-MM-SS` prefix (no `name_` orphan)
- [ ] Confirm destroy still runs after a failed deploy/UI sanity job in Test E2E Flow


Made with [Cursor](https://cursor.com)