### PR TITLE
[8.19] Add missing qualifier.sh for DRA staging

### DIFF
--- a/.buildkite/scripts/qualifier.sh
+++ b/.buildkite/scripts/qualifier.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# this file should be sourced from inside the package and publish script.
+
+fetch_elastic_qualifier() {
+    local branch="${1}"
+    local url="https://storage.googleapis.com/dra-qualifier/${branch}"
+    local qualifier=""
+    if curl -sf -o /dev/null "${url}"; then
+        qualifier=$(curl -s "${url}")
+    fi
+    echo "${qualifier}"
+}
+
+# If this is a snapshot build, omit VERSION_QUALIFIER
+if [ "${WORKFLOW}" = "snapshot" ]; then
+    VERSION_QUALIFIER=''
+
+# If the VERSION_QUALIFIER is already set (e.g. buildkite custom run), don't modify it.
+# Else try to fetch from google bucket for the current branch
+elif [ -z "${VERSION_QUALIFIER+x}" ]; then
+    # VERSION_QUALIFIER is not set, get from bucket
+    VERSION_QUALIFIER="$(fetch_elastic_qualifier "${BUILDKITE_BRANCH}")"
+fi


### PR DESCRIPTION
### Summary of your changes

Staging DRA on 8.19 fails in `dra-generate.sh` because it sources `.buildkite/scripts/qualifier.sh`, which was never on this branch.

The dra-prep backport (#8301 / #8061) added that `source` for staging so `stack_version` can include an alpha/beta qualifier. `qualifier.sh` itself landed on main/9.x in #2950 and was not part of the 8.19 backport.

This PR adds only that file (same contents as main). The rest of #2950 is not required: 8.19's pipeline already dropped the old `VERSION_QUALIFIER` conditions, `publish.sh` is no longer used, and packaging already succeeded without sourcing the file.

Failed job: https://buildkite.com/elastic/cloudbeat/builds/4565#01a07a75-ec9c-4bfe-a151-f76b49e503f1

### Screenshot/Data

N/A — CI script fix.

### Related Issues

- Failed Buildkite job: https://buildkite.com/elastic/cloudbeat/builds/4565#01a07a75-ec9c-4bfe-a151-f76b49e503f1
- Introduced by: https://github.com/elastic/cloudbeat/pull/8301

### Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary README/documentation (if appropriate)

## Test plan
- [x] Confirm CI on this PR is green
- [ ] After merge, rerun / wait for the 8.19 Buildkite pipeline and confirm `Generate DRA steps (staging)` sources `qualifier.sh` and proceeds past the previous `No such file or directory` error


Made with [Cursor](https://cursor.com)