### PR TITLE
fix(cai): correct swapped cloud.account/cloud.project mapping for GCP

### DIFF
--- a/internal/inventory/azurefetcher/fetcher_resource_graph.go
+++ b/internal/inventory/azurefetcher/fetcher_resource_graph.go
@@ -120,7 +120,6 @@ func (f *resourceGraphFetcher) fetch(ctx context.Context, resourceName, serviceN
 	}
 }
 
-//nolint:revive
 type vmProperties struct {
 	Extended struct {
 		InstanceView struct {

--- a/internal/inventory/azurefetcher/fetcher_resource_graph.go
+++ b/internal/inventory/azurefetcher/fetcher_resource_graph.go
@@ -120,15 +120,21 @@ func (f *resourceGraphFetcher) fetch(ctx context.Context, resourceName, serviceN
 	}
 }
 
+type vmInstanceView struct {
+	ComputerName string
+}
+
+type vmExtended struct {
+	InstanceView vmInstanceView
+}
+
+type vmHardwareProfile struct {
+	VmSize string
+}
+
 type vmProperties struct {
-	Extended struct {
-		InstanceView struct {
-			ComputerName string
-		}
-	}
-	HardwareProfile struct {
-		VmSize string
-	}
+	Extended        vmExtended
+	HardwareProfile vmHardwareProfile
 }
 
 func tryUnpackingVMProperties(m map[string]any) *vmProperties {

--- a/internal/inventory/gcpfetcher/fetcher_assets.go
+++ b/internal/inventory/gcpfetcher/fetcher_assets.go
@@ -98,14 +98,7 @@ func getAssetEvent(classification inventory.AssetClassification, item *gcpinvent
 			findRelatedAssetIds(classification.Type, item),
 		),
 		// Any asset type enrichers also setting Cloud fields will need to re-add these fields below
-		inventory.WithCloud(inventory.Cloud{
-			Provider:    inventory.GcpCloudProvider,
-			AccountID:   item.CloudAccount.AccountId,
-			AccountName: item.CloudAccount.AccountName,
-			ProjectID:   item.CloudAccount.OrganisationId,
-			ProjectName: item.CloudAccount.OrganizationName,
-			ServiceName: item.AssetType,
-		}),
+		inventory.WithCloud(commonCloud(item)),
 	}
 
 	// Asset type specific enrichers and common resource-level fields
@@ -269,29 +262,38 @@ var assetEnrichers = map[string]func(item *gcpinventory.ExtendedGcpAsset, fields
 	gcpinventory.ComputeNetworkAssetType:        enrichNetwork,
 }
 
-func enrichOrganization(_ *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+// commonCloud returns the Cloud fields shared by every GCP asset.
+// Callers that call inventory.WithCloud to add asset-type-specific cloud fields MUST start from
+// this value; WithCloud replaces the whole struct, so omitting any field silently drops it.
+// ECS semantics: cloud.account.id = GCP organisation id, cloud.project.id = GCP project id.
+func commonCloud(item *gcpinventory.ExtendedGcpAsset) inventory.Cloud {
+	return inventory.Cloud{
+		Provider:    inventory.GcpCloudProvider,
+		AccountID:   item.CloudAccount.OrganisationId,
+		AccountName: item.CloudAccount.OrganizationName,
+		ProjectID:   item.CloudAccount.AccountId,
+		ProjectName: item.CloudAccount.AccountName,
+		ServiceName: item.AssetType,
+	}
+}
+
+func enrichOrganization(item *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
 	return []inventory.AssetEnricher{
 		inventory.WithOrganization(inventory.Organization{
+			ID:   item.CloudAccount.OrganisationId,
 			Name: getStringValue("displayName", fields),
 		}),
 	}
 }
 
 func enrichComputeInstance(item *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+	cloud := commonCloud(item)
+	cloud.InstanceID = getStringValue("id", fields)
+	cloud.InstanceName = getStringValue("name", fields)
+	cloud.MachineType = getStringValue("machineType", fields)
+	cloud.AvailabilityZone = getStringValue("zone", fields)
 	return []inventory.AssetEnricher{
-		inventory.WithCloud(inventory.Cloud{
-			// This will override the default Cloud fields, so we re-add the common ones
-			Provider:         inventory.GcpCloudProvider,
-			AccountID:        item.CloudAccount.AccountId,
-			AccountName:      item.CloudAccount.AccountName,
-			ProjectID:        item.CloudAccount.OrganisationId,
-			ProjectName:      item.CloudAccount.OrganizationName,
-			ServiceName:      item.AssetType,
-			InstanceID:       getStringValue("id", fields),
-			InstanceName:     getStringValue("name", fields),
-			MachineType:      getStringValue("machineType", fields),
-			AvailabilityZone: getStringValue("zone", fields),
-		}),
+		inventory.WithCloud(cloud),
 		inventory.WithHost(inventory.Host{
 			ID: getStringValue("id", fields),
 		}),
@@ -335,11 +337,11 @@ func enrichGkeCluster(_ *gcpinventory.ExtendedGcpAsset, fields map[string]*struc
 	}
 }
 
-func enrichForwardingRule(_ *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+func enrichForwardingRule(item *gcpinventory.ExtendedGcpAsset, fields map[string]*structpb.Value) []inventory.AssetEnricher {
+	cloud := commonCloud(item)
+	cloud.Region = getStringValue("region", fields)
 	return []inventory.AssetEnricher{
-		inventory.WithCloud(inventory.Cloud{
-			Region: getStringValue("region", fields),
-		}),
+		inventory.WithCloud(cloud),
 	}
 }
 

--- a/internal/inventory/gcpfetcher/fetcher_assets_test.go
+++ b/internal/inventory/gcpfetcher/fetcher_assets_test.go
@@ -58,10 +58,10 @@ func TestAccountFetcher_Fetch_Assets(t *testing.T) {
 			inventory.WithRelatedAssetIds([]string{}),
 			inventory.WithCloud(inventory.Cloud{
 				Provider:    inventory.GcpCloudProvider,
-				AccountID:   "<project UUID>",
-				AccountName: "<project name>",
-				ProjectID:   "<org UUID>",
-				ProjectName: "<org name>",
+				AccountID:   "<org UUID>",
+				AccountName: "<org name>",
+				ProjectID:   "<project UUID>",
+				ProjectName: "<project name>",
 				ServiceName: r.assetType,
 			}),
 			inventory.WithLabels(map[string]string{}),
@@ -120,6 +120,7 @@ func TestAccountFetcher_EnrichAsset(t *testing.T) {
 			},
 			enrichments: inventory.AssetEvent{
 				Organization: &inventory.Organization{
+					ID:   "<org UUID>",
 					Name: "org",
 				},
 			},
@@ -273,19 +274,17 @@ func TestAccountFetcher_EnrichAsset(t *testing.T) {
 			expected.User.Entity = &expected.Entity
 		}
 
-		// Cloud is the only field where we have both common and enriched fields
+		// Every asset carries the common cloud fields. Assert them as literals so that a
+		// wrong mapping (e.g. org in project.id) causes a real test failure.
 		if expected.Cloud == nil {
-			// Use the actual cloud fields when there are no cloud enrichments
-			expected.Cloud = actual.Cloud
-		} else {
-			// Use common cloud fields when there are cloud enrichments
-			expected.Cloud.Provider = actual.Cloud.Provider
-			expected.Cloud.AccountID = actual.Cloud.AccountID
-			expected.Cloud.AccountName = actual.Cloud.AccountName
-			expected.Cloud.ProjectID = actual.Cloud.ProjectID
-			expected.Cloud.ProjectName = actual.Cloud.ProjectName
-			expected.Cloud.ServiceName = actual.Cloud.ServiceName
+			expected.Cloud = &inventory.Cloud{}
 		}
+		expected.Cloud.Provider = inventory.GcpCloudProvider
+		expected.Cloud.AccountID = "<org UUID>"
+		expected.Cloud.AccountName = "<org name>"
+		expected.Cloud.ProjectID = "<project UUID>"
+		expected.Cloud.ProjectName = "<project name>"
+		expected.Cloud.ServiceName = r.assetType
 
 		assert.Equalf(t, expected, actual, "%v failed", "EnrichAsset")
 	}


### PR DESCRIPTION
## Summary

Fixes the GCP Cloud Asset Inventory bug reported in [sdh-beats#7529](https://github.com/elastic/sdh-beats/issues/7529) (support case 02134946, Planet Labs, serverless 9.6.0): organisation values were landing in `cloud.project.*` and project values in `cloud.account.*`, with `cloud.account.*` entirely null for Organisation-type assets.

**Root cause:** `fetcher_assets.go` crossed the two fields when mapping `CloudAccountMetadata` to the `Cloud` struct — `OrganisationId` went to `ProjectID` and `AccountId` went to `AccountID`, the opposite of ECS semantics (`cloud.account.id` = Google Cloud ORGANIZATION_ID, `cloud.project.id` = Google Cloud Project id). The null-account symptom follows naturally: Organisation assets have no `projects/` ancestor so `AccountId`/`AccountName` are empty.

- Extract `commonCloud()` helper with the correct mapping as the single source of truth (prevents silent recurrence).
- Fix `enrichForwardingRule`: was calling `WithCloud` with only `Region`, which replaces the whole struct and silently wiped `cloud.provider` / `cloud.account.*` / `cloud.project.*` on every forwarding rule.
- Fix `enrichOrganization`: was never populating `Organization.ID`.
- Fix tests: `TestAccountFetcher_EnrichAsset` was copying the common cloud fields from `actual` into `expected`, making it blind to wrong mappings — replaced with explicit literal assertions.

## Breaking note for reviewers

`cloud.account.id` changes from GCP project number to GCP organisation number for all asset-inventory documents. This is the ECS-correct behaviour and matches the Azure inventory fetcher convention, but any existing dashboard/saved-query that grouped GCP CAI assets by `cloud.account.id` expecting a project number will shift to grouping by org number. Existing indexed documents are not rewritten.

## Test plan

- [x] `go test ./internal/inventory/gcpfetcher/... -v` — both `TestAccountFetcher_Fetch_Assets` and `TestAccountFetcher_EnrichAsset` pass
- [x] `go test ./internal/inventory/... ./internal/resources/providers/gcplib/...` — all pass
- [ ] End-to-end: on a GCP org, confirm `cloud.account.id` = org id, `cloud.project.id` = project id, `compute.ForwardingRule` docs carry `cloud.provider: gcp`, and `cloudresourcemanager.Organization` docs have `cloud.account.*` populated (was null) and `organization.id` set

Closes https://github.com/elastic/sdh-beats/issues/7529

🤖 Generated with [Claude Code](https://claude.com/claude-code)