### PR TITLE
[Asset Inventory][EC2] Add timeout handler to IAM resolver

### DIFF
--- a/internal/inventory/awsfetcher/fetcher_ec2_instance.go
+++ b/internal/inventory/awsfetcher/fetcher_ec2_instance.go
@@ -20,6 +20,7 @@ package awsfetcher
 import (
 	"context"
 	"strings"
+	"time"
 
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 
@@ -149,7 +150,9 @@ func (e *ec2InstanceFetcher) resolveRoleArn(ctx context.Context, profileArn stri
 		return ""
 	}
 
-	profile, err := e.iamResolver.GetInstanceProfile(ctx, profileName)
+	callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	profile, err := e.iamResolver.GetInstanceProfile(callCtx, profileName)
+	cancel()
 	if err != nil {
 		e.logger.Warnf("Could not resolve IAM role for instance profile %s: %v", profileArn, err)
 		roleArnCache[profileArn] = ""


### PR DESCRIPTION
### Summary of your changes

Add 10s timeout to `GetInstanceProfile` calls in EC2 instance fetcher

The IAM client uses the default HTTP transport with no timeout. If `GetInstanceProfile` hangs, the fetch loop blocks before sending any asset to the channel, so zero EC2 assets are published. Errors are already handled gracefully (falls back to the profile ARN), so a timeout is enough to resolve any issues.


### Related Issues

Resolves error for integration tests.

