### PR TITLE
[CFT] Add Federated Identity template for Elastic Workload Identity (WII)

### DIFF
--- a/deploy/cloudformation/federated-identity-wii-aws.yml
+++ b/deploy/cloudformation/federated-identity-wii-aws.yml
@@ -1,0 +1,384 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: 'Creates an IAM Role for Elastic Workload Identity Federation. The role can be assumed only by the given Elastic deployment or project and grants read-only permissions for all Elastic AWS integrations that support Identity Federation: the AWS package integrations (GuardDuty, Inspector, Config, CloudWatch, and metrics services)'
+
+Parameters:
+  ElasticOrganizationId:
+    Description: Elastic Cloud organization ID.
+    Type: String
+    AllowedPattern: '^[0-9]+$'
+    ConstraintDescription: must be numeric.
+
+  ElasticResourceType:
+    Description: deployment for Elastic Cloud Hosted, project for Elastic Cloud Serverless.
+    Type: String
+    AllowedValues:
+      - deployment
+      - project
+
+  ElasticResourceId:
+    Description: Kibana component ID of the deployment, or the Serverless project ID.
+    Type: String
+    AllowedPattern: '^[A-Za-z0-9]+$'
+    ConstraintDescription: must contain only letters and digits.
+
+  ElasticCloudProvider:
+    Description: Cloud provider the Elastic deployment or project runs on.
+    Type: String
+    AllowedValues:
+      - aws
+      - azure
+      - gcp
+
+  ElasticCloudRegion:
+    Description: Region the Elastic deployment or project runs in (for example eu-west-1, us-central1, eastus2).
+    Type: String
+    AllowedPattern: '^[a-z0-9-]+$'
+    ConstraintDescription: must be a lowercase region name.
+
+  ElasticCloudEnvironment:
+    Description: Elastic Cloud environment. Use production unless testing against an Elastic test environment.
+    Type: String
+    AllowedValues:
+      - production
+      - staging
+      - qa
+
+  CreateOidcProvider:
+    Description: Set to false if this account already has a stack for the same organization and region, so the existing OIDC provider is reused.
+    Type: String
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
+
+Mappings:
+  EnvironmentDomain:
+    production:
+      Domain: svc.elastic.cloud
+    staging:
+      Domain: svc.staging.elastic.cloud
+    qa:
+      Domain: svc.qa.elastic.cloud
+
+Conditions:
+  ShouldCreateOidcProvider: !Equals [!Ref CreateOidcProvider, "true"]
+
+Resources:
+
+  # No ThumbprintList: IAM ignores it for publicly trusted CAs.
+  WiiOidcProvider:
+    Type: AWS::IAM::OIDCProvider
+    Condition: ShouldCreateOidcProvider
+    Properties:
+      Url: !Sub
+        - https://workload-identity-issuer.${ElasticCloudRegion}.${ElasticCloudProvider}.${Domain}/orgs/${ElasticOrganizationId}
+        - Domain: !FindInMap [EnvironmentDomain, !Ref ElasticCloudEnvironment, Domain]
+      ClientIdList:
+        - sts.amazonaws.com
+
+  ElasticWorkloadIdentityRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ElasticWorkloadIdentity-${AWS::StackName}
+      AssumeRolePolicyDocument: !Sub
+        - |
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Federated": "${ProviderArn}"
+                },
+                "Action": "sts:AssumeRoleWithWebIdentity",
+                "Condition": {
+                  "StringEquals": {
+                    "workload-identity-issuer.${ElasticCloudRegion}.${ElasticCloudProvider}.${Domain}/orgs/${ElasticOrganizationId}:aud": "sts.amazonaws.com",
+                    "workload-identity-issuer.${ElasticCloudRegion}.${ElasticCloudProvider}.${Domain}/orgs/${ElasticOrganizationId}:sub": "${ElasticResourceType}:${ElasticResourceId}"
+                  }
+                }
+              }
+            ]
+          }
+        - Domain: !FindInMap [EnvironmentDomain, !Ref ElasticCloudEnvironment, Domain]
+          ProviderArn: !If
+            - ShouldCreateOidcProvider
+            - !GetAtt WiiOidcProvider.Arn
+            - !Sub
+              - arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider/workload-identity-issuer.${ElasticCloudRegion}.${ElasticCloudProvider}.${Domain}/orgs/${ElasticOrganizationId}
+              - Domain: !FindInMap [EnvironmentDomain, !Ref ElasticCloudEnvironment, Domain]
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonGuardDutyReadOnlyAccess
+
+  ElasticAwsInspector:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsInspector-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - inspector2:ListFindings
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsCloudwatchLogs:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsCloudwatchLogs-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - logs:DescribeLogGroups
+              - logs:DescribeLogStreams
+              - logs:FilterLogEvents
+              - logs:GetLogEvents
+              - logs:GetLogGroupFields
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsMetrics:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsMetrics-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - ec2:DescribeRegions
+              - cloudwatch:ListMetrics
+              - cloudwatch:GetMetricData
+              - tag:GetResources
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsHealth:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsHealth-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - health:DescribeEvents
+              - health:DescribeEventDetails
+              - health:DescribeAffectedEntities
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsConfig:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsConfig-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - config:DescribeConfigRules
+              - config:GetComplianceDetailsByConfigRule
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsBilling:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsBilling-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - ce:GetCostAndUsage
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsDynamoDB:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsDynamoDB-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - dynamodb:ListTables
+              - dynamodb:DescribeTable
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsEBS:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsEBS-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - ec2:DescribeVolumes
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsEC2:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsEC2-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - ec2:DescribeInstances
+              - ec2:DescribeInstanceStatus
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsECS:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsECS-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - ecs:ListClusters
+              - ecs:DescribeClusters
+              - ecs:ListServices
+              - ecs:DescribeServices
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsELB:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsELB-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - elasticloadbalancing:DescribeLoadBalancers
+              - elasticloadbalancing:DescribeTargetGroups
+              - elasticloadbalancing:DescribeTargetHealth
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsLambda:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsLambda-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - lambda:ListFunctions
+              - lambda:GetFunction
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsRDS:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsRDS-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - rds:DescribeDBInstances
+              - rds:DescribeDBClusters
+              - rds:ListTagsForResource
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsSNS:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsSNS-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - sns:ListTopics
+              - sns:GetTopicAttributes
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsSQS:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsSQS-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - sqs:ListQueues
+              - sqs:GetQueueAttributes
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsTransitGateway:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsTransitGateway-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - ec2:DescribeTransitGateways
+              - ec2:DescribeTransitGatewayAttachments
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+  ElasticAwsSecurityHub:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: !Sub ElasticAwsSecurityHub-${AWS::StackName}
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - securityhub:GetFindings
+              - securityhub:GetInsights
+            Resource: '*'
+      Roles:
+        - !Ref ElasticWorkloadIdentityRole
+
+Outputs:
+  RoleArn:
+    Description: The ARN of the IAM Role. Paste this into Kibana.
+    Value: !GetAtt ElasticWorkloadIdentityRole.Arn
+
+  StackId:
+    Description: Store this in Kibana to construct stack-update URLs later.
+    Value: !Ref AWS::StackId

--- a/deploy/cloudformation/federated-identity-wii-aws.yml
+++ b/deploy/cloudformation/federated-identity-wii-aws.yml
@@ -6,7 +6,7 @@ Parameters:
   ElasticOrganizationId:
     Description: Elastic Cloud organization ID.
     Type: String
-    AllowedPattern: '^[0-9]+$'
+    AllowedPattern: ^[0-9]+$
     ConstraintDescription: must be numeric.
 
   ElasticResourceType:
@@ -19,7 +19,7 @@ Parameters:
   ElasticResourceId:
     Description: Kibana component ID of the deployment, or the Serverless project ID.
     Type: String
-    AllowedPattern: '^[A-Za-z0-9]+$'
+    AllowedPattern: ^[A-Za-z0-9]+$
     ConstraintDescription: must contain only letters and digits.
 
   ElasticCloudProvider:
@@ -33,7 +33,7 @@ Parameters:
   ElasticCloudRegion:
     Description: Region the Elastic deployment or project runs in (for example eu-west-1, us-central1, eastus2).
     Type: String
-    AllowedPattern: '^[a-z0-9-]+$'
+    AllowedPattern: ^[a-z0-9-]+$
     ConstraintDescription: must be a lowercase region name.
 
   ElasticCloudEnvironment:
@@ -47,10 +47,10 @@ Parameters:
   CreateOidcProvider:
     Description: Set to false if this account already has a stack for the same organization and region, so the existing OIDC provider is reused.
     Type: String
-    Default: "true"
     AllowedValues:
       - "true"
       - "false"
+    Default: "true"
 
 Mappings:
   EnvironmentDomain:
@@ -69,13 +69,13 @@ Resources:
   # No ThumbprintList: IAM ignores it for publicly trusted CAs.
   WiiOidcProvider:
     Type: AWS::IAM::OIDCProvider
-    Condition: ShouldCreateOidcProvider
     Properties:
       Url: !Sub
         - https://workload-identity-issuer.${ElasticCloudRegion}.${ElasticCloudProvider}.${Domain}/orgs/${ElasticOrganizationId}
         - Domain: !FindInMap [EnvironmentDomain, !Ref ElasticCloudEnvironment, Domain]
       ClientIdList:
         - sts.amazonaws.com
+    Condition: ShouldCreateOidcProvider
 
   ElasticWorkloadIdentityRole:
     Type: AWS::IAM::Role

--- a/scripts/publish_cft.sh
+++ b/scripts/publish_cft.sh
@@ -63,3 +63,6 @@ upload_file deploy/cloudformation/cloud-connectors-guardduty.yml \
 upload_file deploy/cloudformation/federated-identity-aws.yml \
     "cloudformation-federated-identity-aws" \
     "${version}"
+upload_file deploy/cloudformation/federated-identity-wii-aws.yml \
+    "cloudformation-federated-identity-wii-aws" \
+    "${version}"


### PR DESCRIPTION
### Summary of your changes

Adds `deploy/cloudformation/federated-identity-wii-aws.yml`, the WII (Elastic Workload Identity Issuer) counterpart of `federated-identity-aws.yml`. Same role and grants, but the trust is an OIDC provider for the WII issuer of the customer's organization, region and CSP, and the role can only be assumed by one deployment (ECH) or project (Serverless):

```
<issuer-host>/orgs/<org-id>:aud = sts.amazonaws.com
<issuer-host>/orgs/<org-id>:sub = <deployment|project>:<id>
```

Inputs are the facts about the Elastic deployment or project, pre-filled by Kibana; the template composes the two JWT claims the trust is built from:

- `ElasticOrganizationId`, `ElasticCloudProvider` (`aws`/`azure`/`gcp`), `ElasticCloudRegion` and `ElasticCloudEnvironment` (`production`/`staging`/`qa`) give the issuer: `workload-identity-issuer.<region>.<provider>.<domain>/orgs/<org>`, with the domain per environment in a `Mappings` block. Only Elastic-owned issuers can result, and Kibana does not need to know the WII hostname scheme.
- `ElasticResourceType` (`deployment`/`project`) and `ElasticResourceId` (Kibana component ID or Serverless project ID) give the subject: `<type>:<id>`.

The custom resource returns the issuer it registered and the trust policy reads it back with `GetAtt`, so the issuer is composed in two places only (the function role's resource ARN and the provider URL). A failed `AssumeRoleWithWebIdentity` can be debugged by comparing the role's trust conditions against the two decoded JWT claims.

The template is also added to `scripts/publish_cft.sh`.

#### OIDC provider

IAM allows one OIDC provider per issuer URL per account, and `AWS::IAM::OIDCProvider` fails with `EntityAlreadyExists` if it exists. The provider is shared by every stack for the same org, region and CSP in an account: other ECH deployments and Serverless projects, repeated onboardings of the same one, and every template update (updates replace the stack). There is no shared state across those to record whether the provider already exists, so neither a parameter nor a separate provider template can be driven reliably.

The provider is therefore managed by a Lambda-backed custom resource (`WiiOidcProvider`) that:

- creates the provider only if it does not exist, and adds the `sts.amazonaws.com` audience if an existing provider lacks it;
- does nothing on delete, so replacing or deleting one stack never breaks the roles of the others (AWS: roles referencing a deleted provider stop working). The `OidcProviderArn` output tells the customer what to delete once the last stack is gone;
- retries transient failures with exponential backoff (2/4/8/16 s): `EntityAlreadyExists` (lost a race with another stack), `AccessDenied` (role policy still propagating), `OpenIdIdpCommunicationError` (IAM contacts the issuer during create), `ConcurrentModification`, `Throttling`, `ServiceFailure`. Every other error is reported back with the IAM message so the stack fails fast;
- has `ServiceTimeout: 600`, so a function that never answers fails the stack after 10 minutes instead of CloudFormation's default hour, while leaving room for Lambda's asynchronous retries.

The function role only has `iam:GetOpenIDConnectProvider`, `iam:CreateOpenIDConnectProvider` and `iam:AddClientIDToOpenIDConnectProvider` on the one provider ARN, plus the Lambda basic execution role so a failing create is visible in CloudWatch Logs: no delete, no network beyond the CloudFormation callback. It cannot register any other issuer even if invoked directly. The `sts.amazonaws.com` audience is fixed in the function rather than passed as a property. No `ThumbprintList`: IAM resolves it for publicly trusted CAs.

Prior art: AWS's own GitHub Actions sample uses a parameter for an existing provider ARN; eksctl and Datadog's EKS tooling create the provider from code before CloudFormation and never delete it; CDK's Lambda-backed provider does not handle an existing one and is now legacy. Nobody solves this inside CloudFormation without code.

#### Why not trust all WII endpoints

WII issues tokens with a per-region `iss`, so in production that is 63 issuers. IAM does not allow wildcards in `Federated` principals, so all 63 provider ARNs would have to be listed in the trust policy (~7.5k chars, default quota 2048, max 8192). Adding the `sub` condition needs one statement per issuer, ~29k chars, which cannot fit at all. A deployment or project lives in one region anyway, so one issuer per stack is both sufficient and the smallest trust.

#### Why no loop

`Fn::ForEach` can create N providers from a list parameter, but it cannot produce list items, so there is no way to feed a variable number of provider ARNs into the role's trust policy. It also needs the `AWS::LanguageExtensions` transform, and with one issuer per stack there is nothing to loop over.

#### Differences from the legacy template

Inline policy names drop the `-${AWS::StackName}` suffix: they only need to be unique within the role, and the suffix pushed long stack names past IAM's 128-character limit. The GuardDuty managed policy ARN uses `${AWS::Partition}`.

### Related Issues

- https://github.com/elastic/kibana-feature-flags/pull/207 — FF lock to not promote changes to customers and limit to internal users for all environments

### Checklist
- [x] `cfn-lint` passes; grants diffed against `federated-identity-aws.yml`
- [x] Custom resource handler exercised against every request type and IAM failure path (create/reuse/add audience/race/propagation/SCP deny/throttling/issuer unreachable/non-retryable/update with new issuer/failed update/delete/rollback delete)
- [x] Deployed against QA for the hosted and serverless flows (parameter-based version)
- [ ] Deploy the custom-resource version against QA: first stack, second stack for the same issuer, delete one, re-create

