### PR TITLE
ci: pin security-policies poetry env to python3.11

### DIFF
--- a/.github/actions/hermit/action.yml
+++ b/.github/actions/hermit/action.yml
@@ -94,7 +94,10 @@ runs:
     - if: ${{ inputs.init-tools == 'true' }}
       name: Install security-policies poetry dependencies
       shell: bash
-      run: cd ./security-policies && poetry install --no-root
+      run: |
+        cd ./security-policies
+        poetry env use python3.11
+        poetry install --no-root
     - if: ${{ inputs.init-tools == 'true' }}
       name: Install pre-commit repos
       shell: bash


### PR DESCRIPTION
Hermit's pre-commit package bumped its runtime dependency from
python3@3.9 to python3@3.14 (cashapp/hermit-packages#773), so hooks
launched through pre-commit now see python3.14 first on PATH. Poetry 2.x
resolves the interpreter from PATH, and since security-policies declares
requires-python = ">=3.11", python3.14 satisfies it: the
"poetry run -C security-policies" hooks created a fresh, empty 3.14
virtualenv instead of reusing the 3.11 one built during setup, failing
with "ModuleNotFoundError: No module named 'git'".

Pinning the env with "poetry env use python3.11" records the selection in
envs.toml so every later "poetry run" reuses the env that actually has
the dependencies installed.

Same fix already applied on 9.4 in #4759.

