### PR TITLE
improve vulnerability scan go setup

### DIFF
--- a/.buildkite/scripts/vulnerability-scan.sh
+++ b/.buildkite/scripts/vulnerability-scan.sh
@@ -68,19 +68,22 @@ checkout_branch() {
     git checkout -f "${branch}"
 }
 
-install_go() {
-    if command -v go >/dev/null 2>&1; then
-        return 0
-    fi
-
-    echo "--- Installing Go (${GO_APK_PACKAGE})"
-    apk add --no-cache "${GO_APK_PACKAGE}"
-}
-
 install_snyk() {
     echo "--- Installing Snyk CLI"
     curl https://static.snyk.io/cli/latest/snyk-linux -o /usr/local/bin/snyk &&
         chmod +x /usr/local/bin/snyk
+}
+
+install_go() {
+    if ! command -v go >/dev/null 2>&1; then
+        echo "--- Installing Go (${GO_APK_PACKAGE})"
+        apk add --no-cache "${GO_APK_PACKAGE}"
+    fi
+
+    echo "--- Verifying Go toolchain"
+    command -v go
+    go version
+    go env GOEXPERIMENT
 }
 
 auth_snyk() {
@@ -125,7 +128,7 @@ run_snyk() {
 
 warm_go_modcache() {
     echo "--- Pre-warming Go module cache"
-    go mod download 2>/dev/null
+    go mod download
 }
 
 install_go
@@ -133,9 +136,9 @@ install_snyk
 auth_snyk
 
 scan_exit=0
-warm_go_modcache
 while IFS= read -r branch; do
     checkout_branch "${branch}"
+    warm_go_modcache
     run_snyk "${branch}" || scan_exit=$?
 done < <(collect_target_branches)
 


### PR DESCRIPTION
## Summary
- Log the Go binary, version, and GOEXPERIMENT used by the vulnerability scan before Snyk runs.
- Run `go mod download` after each target branch checkout so the module cache and validation match the branch being scanned.
- Leave the existing Wolfi/APK Go install path in place because Hermit currently warns when resolving the pinned Go 1.26.6 package in a fresh environment.

## Test plan
- `bash -n .buildkite/scripts/vulnerability-scan.sh`
- `shellcheck .buildkite/scripts/vulnerability-scan.sh`

## References
Closes elastic/security-team#18857

Made with [Cursor](https://cursor.com)