### PR TITLE
fix(ci): enable pnpm via corepack before Kibana bootstrap

### DIFF
--- a/.github/actions/kibana-ftr/action.yml
+++ b/.github/actions/kibana-ftr/action.yml
@@ -77,6 +77,12 @@ runs:
       with:
         chrome-version: ${{ steps.chrome-version.outputs.major }}
 
+    - name: Enable pnpm via corepack
+      shell: bash
+      working-directory: ${{ steps.globals.outputs.KIBANA_DIR }}
+      run: |
+        corepack enable pnpm
+
     - name: Bootstrap Kibana
       shell: bash
       working-directory: ${{ steps.globals.outputs.KIBANA_DIR }}


### PR DESCRIPTION
## Summary
- Kibana migrated from yarn to pnpm ([elastic/kibana#284611](https://github.com/elastic/kibana/pull/284611)), causing the nightly "Run UI Sanity checks (Kibana)" job to fail because pnpm is not installed
- Adds a `corepack enable pnpm` step in the `kibana-ftr` action before bootstrapping, which activates the exact pnpm version declared in Kibana's `packageManager` field
- Existing `yarn kbn bootstrap` commands are preserved unchanged — they delegate to pnpm once pnpm is available

## Test plan
- [ ] Nightly run passes "Run UI Sanity checks (Kibana)" on both ECH and Serverless jobs

## Related
- Failing run: https://github.com/elastic/cloudbeat/actions/runs/34429022775/job/102720870318
- Kibana migration PR: https://github.com/elastic/kibana/pull/284611

🤖 Generated with [Claude Code](https://claude.com/claude-code)